### PR TITLE
MAT-5566 Period Start and End date consistency

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -59,6 +59,10 @@ export class EditMeasurePage {
     public static readonly successfulMeasureDeleteMsg = '[data-testid=edit-measure-information-success-text]'
 
     //Measure Meta Data
+    //Model & Mesasurement Start and End date(s)
+    public static readonly mpStart = '[name="measurementPeriodStart"]'
+    public static readonly mpEnd = '[id="measurementPeriodEndDate"]'
+
     //Measure Steward & Developers Page
     public static readonly measureStewardDrpDwn = '[data-testid="steward"]'
     public static readonly measureStewardDrpDwnOption = '#steward-option-0'

--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -43,25 +43,6 @@ export class MeasuresPage {
         })
     }
 
-    /*     public static exportMeasure(): void {
-    
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {
-                Utilities.waitForElementVisible('[data-testid=measure-action-' + fileContents + ']', 30000)
-                cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.visible')
-                Utilities.waitForElementEnabled('[data-testid=measure-action-' + fileContents + ']', 30000)
-                cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.enabled')
-                cy.get('[data-testid=measure-action-' + fileContents + ']').click()
-    
-                cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
-    
-                cy.get('[data-testid=export-measure-' + fileContents + ']').click()
-    
-                cy.wait('@measureExport', { timeout: 60000 }).then(({ response }) => {
-                    expect(response.statusCode).to.eq(200)
-                })
-            })
-        } */
-
     public static validateVersionNumber(expectedValue: string, versionNumber: string): void {
         cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {
 

--- a/cypress/e2e/Services/Measure Service/Measure.cy.ts
+++ b/cypress/e2e/Services/Measure Service/Measure.cy.ts
@@ -68,6 +68,7 @@ describe('Measure Service: Create Measure', () => {
 
         })
     })
+
     //create a QDM measure
     it('Create New Measure, successful creation', () => {
         measureName = 'TestMeasure' + Date.now() + randValue

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureValidations.cy.ts
@@ -1,13 +1,33 @@
 import { OktaLogin } from "../../../../Shared/OktaLogin"
+import { LandingPage } from "../../../../Shared/LandingPage"
 import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import { MeasureCQL } from "../../../../Shared/MeasureCQL"
+import { Global } from "../../../../Shared/Global"
 import { Utilities } from "../../../../Shared/Utilities"
+import { Environment } from "../../../../Shared/Environment"
+import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
+import { v4 as uuidv4 } from 'uuid'
 
-let measureName = 'TestMeasure' + Date.now()
-let CqlLibraryName = 'TestLibrary' + Date.now()
+let randValue = (Math.floor((Math.random() * 1000) + 1))
 let newMeasureName = ''
 let newCqlLibraryName = ''
+
+const now = require('dayjs')
+let mpStartDate = now().subtract('1', 'year').format('YYYY-MM-DD')
+let mpEndDate = now().format('YYYY-MM-DD')
+
+let UiMpStartDate = now().subtract('1', 'year').format('MM/DD/YYYY')
+let UiMpEndDate = now().format('MM/DD/YYYY')
+
+let measureName = ''
+let CQLLibraryName = ''
+let CqlLibraryName = ''
+let model = 'QI-Core v4.1.1'
+let harpUser = Environment.credentials().harpUser
+let eCQMTitle = 'eCQMTitle'
+let versionIdPath = 'cypress/fixtures/versionId'
 
 describe('Edit Measure Validations', () => {
     before('Create Measure', () => {
@@ -169,4 +189,100 @@ describe('Measurement Period Validations', () => {
         cy.get(CreateMeasurePage.editMeasurementPeriodEndDateError).should('contain.text', 'Invalid date format. (mm/dd/yyyy)')
     })
 
+})
+
+describe('Setting time / date value in EST reflects as the same in user time zone', () => {
+
+    beforeEach('Set Access Token', () => {
+        cy.setAccessTokenCookie()
+    })
+    afterEach('Clean up', () => {
+
+        OktaLogin.Logout()
+        Utilities.deleteMeasure(measureName, CQLLibraryName)
+
+    })
+
+    it('Create New Measure, successful creation', () => {
+        measureName = 'TestMeasure' + Date.now() + randValue
+        CQLLibraryName = 'TestCql' + Date.now() + randValue
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.request({
+                url: '/api/measure',
+                method: 'POST',
+                headers: {
+                    Authorization: 'Bearer ' + accessToken.value
+                },
+                body: {
+                    "measureName": measureName,
+                    "cqlLibraryName": CQLLibraryName,
+                    "model": model,
+                    "versionId": uuidv4(),
+                    "measureSetId": uuidv4(),
+                    "ecqmTitle": eCQMTitle,
+                    "measurementPeriodStart": mpStartDate,
+                    "measurementPeriodEnd": mpEndDate
+                }
+            }).then((response) => {
+                expect(response.status).to.eql(201)
+                expect(response.body.createdBy).to.eql(harpUser)
+                cy.writeFile('cypress/fixtures/measureId', response.body.id)
+                cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
+            })
+
+        })
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+
+        cy.get(EditMeasurePage.leftPanelModelAndMeasurementPeriod).click()
+
+        cy.get(EditMeasurePage.mpStart).should('contain.value', UiMpStartDate)
+        cy.get(EditMeasurePage.mpEnd).should('contain.value', UiMpEndDate)
+
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        OktaLogin.Logout()
+        cy.setAccessTokenCookie()
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.readFile(versionIdPath).should('exist').then((vId) => {
+                    cy.request({
+                        url: '/api/measures/' + id,
+                        method: 'PUT',
+                        headers: {
+                            Authorization: 'Bearer ' + accessToken.value
+                        },
+                        body: {
+                            "id": id,
+                            "measureName": measureName,
+                            "cqlLibraryName": CQLLibraryName,
+                            "model": 'QI-Core v4.1.1',
+                            "versionId": vId,
+                            "measureSetId": uuidv4(),
+                            "ecqmTitle": eCQMTitle,
+                            "measurementPeriodStart": '2012-01-01T05:00:00.000+00:00',
+                            "measurementPeriodEnd": '2012-12-31T05:00:00.000+00:00',
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                    })
+                })
+            })
+        })
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+
+        cy.get(EditMeasurePage.leftPanelModelAndMeasurementPeriod).click()
+
+        cy.get(EditMeasurePage.mpStart).should('contain.value', '01/01/2012')
+        cy.get(EditMeasurePage.mpEnd).should('contain.value', '12/31/2012')
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        OktaLogin.Logout()
+    })
 })


### PR DESCRIPTION
Added tests and updated support files to verify Measure Period Start and End dates are consistent, in the UI, regardless of time zone they were entered.