### PR TITLE
 Regression-test-failure-fixes-and-skips

### DIFF
--- a/cypress/e2e/Services/Measure Service/DraftMeasure.cy.ts
+++ b/cypress/e2e/Services/Measure Service/DraftMeasure.cy.ts
@@ -186,7 +186,8 @@ describe.skip('Version and Draft CQL Library', () => {
         })
     })
 })
-describe('Version and Draft CQL Library', () => {
+//skipping until the measureVersioning flag is removed
+describe.skip('Draftable API end point tests', () => {
 
     beforeEach('Craete Measure, and add Cohort group', () => {
         cy.setAccessTokenCookie()

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
@@ -47,7 +47,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
         ' flag to be set to the mismatch flag. Correcting the CQL to removes the errors flag', () => {
             //Click on Edit Measure
             //MeasuresPage.clickEditforCreatedMeasure()
-            MeasuresPage.measureAction('edit', true)
+            MeasuresPage.measureAction('edit', false)
 
             cy.get(EditMeasurePage.cqlEditorTab).click()
             cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
@@ -152,7 +152,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             //log back in
             OktaLogin.Login()
             //click edit on measure with error
-            MeasuresPage.measureAction('edit', true)
+            MeasuresPage.measureAction('edit', false)
             //navigate to the CQL Editor tab
             cy.get(EditMeasurePage.cqlEditorTab).should('exist')
             cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
@@ -193,7 +193,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
         ' flag to be set to the mismatch flag. Correcting the PC selections to match CQL expectations removes the errors flag', () => {
             //Click on Edit Measure
             //MeasuresPage.clickEditforCreatedMeasure()
-            MeasuresPage.measureAction('edit', true)
+            MeasuresPage.measureAction('edit', false)
 
             cy.get(EditMeasurePage.cqlEditorTab).click()
             cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
@@ -298,7 +298,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             //log back in
             OktaLogin.Login()
             //click edit on measure with error
-            MeasuresPage.measureAction('edit', true)
+            MeasuresPage.measureAction('edit', false)
             //Click on the measure group tab
             cy.get(EditMeasurePage.measureGroupsTab).should('exist')
             cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseImport/TestCaseImportviaFile.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseImport/TestCaseImportviaFile.cy.ts
@@ -30,7 +30,8 @@ let testCaseJsonTstLargeBatch02 = TestCaseJson.largeBatchTC4ImportId2
 let testCaseJsonTstLargeBatch03 = TestCaseJson.largeBatchTC4ImportId3
 let testCaseJsonTstLargeBatch04 = TestCaseJson.largeBatchTC4ImportId4
 let testCaseJsonTstLargeBatch05 = TestCaseJson.largeBatchTC4ImportId5
-describe('Import Test cases onto an existing measure via file', () => {
+//skipping all test case import tests until flag is removed
+describe.skip('Import Test cases onto an existing measure via file', () => {
 
     beforeEach('Login and Create Measure', () => {
 


### PR DESCRIPTION
Regression test failure fixes and skips -- Updated some test files to have tests skipped, due to some feature flag being turned off. Other test files were updated to use a recently created function, that allows us to get around if a feature flag is turned off.