### PR TITLE
Regression test failures around CQL Library test files and related support file

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -25,12 +25,12 @@ export class CQLLibraryPage {
     public static readonly currentCQLLibSavebtn = '[data-testid="cql-library-save-button"]'
     public static readonly headerDetails = '[class="details"]'
     public static readonly cqlLibraryDesc = '[id="cql-library-description"]'
-    public static readonly cqlLibraryPublisher = '[data-testid="cql-library-publisher"]'
+    public static readonly cqlLibraryCreatePublisher = '[data-testid="cql-library-publisher"]'
     public static readonly cqlLibraryModalField = '[id="model-select"]'
     public static readonly cqlLibraryCreateForm = '[id="menu-model"]'
     public static readonly cqlLibraryCreateFormSideClickArea = '[class="MuiBox-root css-0"]'
     public static readonly cqlLibraryEditPublisher = '[data-testid="publisher"]'
-    public static readonly cqlLibraryCreatePublisherDrpDwn = '[id="mui-3-option-0"]'
+    public static readonly cqlLibraryCreatePublisherDrpDwn = '[aria-activedescendant="mui-3-option-0"]'
     public static readonly cqlLibraryEditPublisherDrpDwn = '#mui-4-option-0'
     public static readonly cqlLibDescHelperText = '[data-testid="description-helper-text"]'
     public static readonly cqlLibPubHelperText = '[data-testid="publisher-helper-text"]'
@@ -53,9 +53,9 @@ export class CQLLibraryPage {
         cy.get(this.newCQLLibName).type(CQLLibraryName)
         Utilities.dropdownSelect(CQLLibraryPage.cqlLibraryModelDropdown, CQLLibraryPage.cqlLibraryModelQICore)
         cy.get(this.cqlLibraryDesc).type('description')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type(CQLLibraryPublisher).type('{downArrow}{enter}')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type(CQLLibraryPublisher).type('{downArrow}{enter}')
 
         this.clickCreateLibraryButton()
         cy.get(Header.cqlLibraryTab).click()

--- a/cypress/integration/WebInterface/CQL Library/CQL Editor/ValidateCQLLibraryEditor.spec.ts
+++ b/cypress/integration/WebInterface/CQL Library/CQL Editor/ValidateCQLLibraryEditor.spec.ts
@@ -38,13 +38,11 @@ describe('Validate CQL on CQL Library page', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()
-        
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
+                
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
         cy.get(CQLLibraryPage.warningAlert).should('contain.text', 'CQL updated successfully! Library Name ' +
@@ -75,12 +73,10 @@ describe('Validate CQL on CQL Library page', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()        
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         //save the value in the CQL Editor
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
@@ -89,6 +85,8 @@ describe('Validate CQL on CQL Library page', () => {
             'and/or Version can not be updated in the CQL Editor. MADiE has overwritten the updated Library Name and/or Version.')
 
         //Validate error(s) in CQL Editor window
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').wait(1000).click({force:true, multiple: true})
@@ -104,6 +102,8 @@ describe('Validate CQL on CQL Library page', () => {
         CQLLibrariesPage.clickEditforCreatedLibrary()
 
         //Validate error(s) in CQL Editor windows
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').wait(1000).click({force:true, multiple: true})
@@ -130,12 +130,10 @@ describe('Validate CQL on CQL Library page', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()        
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         //save the value in the CQL Editor
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.visible')
@@ -146,6 +144,8 @@ describe('Validate CQL on CQL Library page', () => {
             'and/or Version can not be updated in the CQL Editor. MADiE has overwritten the updated Library Name and/or Version.')
 
         //Validate error(s) in CQL Editor after saving
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').wait(1000).click({force:true, multiple: true})
@@ -158,6 +158,8 @@ describe('Validate CQL on CQL Library page', () => {
         CQLLibrariesPage.clickEditforCreatedLibrary()
 
         //Validate error(s) in CQL Editor persists after saving
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').wait(1000).click({force:true, multiple: true})
@@ -184,12 +186,10 @@ describe('Validate CQL on CQL Library page', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()        
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         //save the value in the CQL Editor
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
@@ -245,12 +245,10 @@ describe('CQL Library: CQL Editor: valueSet', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()        
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
@@ -275,12 +273,10 @@ describe('CQL Library: CQL Editor: valueSet', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()        
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
@@ -305,12 +301,10 @@ describe('CQL Library: CQL Editor: valueSet', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('Peter Griffin')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
@@ -321,6 +315,8 @@ describe('CQL Library: CQL Editor: valueSet', () => {
         cy.get(CQLLibraryPage.umlsErrorMessage).should('not.be.visible')
 
         //Validate error(s) in CQL Editor window
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
+        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').wait(1000).click({force:true, multiple: true})

--- a/cypress/integration/WebInterface/CQL Library/CreateCQLLibraryValidations.spec.ts
+++ b/cypress/integration/WebInterface/CQL Library/CreateCQLLibraryValidations.spec.ts
@@ -47,12 +47,10 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('SemanticBits')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('SemanticBits')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('{downArrow}').type('{enter}')
 
         //save the new CQL Library
         CQLLibraryPage.clickCreateLibraryButton()
@@ -98,12 +96,10 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('SemanticBits')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).invoke('click') 
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('SemanticBits')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('{downArrow}').type('{enter}')
 
         //save the new CQL Library
         CQLLibraryPage.clickCreateLibraryButton()
@@ -177,12 +173,10 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('SemanticBits')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('SemanticBits')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('{downArrow}').type('{enter}')
 
         cy.get(CQLLibraryPage.saveCQLLibraryBtn).click()
         cy.get(CQLLibraryPage.duplicateCQLLibraryNameError).should('contain.text', 'Library name must be unique. cqlLibraryName : Library name must be unique.')
@@ -261,7 +255,7 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //move to and then away from the publisher field
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).wait(1000).click()
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).wait(1000).click()
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('exist')
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('be.visible')
         cy.get(CQLLibraryPage.cqlLibraryDesc).click()
@@ -293,12 +287,10 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('SemanticBits')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click()         
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('SemanticBits')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('{downArrow}').type('{enter}')
 
         CQLLibraryPage.clickCreateLibraryButton()
 
@@ -353,9 +345,7 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
         cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
         cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('SemanticBits')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisherDrpDwn).click()         
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
 
         cy.get(CQLLibraryPage.cqlLibraryStickySave).click()
 

--- a/cypress/integration/WebInterface/CQL Library/EditCQLLibraryValidations.spec.ts
+++ b/cypress/integration/WebInterface/CQL Library/EditCQLLibraryValidations.spec.ts
@@ -46,12 +46,10 @@ describe('Edit Measure', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
 
         //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryPublisher).type('SemanticBits')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryCreatePublisherDrpDwn).click() 
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('exist')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('SemanticBits')
+        cy.get(CQLLibraryPage.cqlLibraryCreatePublisher).type('{downArrow}').type('{enter}')
 
         //save the new CQL Library
         CQLLibraryPage.clickCreateLibraryButton()
@@ -96,7 +94,7 @@ describe('Edit Measure', () => {
         let randValue = (Math.floor((Math.random() * 1000) + 1))
         let LibraryName = CQLLibraryName+randValue
 
-        CQLLibraryPage.createCQLLibraryAPI(LibraryName, 'Peter Grifin')
+        CQLLibraryPage.createCQLLibraryAPI(LibraryName, 'Able Health')
         OktaLogin.Login()
 
         //navigate to the CQL Libaray page and navigate to the edit CQL Library page
@@ -124,7 +122,7 @@ describe('Edit Measure', () => {
         let LibraryName = CQLLibraryName+randValue
 
         //create CQL Library via API
-        CQLLibraryPage.createCQLLibraryAPI(LibraryName, 'Peter Grifin')
+        CQLLibraryPage.createCQLLibraryAPI(LibraryName, 'Able Health')
 
         OktaLogin.Login()
 
@@ -152,7 +150,9 @@ describe('Edit Measure', () => {
         //enter / select a publisher value
         cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
         cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Peter Grifin')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}')
+        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{enter}')
 
         cy.get(CQLLibraryPage.cqlLibraryStickySave).should('exist')
         cy.get(CQLLibraryPage.cqlLibraryStickySave).should('be.visible')
@@ -192,7 +192,7 @@ describe('Edit Measure', () => {
         let LibraryName = CQLLibraryName+randValue
 
         //create CQL Library via API
-        CQLLibraryPage.createCQLLibraryAPI(LibraryName, 'Peter Grifin')
+        CQLLibraryPage.createCQLLibraryAPI(LibraryName, 'Able Health')
 
         OktaLogin.Login()
 

--- a/cypress/integration/WebInterface/Measure/CQL Editor/MeasureBundle.spec.ts
+++ b/cypress/integration/WebInterface/Measure/CQL Editor/MeasureBundle.spec.ts
@@ -7,6 +7,7 @@ import {EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import {CreateMeasurePage} from "../../../../Shared/CreateMeasurePage"
 import {MeasureCQL} from "../../../../Shared/MeasureCQL"
 import {MeasureGroupPage} from "../../../../Shared/MeasureGroupPage"
+import { symlink } from "fs"
 
 let measureName = 'MeasureName ' + Date.now()
 let CqlLibraryName = 'CQLLibraryName' + Date.now()
@@ -290,7 +291,7 @@ describe('Measure bundle end point returns stratifications', () => {
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.wait(15500)
         OktaLogin.Logout()
@@ -303,7 +304,7 @@ describe('Measure bundle end point returns stratifications', () => {
 
     })
 
-    it('Measure bundle end point returns stratifications for Cohort Measure', () => {
+    it.only('Measure bundle end point returns stratifications for Cohort Measure', () => {
 
         //Click on Edit Measure
         MeasuresPage.clickEditforCreatedMeasure()
@@ -336,9 +337,9 @@ describe('Measure bundle end point returns stratifications', () => {
                 cy.wrap($ele).click()
             }
         })
-        cy.get(MeasureGroupPage.ucumScoringUnitSelect).type('ml')
+        cy.get(MeasureGroupPage.ucumScoringUnitSelect).type('ml').type('{downArrow}').type('{enter}')
         //Select ml milliLiters from the dropdown
-        cy.get(MeasureGroupPage.ucumScoringUnitfullName).click()
+        //cy.get(MeasureGroupPage.ucumScoringUnitfullName).click()
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Surgical Absence of Cervix')
 
         //Click on Stratification tab
@@ -392,6 +393,7 @@ describe('Measure bundle end point returns stratifications', () => {
                 })
             })
         })
+        cy.pause()
     })
 
     it('Measure bundle end point returns stratifications for Continuous Variable Measure', () => {


### PR DESCRIPTION
Updated the following files to fix regression failures concerning CQL Library:
-- CreateCQLLibraryValidations.spec.ts
-- EditCQLLibraryValidations.spec.ts
-- ValidateCQLLibraryEditor.spec.ts

Additionally, updated the following file support file: 
-- CQLLibraryPage.ts

Lastly, the following file was changed but additional work will be done to this file to fix another regression failures and to address a user story:
-- MeasureBundle.spec.ts