### PR TITLE
Changes around the beforeEach blocks, where CQL is being edited in the UI

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMMeasureGroupStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMMeasureGroupStratification.cy.ts
@@ -140,6 +140,10 @@ describe.skip('Validating Stratification tabs', () => {
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{del}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.Login()
     })
 

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
@@ -54,6 +54,10 @@ describe.skip('Validate QDM Population Criteria section -- scoring and populatio
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{del}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.Login()
     })
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseCreation.cy.ts
@@ -145,6 +145,10 @@ describe.skip('Validating the creation of QDM Test Case', () => {
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{del}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.Login()
     })
 


### PR DESCRIPTION
Noticed that doing a single carriage return in the CQL value -- as we do for QI Core tests -- it creates an invalid line in the CQL. So, I have updated where I am doing this for QDM to, basically, reverse the carriage return after initially saving it.