### PR TITLE
MAT-5431 Add library.useContext to the Library Model

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -147,7 +147,8 @@ export class CQLLibraryPage {
                     'createdBy': user,
                     "description": "description",
                     "publisher": CQLLibraryPublisher,
-                    'cql': ""
+                    'cql': "",
+                    "programUseContext": { "code": "a", "display": "b", "codeSystem": "c" }
                 }
             }).then((response) => {
                 expect(response.status).to.eql(201)

--- a/cypress/e2e/Services/CQL Library Service/CreateCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/CreateCQL-Library.cy.ts
@@ -1,15 +1,21 @@
-import {Environment} from "../../../Shared/Environment"
-import {CQLLibraryPage} from "../../../Shared/CQLLibraryPage"
+import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
+import { Environment } from "../../../Shared/Environment"
 
 let CQLLibraryName = ''
-let harpUser = Environment.credentials().harpUser
 let model = 'QI-Core v4.1.1'
+let CQLLibraryPublisher = 'SemanticBits'
+let harpUser = Environment.credentials().harpUser
 
 describe('CQL Library Service: Create CQL Library', () => {
 
     beforeEach('Set Access Token', () => {
 
+        CQLLibraryName = 'TestCqlLibrary' + Date.now()
+
         cy.setAccessTokenCookie()
+
+        //Create CQL Library with Regular User
+        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
 
     })
 
@@ -26,13 +32,17 @@ describe('CQL Library Service: Create CQL Library', () => {
                 },
                 body: {
                     "cqlLibraryName": CQLLibraryName,
-                    "model": model
+                    "model": model,
+                    "programUseContext": { "code": "a", "display": "b", "codeSystem": "c" }
                 }
             }).then((response) => {
                 expect(response.status).to.eql(201)
                 expect(response.body.id).to.be.exist
                 expect(response.body.cqlLibraryName).to.eql(CQLLibraryName)
                 expect(response.body.createdBy).to.eql(harpUser)
+                expect(response.body.programUseContext.code).to.eql('a')
+                expect(response.body.programUseContext.display).to.eql('b')
+                expect(response.body.programUseContext.codeSystem).to.eql('c')
             })
         })
     })
@@ -51,6 +61,28 @@ describe('CQL Library Service: Create CQL Library', () => {
                 expect(response.body).to.not.be.null
                 expect(response.body).to.be.a('array')
                 expect(response.body[0].id).to.be.exist
+            })
+        })
+    })
+
+    it('Get specific CQL Library', () => {
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
+                cy.request({
+                    url: '/api/cql-libraries/' + cqlLibraryId,
+                    method: 'GET',
+                    headers: {
+                        authorization: 'Bearer ' + accessToken.value
+                    }
+                }).then((response) => {
+                    expect(response.status).to.eql(200)
+                    expect(response.body).to.not.be.null
+                    expect(response.body.id).to.be.exist
+                    expect(response.body.programUseContext.code).to.eql('a')
+                    expect(response.body.programUseContext.display).to.eql('b')
+                    expect(response.body.programUseContext.codeSystem).to.eql('c')
+                })
             })
         })
     })

--- a/cypress/e2e/Services/CQL Library Service/EditCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/EditCQL-Library.cy.ts
@@ -1,5 +1,5 @@
-import {CQLLibraryPage} from "../../../Shared/CQLLibraryPage"
-import {Environment} from "../../../Shared/Environment"
+import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
+import { Environment } from "../../../Shared/Environment"
 
 let CQLLibraryName = ''
 let updatedCQLLibraryName = ''
@@ -46,12 +46,16 @@ describe('Edit CQL Library', () => {
                     body: {
                         "id": cqlLibraryId,
                         "cqlLibraryName": updatedCQLLibraryName,
-                        "model": model
+                        "model": model,
+                        "programUseContext": { "code": "a", "display": "b", "codeSystem": "c" }
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
                     expect(response.body.id).to.be.exist
                     expect(response.body.cqlLibraryName).to.eql(updatedCQLLibraryName)
+                    expect(response.body.programUseContext.code).to.eql('a')
+                    expect(response.body.programUseContext.display).to.eql('b')
+                    expect(response.body.programUseContext.codeSystem).to.eql('c')
                 })
             })
         })


### PR DESCRIPTION
Updated backend tests around CQL Libraries to include:
-- a GET request test that pulls back a specific CQL Library 
-- a POST, PUT, and GET tests that include the new programUseContext object for MAT-5431