### PR TITLE
MAT-4695 & MAT-4693 & some minor regression timing fixes

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -51,6 +51,8 @@ export class TestCasesPage {
     public static readonly testCalculationResultsLineEight = '[data-testid="calculation-results"] > div > :nth-child(8)'
     public static readonly testCalculationResultsLineNine = '[data-testid="calculation-results"] > div > :nth-child(9)'
     public static readonly testCalculationError = '[data-testid="calculation-error-alert"]'
+    public static readonly testCaseListPassingPercTab = '[data-testid="passing-tab"]'
+    public static readonly testCaseListCoveragePercTab = '[data-testid="coverage-tab"]'
 
     //Test Case Population Values
     public static readonly testCaseIPPCheckBox = '[data-testid="test-population-initialPopulation-expected"]'

--- a/cypress/integration/WebInterface/Test Cases/TestCasePopulationValues.spec.ts
+++ b/cypress/integration/WebInterface/Test Cases/TestCasePopulationValues.spec.ts
@@ -57,7 +57,6 @@ describe('Test Case Expected Measure Group population values based on initial me
         cy.get(TestCasesPage.newTestCaseButton).click()
         cy.get(TestCasesPage.testCasePopulationHeaderForNoMeasureGroup).should('contain.text', 'There are no groups associated with this measure. Please review the Groups tab.')
     })
-
     it('Validate Population Values check boxes are correct based on measure scoring value that is applied, ' +
         'when the measure is initially created (default measure group)', () => {
 
@@ -344,7 +343,7 @@ describe('Test Case Population dependencies', () => {
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.wait(4500)
+        cy.wait(13500)
         OktaLogin.Logout()
         MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial PopulationOne', 'Initial PopulationOne', 'Initial PopulationOne', 'Boolean')
         OktaLogin.Login()
@@ -604,7 +603,7 @@ describe('TC Pop value options are limited to those that are defined from Measur
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.wait(4500)
+        cy.wait(14500)
         OktaLogin.Logout()
         OktaLogin.Login()
 
@@ -745,7 +744,7 @@ describe('Test Case Expected Measure Group population values based on initial me
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.wait(4500)
+        cy.wait(14500)
         OktaLogin.Logout()
         MeasureGroupPage.CreateRatioMeasureGroupAPI(null, null, null, null, null, 'Procedure')
         OktaLogin.Login()

--- a/cypress/integration/WebInterface/Test Cases/Validations/PassingCodeCoverageTestCaseListPage.spec.ts
+++ b/cypress/integration/WebInterface/Test Cases/Validations/PassingCodeCoverageTestCaseListPage.spec.ts
@@ -1,0 +1,96 @@
+import {OktaLogin} from "../../../../Shared/OktaLogin"
+import {CreateMeasurePage} from "../../../../Shared/CreateMeasurePage"
+import {MeasuresPage} from "../../../../Shared/MeasuresPage"
+import {EditMeasurePage} from "../../../../Shared/EditMeasurePage"
+import {MeasureGroupPage} from "../../../../Shared/MeasureGroupPage"
+import {Utilities} from "../../../../Shared/Utilities"
+import {MeasureCQL} from "../../../../Shared/MeasureCQL"
+import {TestCasesPage} from "../../../../Shared/TestCasesPage"
+import {TestCaseJson} from "../../../../Shared/TestCaseJson"
+
+
+let measureName = 'TestMeasure' + Date.now()
+let CqlLibraryName = 'TestLibrary' + Date.now()
+let randValue = (Math.floor((Math.random() * 1000) + 1))
+let testCaseTitle = 'Title for Auto Test'
+let testCaseDescription = 'DENOMFail' + Date.now()
+let testCaseSeries = 'SBTestSeries'
+let validTestCaseJson = TestCaseJson.TestCaseJson_Valid_w_All_Encounter
+let newMeasureName = measureName + randValue
+let newCqlLibraryName = CqlLibraryName + randValue
+let measureCQL = MeasureCQL.CQL_Multiple_Populations
+
+describe('Test Case Validations', () => {
+
+    beforeEach('Create Measure', () => {
+        CreateMeasurePage.CreateAPIQICoreMeasureWithCQL(newMeasureName, newCqlLibraryName, measureCQL)
+        OktaLogin.Login()
+        MeasuresPage.clickEditforCreatedMeasure()
+        cy.get(EditMeasurePage.cqlEditorTab).should('exist')
+        cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('exist')
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.wait(13500)
+        OktaLogin.Logout()
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial Population', 'Initial Population', 'Initial Population', 'Boolean')
+        OktaLogin.Login()
+    })
+    afterEach('Logout', () => {
+        OktaLogin.Logout()
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+
+    })
+
+    it('Validate Passing and Code Coverage tabs contain the initial "-" value, and displayes a percentage when Test Case is ran', () => {
+
+        //Click on Edit Measure
+        MeasuresPage.clickEditforCreatedMeasure()
+
+        //create test case
+        TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, validTestCaseJson, true)
+
+        //navigate to the test case list page
+        cy.get(EditMeasurePage.testCasesTab).should('exist')
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        //verify initial "-" value, appears in the pasing and code coverage tabs
+        cy.get(TestCasesPage.testCaseListPassingPercTab).should('exist')
+        cy.get(TestCasesPage.testCaseListPassingPercTab).should('be.visible')
+        cy.get(TestCasesPage.testCaseListPassingPercTab).should('contain.text', '-')
+
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('exist')
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '-')
+
+        //click on edit button to go into the edit form for the test case
+        TestCasesPage.clickEditforCreatedTestCase
+
+        //navigate back to the test case list page
+        cy.get(EditMeasurePage.testCasesTab).should('exist')
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        //click the Execute Test Cases button
+        cy.get(TestCasesPage.executeTestCaseButton).should('exist')
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.be.enabled')
+        cy.get(TestCasesPage.executeTestCaseButton).click()
+
+        //verify percentage number appears in tabs heading
+        cy.get(TestCasesPage.testCaseListPassingPercTab).should('exist')
+        cy.get(TestCasesPage.testCaseListPassingPercTab).should('be.visible')
+        cy.get(TestCasesPage.testCaseListPassingPercTab).should('not.contain.text', '-')
+
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('exist')
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('not.contain.text', '-')
+
+    })    
+})

--- a/cypress/integration/WebInterface/Test Cases/Validations/StratificationExpectedValues.spec.ts
+++ b/cypress/integration/WebInterface/Test Cases/Validations/StratificationExpectedValues.spec.ts
@@ -522,11 +522,6 @@ describe('Stratification Expected values for Non Boolean Population Basis', () =
         cy.get(TestCasesPage.runTestButton).should('be.visible')
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
-
-        //validate color of Measure Group-1 Stratification after running
-        cy.get(TestCasesPage.eaMeasureGroupOneStratification).should('exist')
-        cy.get(TestCasesPage.eaMeasureGroupOneStratification).should('be.visible')
-        cy.get(TestCasesPage.eaMeasureGroupOneStratification).should('have.color', '#4d7e23')
         
     })
 

--- a/cypress/integration/WebInterface/Test Cases/Validations/StratificationExpectedValues.spec.ts
+++ b/cypress/integration/WebInterface/Test Cases/Validations/StratificationExpectedValues.spec.ts
@@ -36,7 +36,7 @@ describe('Stratification Expected values for Boolean Population Basis', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.wait(14500)
+        cy.wait(15500)
         OktaLogin.Logout()
         MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial Population', 'Initial Population', 'Initial Population', 'Boolean')
         OktaLogin.Login()
@@ -371,7 +371,7 @@ describe('Stratification Expected values for Non Boolean Population Basis', () =
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.wait(14500)
+        cy.wait(15500)
         OktaLogin.Logout()
         MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Qualifying Encounters', 'Qualifying Encounters', 'Qualifying Encounters', 'Encounter')
         OktaLogin.Login()
@@ -523,6 +523,11 @@ describe('Stratification Expected values for Non Boolean Population Basis', () =
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
+        //validate color of Measure Group-1 Stratification after running
+        cy.get(TestCasesPage.eaMeasureGroupOneStratification).should('exist')
+        cy.get(TestCasesPage.eaMeasureGroupOneStratification).should('be.visible')
+        cy.get(TestCasesPage.eaMeasureGroupOneStratification).should('have.color', '#4d7e23')
+        
     })
 
     it('Run a failing Test Case with Stratification Expected Values for Non Boolean Population basis', () =>{


### PR DESCRIPTION
Made some minor adjustments to the following files to resolve some minor timing issues:
-- TestCasePopulationValues.spec.ts
-- StratificationExpectedValues.spec.ts

Additionally, I added a new file:
-- PassingCodeCoverageTestCaseListPage.spec.ts
to cover a test case that can be automated,
in relation to user stories MAT-4695 and MAT-4693. I also updated the following file to support the new the new test spec file for those user stories:
--TestCasesPage.ts