### PR TITLE
MAT-4970 Resource IDs required and uniqueness

### DIFF
--- a/cypress/Shared/TestCaseJson.ts
+++ b/cypress/Shared/TestCaseJson.ts
@@ -11,6 +11,28 @@ export class TestCaseJson {
     ' [ {{} "system": "http://clinfhir.com/fhir/NamingSystem/identifier","value": "20181011LizzyHealth"} ],"name": [ {{} "use": "official",' +
     ' "text": "Lizzy Health","family": "Health","given": [ "Lizzy" ]} ],"gender": "female","birthDate": "2000-10-11"}} ]}'
 
+    public static readonly TestCaseJson_missingResourceIDs = '{{} "resourceType": "Bundle", "id": "1366", "meta": {{}   "versionId": "1",' +
+    ' "lastUpdated": "2022-03-30T19:02:32.620+00:00"  },  "type": "collection",  "entry": [ {{}   "fullUrl": "http://local/Encounter",' +
+    ' "resource": {{} "resourceType": "Encounter","meta": {{} "versionId": "1","lastUpdated": "2021-10-13T03:34:10.160+00:00","source":"#nEcAkGd8PRwPP5fA"},' +
+    ' "text": {{} "status": "generated","div":"<div xmlns=\\"http://www.w3.org/1999/xhtml\\">Sep 9th 2021 for Asthma<a name=\\"mm\\"/></div>\"},' +
+    ' "status": "finished","class": {{} "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode","code": "IMP","display":"inpatient encounter"},' +
+    ' "type": [ {{} "text": "OutPatient"} ],"subject": {{} "reference": "Patient/1"},"participant": [ {{} "individual": {{} "reference": "Practitioner/30164",' +
+    ' "display": "Dr John Doe"}} ],"period": {{} "start": "2021-01-01T03:34:10.054Z"}}}, {{} "fullUrl": "http://local/Patient","resource": {{} "resourceType":'+
+    ' "Patient","text": {{} "status": "generated","div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">Lizzy Health</div>\"}, "meta": {{} "profile": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"}, "identifier":' +
+    ' [ {{} "system": "http://clinfhir.com/fhir/NamingSystem/identifier","value": "20181011LizzyHealth"} ],"name": [ {{} "use": "official",' +
+    ' "text": "Lizzy Health","family": "Health","given": [ "Lizzy" ]} ],"gender": "female","birthDate": "2000-10-11"}} ]}'
+
+    public static readonly TestCaseJson_resourceIDsDup = '{{} "resourceType": "Bundle", "id": "1366", "meta": {{}   "versionId": "1",' +
+    ' "lastUpdated": "2022-03-30T19:02:32.620+00:00"  },  "type": "collection",  "entry": [ {{}   "fullUrl": "http://local/Encounter",' +
+    ' "resource": {{} "id":"1", "resourceType": "Encounter","meta": {{} "versionId": "1","lastUpdated": "2021-10-13T03:34:10.160+00:00","source":"#nEcAkGd8PRwPP5fA"},' +
+    ' "text": {{} "status": "generated","div":"<div xmlns=\\"http://www.w3.org/1999/xhtml\\">Sep 9th 2021 for Asthma<a name=\\"mm\\"/></div>\"},' +
+    ' "status": "finished","class": {{} "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode","code": "IMP","display":"inpatient encounter"},' +
+    ' "type": [ {{} "text": "OutPatient"} ],"subject": {{} "reference": "Patient/1"},"participant": [ {{} "individual": {{} "reference": "Practitioner/30164",' +
+    ' "display": "Dr John Doe"}} ],"period": {{} "start": "2021-01-01T03:34:10.054Z"}}}, {{} "fullUrl": "http://local/Patient","resource": {{} "id":"1", "resourceType":'+
+    ' "Patient","text": {{} "status": "generated","div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">Lizzy Health</div>\"}, "meta": {{} "profile": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient"}, "identifier":' +
+    ' [ {{} "system": "http://clinfhir.com/fhir/NamingSystem/identifier","value": "20181011LizzyHealth"} ],"name": [ {{} "use": "official",' +
+    ' "text": "Lizzy Health","family": "Health","given": [ "Lizzy" ]} ],"gender": "female","birthDate": "2000-10-11"}} ]}'
+
     public static readonly TestCaseJson_Valid_w_All_Encounter = '{{} "resourceType": "Bundle", "id": "1366", "meta": {{}  "versionId": "1",' +
     ' "lastUpdated": "2022-03-30T19:02:32.620+00:00" }, "type": "collection", "entry": [ {{}   "fullUrl": "http://local/Encounter/1",   "resource": {{}' +
     ' "id":"1", "resourceType": "Encounter", "id": "Encounter-1", "meta": {{}  "versionId": "1",  "lastUpdated": "2021-10-13T03:34:10.160+00:00",  "source": "#nEcAkGd8PRwPP5fA"' +

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -35,7 +35,7 @@ export class TestCasesPage {
     public static readonly secondTestCaseStatus = '[class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorError MuiChip-filledError css-c3eeld"]'
     public static readonly testCaseTitleInlineError = '[data-testid="title-helper-text"]'
     public static readonly testCaseJsonValidationErrorBtn = '[data-testid="show-json-validation-errors-button"]'
-    public static readonly testCaseJsonValidationDisplayList = '[data-testid="json-validation-errors-list"] > span'
+    public static readonly testCaseJsonValidationDisplayList = '[data-testid="json-validation-errors-list"]'
     public static readonly testCaseJsonValidationErrorList = '.EditTestCase__ValidationAlertCard-sc-m537sm-4'
     public static readonly testCasePopulationList = '[data-testid="create-test-case-populations"]'
     public static readonly testCaseExecutionError = '[data-testid="display-tests-error"]'

--- a/cypress/integration/WebInterface/Measure/CQL Editor/MeasureBundle.spec.ts
+++ b/cypress/integration/WebInterface/Measure/CQL Editor/MeasureBundle.spec.ts
@@ -30,9 +30,6 @@ describe('Measure Bundle end point returns cqlErrors as true', () => {
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.wait(15500)
@@ -59,9 +56,6 @@ describe('Measure Bundle end point returns cqlErrors as true', () => {
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         //making some minor and invalid change to the Measure CQL
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}{home}')
@@ -115,9 +109,6 @@ describe('Bundle returns elmXML', () => {
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.wait(15500)
@@ -142,9 +133,6 @@ describe('Bundle returns elmXML', () => {
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         //make some insignificant change
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
@@ -199,9 +187,6 @@ describe('Measure bundle end point returns scoring type for multiple Measure gro
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.wait(15500)
@@ -313,9 +298,6 @@ describe('Measure bundle end point returns stratifications', () => {
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
         cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -433,9 +415,6 @@ describe('Measure bundle end point returns stratifications', () => {
 
         //navigate to CQL Editor page / tab
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {

--- a/cypress/integration/WebInterface/Test Cases/Validations/RunAndExecuteTestCaseButtonValidations.spec.ts
+++ b/cypress/integration/WebInterface/Test Cases/Validations/RunAndExecuteTestCaseButtonValidations.spec.ts
@@ -53,9 +53,6 @@ describe('Run Test Case button validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -122,9 +119,6 @@ describe('Run Test Case button validations', () => {
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -153,9 +147,6 @@ describe('Run Test Case button validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -264,9 +255,6 @@ describe('Run Test Case button validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -373,9 +361,6 @@ describe('Run Test Case button validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -542,9 +527,6 @@ describe('Execute Test Case Button Validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -618,9 +600,6 @@ describe('Execute Test Case Button Validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -681,9 +660,6 @@ describe('Execute Test Case Button Validations', () => {
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
 
         cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
             cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
@@ -755,9 +731,6 @@ describe('Run and Execute Test case', () => {
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
         cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -892,9 +865,6 @@ describe('Run / Execute Test case and verify passing percentage', () => {
         OktaLogin.Login()
         MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        if ((EditMeasurePage.dirtCheckModal)) {
-            cy.get(EditMeasurePage.keepWorkingCancel).click()
-        }
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
         cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')

--- a/cypress/integration/WebInterface/Test Cases/Validations/TestCaseJSON_TerminologyTests.spec.ts
+++ b/cypress/integration/WebInterface/Test Cases/Validations/TestCaseJSON_TerminologyTests.spec.ts
@@ -9,14 +9,17 @@ import {MeasureGroupPage} from "../../../../Shared/MeasureGroupPage"
 import {MeasureCQL} from "../../../../Shared/MeasureCQL"
 
 let measureName = 'TestMeasure' + Date.now()
-let newMeasureName = ''
-let newCqlLibraryName
 let CqlLibraryName = 'TestLibrary' + Date.now()
-let measureCQL = MeasureCQL.CQL_Multiple_Populations
-
 let testCaseTitle = 'test case title'
 let testCaseDescription = 'DENOMFail' + Date.now()
+let missingResourceIDTCJson = TestCaseJson.TestCaseJson_missingResourceIDs
+let dupResourceIDTCJson = TestCaseJson.TestCaseJson_resourceIDsDup
 let testCaseSeries = 'SBTestSeries'
+let measureCQL = MeasureCQL.CQL_Multiple_Populations
+let mesureCQLPFTests = MeasureCQL.CQL_Populations
+
+let newMeasureName = ''
+let newCqlLibraryName
 let validTerminologyFHIR_and_QICORETestCaseJson = TestCaseJson.validTestCaseJsonFHIR_and_QICORE
 let invalidTerminologyFHIR_and_QICOREEntireEntryBlockTestCaseJson = TestCaseJson.invalidTestCaseJsonFHIR_and_QICORE
 let invalidTerminologyFHIR_and_QICOREStatusTestCaseJson = TestCaseJson.invalidTestCaseJsonFHIR_and_QICORE_Status
@@ -87,13 +90,11 @@ describe('Test Case JSON / terminology tests: Negative tests -- Test Case JSON d
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
-
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid + '\ndefine "ipp":\n\n  exists ["Encounter": "Office Visit"] E where E.period.start during "Measurement Period"\n')
         })
     })
-     it('Test Case JSON improper use of / invalid value set(s) -- Encounter in wrong status -- FHIR', () =>{
+    it('Test Case JSON improper use of / invalid value set(s) -- Encounter in wrong status -- FHIR', () =>{
         //Click on Edit Button
          MeasuresPage.clickEditforCreatedMeasure()
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -142,7 +143,6 @@ describe('Test Case JSON / terminology tests: Negative tests -- Test Case JSON d
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
-         //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid /* + '\ndefine "ipp":\n\n exists ["Encounter": "Office Visit"] E where E.period.start during "Measurement Period"\n\ndefine function ToDateTime(value dateTime): value.value\n' */)
         })
@@ -194,13 +194,9 @@ describe('Test Case JSON / terminology tests: Negative tests -- Test Case JSON d
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid /* + '\ndefine "ipp":\n\n  exists ["Encounter": "Office Visit"] E where E.period.start during "Measurement Period"\n' */)
         })
-
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', '\ndefine "ipp":\n\n  exists ["Encounter": "Office Visit"] E where E.period.start during "Measurement Period"\n')
-
     })
     it('Test Case JSON improper use of / invalid value set(s) -- missing entire Encounter block -- FHIR based QICore', () =>{
         //Click on Edit Button
@@ -248,14 +244,9 @@ describe('Test Case JSON / terminology tests: Negative tests -- Test Case JSON d
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
-
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid /* + '\ndefine "num":\n    exists ["Encounter": "Office Visit"] E where E.status ~ \'finished\'\n' */)
         })
-        
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', '\ndefine "num":\n    exists ["Encounter": "Office Visit"] E where E.status ~ \'finished\'\n')
-
     })
     it('Test Case JSON improper use of / invalid value set(s) -- Encounter in wrong status -- FHIR based QICore', () =>{
         //Click on Edit Button
@@ -302,8 +293,6 @@ describe('Test Case JSON / terminology tests: Negative tests -- Test Case JSON d
         cy.get(TestCasesPage.runTestButton).should('be.visible')
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
-
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
 
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid /* + '\ndefine "num":\n    exists ["Encounter": "Office Visit"] E where E.status ~ \'finished\'\n' */)
@@ -392,15 +381,10 @@ describe('Test Case JSON / terminology tests: positive tests -- Test Case JSON u
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
-
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid /* + '\ndefine "ipp":\n\n  exists ["Encounter": "Office Visit"] E where E.period.start during "Measurement Period"\n' */)
         })
-
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', '\ndefine "ipp":\n\n  exists ["Encounter": "Office Visit"] E where E.period.start during "Measurement Period"\n')
     })
-
     it('Test Case JSON proper use of value set(s) -- FHIR based QICore', () =>{
         //Click on Edit Button
         MeasuresPage.clickEditforCreatedMeasure()
@@ -463,13 +447,9 @@ describe('Test Case JSON / terminology tests: positive tests -- Test Case JSON u
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
         cy.get(TestCasesPage.runTestButton).click()
 
-        //cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Measure Group 1 - (Proportion)')
-
         cy.readFile('cypress/fixtures/groupId').should('exist').then((groupid) => {
             cy.get(TestCasesPage.testCalculationResults).should('contain.text', 'Population Group: ' + groupid /* + '\ndefine "num":\n    exists ["Encounter": "Office Visit"] E where E.status ~ \'finished\'\n' */)
         })
-
-        //cy.get(TestCasesPage.testCalculationResultsLineTwo).should('contain.text', '\ndefine "num":\n    exists ["Encounter": "Office Visit"] E where E.status ~ \'finished\'\n')
     })
 })
 
@@ -499,7 +479,6 @@ describe('Warning modal on Test Case JSON Editor', () => {
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, newCqlLibraryName)
     })
-
     it('Verify warning modal when the Test Case JSON has unsaved changes', () => {
 
         //Click on Edit Measure
@@ -549,5 +528,218 @@ describe('Warning modal on Test Case JSON Editor', () => {
         cy.get(TestCasesPage.continueDiscardChangesBtn).click()
         cy.get(TestCasesPage.newTestCaseButton).should('exist')
 
+    })
+})
+describe('JSON Rescource ID tests', () => {
+
+    beforeEach('Create measure, login and update CQL, create group, and login', () => {
+
+        CqlLibraryName = 'TestLibrary5' + Date.now()
+
+        CreateMeasurePage.CreateAPIQICoreMeasureWithCQL(measureName, CqlLibraryName, mesureCQLPFTests)
+        OktaLogin.Login()
+        MeasuresPage.clickEditforCreatedMeasure()
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.wait(17000)
+        OktaLogin.Logout()
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial Population', 'Initial Population', 'Initial Population', 'boolean')
+        OktaLogin.Login()
+    })
+
+    afterEach('Logout and Clean up Measures', () => {
+
+        OktaLogin.Logout()
+
+        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let newCqlLibraryName = CqlLibraryName + randValue
+
+        Utilities.deleteMeasure(measureName, newCqlLibraryName)
+    })
+
+    it('JSON missing Resource IDs', () => {
+
+        //Click on Edit Measure
+        MeasuresPage.clickEditforCreatedMeasure()
+
+        //Add second Measure Group with return type as Boolean
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
+        cy.get(MeasureGroupPage.measureGroupTypeCheckbox).each(($ele) => {
+            if ($ele.text() == "Text") {
+                cy.wrap($ele).should('exist')
+                cy.wrap($ele).focus()
+                cy.wrap($ele).click()
+            }
+        })
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+
+        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
+        cy.get(MeasureGroupPage.popBasis).should('exist')
+        cy.get(MeasureGroupPage.popBasis).should('be.visible')
+        cy.get(MeasureGroupPage.popBasis).click()
+        cy.get(MeasureGroupPage.popBasis).type('boolean')
+        cy.get(MeasureGroupPage.popBasisOption).click()
+
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
+
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
+        
+
+        //validation successful save message
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+
+        //Navigate to Test Cases page and add Test Case details
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.newTestCaseButton).should('be.visible')
+        cy.get(TestCasesPage.newTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.newTestCaseButton).click()
+
+        cy.get(TestCasesPage.createTestCaseDialog).should('exist')
+        cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
+
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
+        Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 20000)
+        Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 20000)
+        cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).focus()
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCaseDescription)
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseGroupInput).type(testCaseSeries).type('{enter}')
+
+        TestCasesPage.clickCreateTestCaseButton()
+
+        //Verify created test case Title and Series exists on Test Cases Page
+        TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //Add json to the test case
+        cy.get(TestCasesPage.aceEditor).type(missingResourceIDTCJson)
+
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+
+        cy.get(TestCasesPage.detailsTab).click()
+        cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).click()
+        cy.get(TestCasesPage.confirmationMsg).should('exist')
+        cy.get(TestCasesPage.confirmationMsg).should('be.visible')
+        cy.get(TestCasesPage.confirmationMsg).should('contain.text', 'An error occurred with the Test Case JSON while updating the test case')
+
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('exist')
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('be.visible')
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('contain.text', 'All resources in bundle must have unique ID regardless of type. Multiple resources detected with ID [null]')
+    })
+    it('JSON has Resource IDs duplicated for different resources', () => {
+
+        //Click on Edit Measure
+        MeasuresPage.clickEditforCreatedMeasure()
+
+        //Add second Measure Group with return type as Boolean
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
+        cy.get(MeasureGroupPage.measureGroupTypeCheckbox).each(($ele) => {
+            if ($ele.text() == "Text") {
+                cy.wrap($ele).should('exist')
+                cy.wrap($ele).focus()
+                cy.wrap($ele).click()
+            }
+        })
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+
+        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
+        cy.get(MeasureGroupPage.popBasis).should('exist')
+        cy.get(MeasureGroupPage.popBasis).should('be.visible')
+        cy.get(MeasureGroupPage.popBasis).click()
+        cy.get(MeasureGroupPage.popBasis).type('boolean')
+        cy.get(MeasureGroupPage.popBasisOption).click()
+
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
+
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
+        
+
+        //validation successful save message
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+
+        //Navigate to Test Cases page and add Test Case details
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.newTestCaseButton).should('be.visible')
+        cy.get(TestCasesPage.newTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.newTestCaseButton).click()
+
+        cy.get(TestCasesPage.createTestCaseDialog).should('exist')
+        cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
+
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
+        Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 20000)
+        Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 20000)
+        cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).focus()
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCaseDescription)
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseGroupInput).type(testCaseSeries).type('{enter}')
+
+        TestCasesPage.clickCreateTestCaseButton()
+
+        //Verify created test case Title and Series exists on Test Cases Page
+        TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //Add json to the test case
+        cy.get(TestCasesPage.aceEditor).type(dupResourceIDTCJson)
+
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+
+        cy.get(TestCasesPage.detailsTab).click()
+        cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).click()
+        cy.get(TestCasesPage.confirmationMsg).should('exist')
+        cy.get(TestCasesPage.confirmationMsg).should('be.visible')
+        cy.get(TestCasesPage.confirmationMsg).should('contain.text', 'An error occurred with the Test Case JSON while updating the test case')
+
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('exist')
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('be.visible')
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('contain.text', 'All resources in bundle must have unique ID regardless of type. Multiple resources detected with ID [1]')
     })
 })


### PR DESCRIPTION
Added tests that negatively tests resource IDs
-- if two IDs are the same but the resource are different then error is thrown due to duplicated IDs
-- if IDs are missing then error is thrown

Other tests that verifies the IDs, positively, have already been updated to include the proper use of IDs.