### PR TITLE
Regression test failure on CreateCQLLibraryValidations test file

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/CreateCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CreateCQLLibraryValidations.cy.ts
@@ -69,7 +69,7 @@ describe('CQL Library Validations', () => {
         cy.get(CQLLibraryPage.headerDetails).should('be.visible')
         cy.get(CQLLibraryPage.headerDetails).should('include.text', 'Libraries/Details')
         cy.get(CQLLibraryPage.headerDetails).should('include.text', newCQLLibraryName)
-        cy.get(CQLLibraryPage.headerDetails).should('include.text', 'v0.0.000')
+        cy.get(CQLLibraryPage.headerDetails).should('include.text', 'Version 0.0.000')
         cy.get(CQLLibraryPage.headerDetails).should('include.text', 'Draft')
         cy.get(CQLLibraryPage.headerDetails).should('include.text', 'QI-Core v4.1.1')
         cy.get(CQLLibraryPage.headerDetails).should('include.text', lastUpdated)


### PR DESCRIPTION
Updated the CreateCQLLibraryValidations test file to account for the word "version", as opposed to just "v" in front of the version number.