### PR TITLE
MeasureGroupTabs.cy.ts regression fix

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -85,7 +85,7 @@ export class MeasureGroupPage {
     public static readonly measureObservationPopSelect = '[id="measure-observation-cv-obs"]'
     public static readonly measurePopulationOption = '[data-testid="select-option-measure-group-population"]'
     public static readonly measureObsAggregSelect = '[id="measure-observation-aggregate-cv-obs"]'
-    public static readonly populationMismatchErrorMsg = '[data-testid="helper-text"]'
+    public static readonly populationMismatchErrorMsg = '[data-testid="Stratification-select-1-helper-text"]'
     public static readonly initialPopulationMismatchErrorMsg = '[data-testid="population-select-initial-population-select-helper-text"]'
     public static readonly measurePopulationMismatchErrorMsg = '[data-testid="population-select-measure-population-select-helper-text"]'
     public static readonly measurePopulationExclusionMismatchErrorMsg = '[data-testid="population-select-measure-population-exclusion-select-helper-text"]'

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureGroupTabs.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureGroupTabs.cy.ts
@@ -729,7 +729,7 @@ describe('Validating Stratification tabs', () => {
         Utilities.dropdownSelect(MeasureGroupPage.stratAssociationFour, 'initialPopulation')
         cy.get(MeasureGroupPage.stratDescFour).type('StratificationFour')
 
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click({force:true})
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click({ force: true })
 
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
 


### PR DESCRIPTION
Updated the MeasureGroupTabs.cy.ts along with the support file, MeasureGroupPage.ts, to resolve regression test failures from the MeasureGroupTabs.cy.ts file.