### PR TITLE
MAT-5138 Changing CQL after selections on PC, for populations

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -1,5 +1,7 @@
 import { EditMeasurePage } from "./EditMeasurePage"
 export class CQLEditorPage {
+    //error toast message when a CQL change has an affect on PC
+    public static readonly measureErrorToast = '[data-testid="measure-errors-toast"]'
 
     //error tooltip container
     public static readonly errorContainer = '#ace-editor-wrapper > div.ace_tooltip'

--- a/cypress/Shared/MeasureCQL.ts
+++ b/cypress/Shared/MeasureCQL.ts
@@ -474,4 +474,39 @@ export class MeasureCQL {
         '			such that HPVTest.value is not null\n' +
         '        and Global.\"Normalize Interval\"(HPVTest.effective) starts within 1 day of start of Global.\"Normalize Interval\"(PapTestOver30YearsOld.effective)\n' +
         '				and HPVTest.status in {{} \'final\', \'amended\', \'corrected\', \'preliminary\' }'
+
+    public static readonly measureCQL_5138_test = 'library Library4969 version \'0.0.000\'\n' +
+        'using QICore version \'4.1.1\'\n' +
+        'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
+        'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
+        'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
+        'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
+        'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
+        'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
+        'valueset "End Stage Renal Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353\' \n' +
+        '\n' +
+        'parameter "Measurement Period" Interval<DateTime>\n' +
+        'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
+        '\n' +
+        'context Patient\n' +
+        '\n' +
+        '\n' +
+        'define "Initial Population":\n' +
+        '  true\n' +
+        ' \n' +
+        ' define "ipp":\n' +
+        '    true\n' +
+        '    \n' +
+        'define "mpopEx":\n' +
+        '  ["Encounter"] E where E.status = \'finished\'\n' +
+        ' \n' +
+        'define function boolFunc():\n' +
+        '  1\n' +
+        '\n' +
+        'define function boolFunc2():\n' +
+        '  14\n' +
+        '\n' +
+        'define function daysObs(e Encounter):\n' +
+        '  duration in days of e.period\n'
+
 }

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -7,6 +7,9 @@ import { v4 as uuidv4 } from 'uuid'
 
 export class MeasureGroupPage {
 
+    //mismatch CQL error
+    public static readonly CQLPCMismatchError = '[class="madie-alert error"]'
+
     //CQL has errors message
     public static readonly CQLHasErrorMsg = '[data-testid="error-alerts"]'
 

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -5,9 +5,12 @@ import { Utilities } from "./Utilities"
 
 export class TestCasesPage {
 
+    //TC error concerning CQL and PC mismatch
+    public static readonly CQLPCTCMismatchError = '[data-testid="execution_context_loading_errors"]'
+
     //edit test case without knowing test case ID
-    public static actionBtnNoId = '[class="action-button"]'
-    public static editBtnNoId = '[class="btn-container"]'
+    public static readonly actionBtnNoId = '[class="action-button"]'
+    public static readonly editBtnNoId = '[class="btn-container"]'
 
     //tabs on the test case page
     public static readonly cqlHasErrorsMsg = '[data-testid="test-case-cql-has-errors-message"]'
@@ -36,7 +39,6 @@ export class TestCasesPage {
     public static readonly testCaseSeriesList = 'tbody > tr > :nth-child(3)'
     public static readonly aceEditor = '[data-testid="test-case-json-editor"]'
     public static readonly aceEditorJsonInput = '[data-testid="test-case-json-editor-input"]'
-
     public static readonly testCaseTitle = '[data-testid="test-case-title"]'
     public static readonly executeTestCaseButton = '[data-testid="execute-test-cases-button"]'
     public static readonly testCaseStatus = '[class="MuiBox-root css-0"]'

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
@@ -1,0 +1,341 @@
+import { TestCaseJson } from "../../../../Shared/TestCaseJson"
+import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
+import { TestCasesPage } from "../../../../Shared/TestCasesPage"
+import { OktaLogin } from "../../../../Shared/OktaLogin"
+import { Utilities } from "../../../../Shared/Utilities"
+import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
+import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { MeasureCQL } from "../../../../Shared/MeasureCQL"
+
+let measureName = 'TestMeasure' + Date.now()
+let CqlLibraryName = 'TestLibrary' + Date.now()
+let randValue = (Math.floor((Math.random() * 1000) + 1))
+let testCaseTitle = 'Title for Auto Test'
+let testCaseDescription = 'DENOMFail' + Date.now()
+let testCaseSeries = 'SBTestSeries'
+let testCaseJsonIppPass = TestCaseJson.RatioEpisodeSingleIPNoMO_IPP_PASS
+let newMeasureName = measureName + randValue
+let newCqlLibraryName = CqlLibraryName + randValue
+let measureCQL = MeasureCQL.measureCQL_5138_test
+
+describe('CQL Changes and how that impacts test cases, observations and population criteria', () => {
+
+    beforeEach('Create Measure, Test Case and login', () => {
+
+        randValue = (Math.floor((Math.random() * 1000) + 1))
+        newMeasureName = measureName + randValue
+        newCqlLibraryName = CqlLibraryName + randValue
+
+        //Create New Measure
+        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJsonIppPass)
+        OktaLogin.Login()
+    })
+
+    afterEach('Logout and Clean up Measures', () => {
+
+        randValue = (Math.floor((Math.random() * 1000) + 1))
+        newCqlLibraryName = CqlLibraryName + randValue
+
+        OktaLogin.Logout()
+        //Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
+
+    })
+    it('Updating CQL to be errorneous, after initial CQL, PC, and Test Case has been setup, causes errors and the errors' +
+        ' flag to be set to the mismatch flag. Correcting the CQL to removes the errors flag', () => {
+            //Click on Edit Measure
+            //MeasuresPage.clickEditforCreatedMeasure()
+            MeasuresPage.measureAction('edit', true)
+
+            cy.get(EditMeasurePage.cqlEditorTab).click()
+            cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+            cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+            //Click on the measure group tab
+            cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+            cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+            cy.get(EditMeasurePage.measureGroupsTab).click()
+
+            Utilities.setMeasureGroupType()
+
+            cy.get(MeasureGroupPage.popBasis).should('exist')
+            cy.get(MeasureGroupPage.popBasis).should('be.visible')
+            cy.get(MeasureGroupPage.popBasis).click()
+            cy.get(MeasureGroupPage.popBasis).type('Encounter')
+            cy.get(MeasureGroupPage.popBasisOption).click()
+
+            Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCV)
+            Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'mpopEx')
+            Utilities.dropdownSelect(MeasureGroupPage.measurePopulationSelect, 'mpopEx')
+            Utilities.dropdownSelect(MeasureGroupPage.cvMeasureObservation, 'daysObs')
+            Utilities.dropdownSelect(MeasureGroupPage.cvAggregateFunction, 'Maximum')
+
+            cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+            //validation successful save message
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+
+            //Navigate to Test Cases page and add Test Case details
+            cy.get(EditMeasurePage.testCasesTab).click()
+            TestCasesPage.clickEditforCreatedTestCase()
+
+            //click on Expected/Actual tab
+            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
+            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
+            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+
+            //Click on RunTest Button
+            cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
+            cy.get(TestCasesPage.editTestCaseSaveButton).click()
+            cy.get(TestCasesPage.runTestButton).should('exist')
+            cy.get(TestCasesPage.runTestButton).should('be.visible')
+            cy.get(TestCasesPage.runTestButton).should('be.enabled')
+            cy.get(TestCasesPage.runTestButton).wait(1000).click({ force: true })
+            cy.get(TestCasesPage.cvMeasureObservationActualValue).should('have.value', '30')
+
+            //navigate to the CQL Editor tab
+            cy.get(EditMeasurePage.cqlEditorTab).should('exist')
+            cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
+            cy.get(EditMeasurePage.cqlEditorTab).click()
+
+            cy.get(EditMeasurePage.cqlEditorTextBox).invoke('click')
+            //remove the dayObs line(s) from CQL
+            cy.get(EditMeasurePage.cqlEditorTextBox).type('{end}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{moveToEnd}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}')
+            //save changes to CQL
+            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+
+            //wait until toast message appears
+            Utilities.waitForElementVisible(CQLEditorPage.measureErrorToast, 3500)
+            cy.get(CQLEditorPage.measureErrorToast).should('contain.text', 'CQL return types do not match population criteria! Test Cases will not execute until this issue is resolved.')
+            //navigate to the PC tab and verify mismatch message appears
+            cy.get(EditMeasurePage.measureGroupsTab).click()
+            cy.get(MeasureGroupPage.CQLPCMismatchError).should('contain.text', 'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.')
+            //navigate to the TC tab and verify mismatch message appears and the exectue test case button is disabled
+            cy.get(EditMeasurePage.testCasesTab).click()
+            cy.get(TestCasesPage.CQLPCTCMismatchError).should('contain.text', 'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.')
+            cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
+            TestCasesPage.clickEditforCreatedTestCase()
+            //navigate into the test case and verify that the Run Test Case button is also disabled
+            cy.get(TestCasesPage.runTestButton).should('be.disabled')
+
+            //verify that the errors flag indicates the mismatch CQL PC return type error
+            //log out of UI
+            OktaLogin.Logout()
+            //log into backend
+            cy.setAccessTokenCookie()
+            cy.getCookie('accessToken').then((accessToken) => {
+                cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.request({
+                        url: '/api/measures/' + id,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body.errors[0]).to.equal('MISMATCH_CQL_POPULATION_RETURN_TYPES')
+
+
+                    })
+
+                })
+            })
+            //log back in
+            OktaLogin.Login()
+            //click edit on measure with error
+            MeasuresPage.measureAction('edit', true)
+            //navigate to the CQL Editor tab
+            cy.get(EditMeasurePage.cqlEditorTab).should('exist')
+            cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
+            cy.get(EditMeasurePage.cqlEditorTab).click()
+
+            cy.get(EditMeasurePage.cqlEditorTextBox).invoke('click')
+
+            //remove the dayObs line(s) from CQL
+            cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToStart}{home}{ctrl+a}{del}{moveToStart}{home}' + measureCQL + '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{del}')
+            //save changes to CQL
+            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+            cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+            //verify that the errors flag contains no errors / has been cleared
+            //log out of UI
+            OktaLogin.Logout()
+            //log into backend
+            cy.setAccessTokenCookie()
+            cy.getCookie('accessToken').then((accessToken) => {
+                cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.request({
+                        url: '/api/measures/' + id,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body.errors).is.empty
+
+
+                    })
+
+                })
+            })
+        })
+    it('Updating CQL to be errorneous, after initial CQL, PC, and Test Case has been setup, causes errors and the errors' +
+        ' flag to be set to the mismatch flag. Correcting the PC selections to match CQL expectations removes the errors flag', () => {
+            //Click on Edit Measure
+            //MeasuresPage.clickEditforCreatedMeasure()
+            MeasuresPage.measureAction('edit', true)
+
+            cy.get(EditMeasurePage.cqlEditorTab).click()
+            cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+            cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+            //Click on the measure group tab
+            cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+            cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+            cy.get(EditMeasurePage.measureGroupsTab).click()
+
+            Utilities.setMeasureGroupType()
+
+            cy.get(MeasureGroupPage.popBasis).should('exist')
+            cy.get(MeasureGroupPage.popBasis).should('be.visible')
+            cy.get(MeasureGroupPage.popBasis).click()
+            cy.get(MeasureGroupPage.popBasis).type('Encounter')
+            cy.get(MeasureGroupPage.popBasisOption).click()
+
+            Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCV)
+            Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'mpopEx')
+            Utilities.dropdownSelect(MeasureGroupPage.measurePopulationSelect, 'mpopEx')
+            Utilities.dropdownSelect(MeasureGroupPage.cvMeasureObservation, 'daysObs')
+            Utilities.dropdownSelect(MeasureGroupPage.cvAggregateFunction, 'Maximum')
+
+            cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+            //validation successful save message
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+
+            //Navigate to Test Cases page and add Test Case details
+            cy.get(EditMeasurePage.testCasesTab).click()
+            TestCasesPage.clickEditforCreatedTestCase()
+
+            //click on Expected/Actual tab
+            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
+            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
+            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+
+            //Click on RunTest Button
+            cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
+            cy.get(TestCasesPage.editTestCaseSaveButton).click()
+            cy.get(TestCasesPage.runTestButton).should('exist')
+            cy.get(TestCasesPage.runTestButton).should('be.visible')
+            cy.get(TestCasesPage.runTestButton).should('be.enabled')
+            cy.get(TestCasesPage.runTestButton).wait(1000).click({ force: true })
+            cy.get(TestCasesPage.cvMeasureObservationActualValue).should('have.value', '30')
+
+            //navigate to the CQL Editor tab
+            cy.get(EditMeasurePage.cqlEditorTab).should('exist')
+            cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
+            cy.get(EditMeasurePage.cqlEditorTab).click()
+
+            cy.get(EditMeasurePage.cqlEditorTextBox).invoke('click')
+            //remove the dayObs line(s) from CQL
+            cy.get(EditMeasurePage.cqlEditorTextBox).type('{end}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{moveToEnd}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}')
+            //save changes to CQL
+            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+
+            //wait until toast message appears
+            Utilities.waitForElementVisible(CQLEditorPage.measureErrorToast, 3500)
+            cy.get(CQLEditorPage.measureErrorToast).should('contain.text', 'CQL return types do not match population criteria! Test Cases will not execute until this issue is resolved.')
+            //navigate to the PC tab and verify mismatch message appears
+            cy.get(EditMeasurePage.measureGroupsTab).click()
+            cy.get(MeasureGroupPage.CQLPCMismatchError).should('contain.text', 'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.')
+            //navigate to the TC tab and verify mismatch message appears and the exectue test case button is disabled
+            cy.get(EditMeasurePage.testCasesTab).click()
+            cy.get(TestCasesPage.CQLPCTCMismatchError).should('contain.text', 'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.')
+            cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
+            TestCasesPage.clickEditforCreatedTestCase()
+            //navigate into the test case and verify that the Run Test Case button is also disabled
+            cy.get(TestCasesPage.runTestButton).should('be.disabled')
+
+            //verify that the errors flag indicates the mismatch CQL PC return type error
+            //log out of UI
+            OktaLogin.Logout()
+            //log into backend
+            cy.setAccessTokenCookie()
+            cy.getCookie('accessToken').then((accessToken) => {
+                cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.request({
+                        url: '/api/measures/' + id,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body.errors[0]).to.equal('MISMATCH_CQL_POPULATION_RETURN_TYPES')
+
+
+                    })
+
+                })
+            })
+            //log back in
+            OktaLogin.Login()
+            //click edit on measure with error
+            MeasuresPage.measureAction('edit', true)
+            //Click on the measure group tab
+            cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+            cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+            cy.get(EditMeasurePage.measureGroupsTab).click()
+            //update PC scoring value to match updated CQL
+            Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
+            Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'mpopEx')
+
+            cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
+            //validation successful updated message
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+
+            //verify that the errors flag contains no errors / has been cleared
+            //log out of UI
+            OktaLogin.Logout()
+            //log into backend
+            cy.setAccessTokenCookie()
+            cy.getCookie('accessToken').then((accessToken) => {
+                cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.request({
+                        url: '/api/measures/' + id,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body.errors).is.empty
+
+
+                    })
+
+                })
+            })
+        })
+
+})


### PR DESCRIPTION
Created new test file to handle the very specific scenario of a mismatch between an already existing CQL value and an already existing PC. Automated tests also validates updates to error flag after mismatches are fixed.