### PR TITLE
MAT-5811 Verify Library appears correctly in searched and stand-alone All Libraries and My Libraries lists

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -5,6 +5,7 @@ import { v4 as uuidv4 } from 'uuid'
 
 export class CQLLibraryPage {
 
+    public static readonly cqlLibSearchResultsTable = '[data-testid="table-body"]'
     public static readonly cqlLibraryProgramUseContext = '[id="programUseContext"]'
     public static readonly createCQLLibraryBtn = '[data-testid="create-new-cql-library-button"]'
     public static readonly cqlLibraryNameTextbox = '[data-testid="cql-library-name-text-field-input"]'

--- a/cypress/e2e/WebInterface/CQL Library/CQLLibrarySearch.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQLLibrarySearch.cy.ts
@@ -5,6 +5,8 @@ import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 
 var CQLLibraryName = ""
 let CQLLibraryPublisher = 'ICFer'
+var CQLLibraryNameAlt = ""
+let CQLLibraryPublisherAlt = 'ICFerALTUser'
 describe('CQL Library Search Validations', () => {
 
     beforeEach('Login', () => {
@@ -166,6 +168,121 @@ describe('CQL Library Search Validations', () => {
         cy.get(CQLLibraryPage.ClearSearchBox).click()
 
         cy.get(CQLLibraryPage.LibTableRows).should('have.length.greaterThan', 1)
+
+    })
+})
+describe('CQL Library Search Validations -- User ownership', () => {
+
+    beforeEach('Login', () => {
+        var randValue = (Math.floor((Math.random() * 1000) + 1))
+        CQLLibraryNameAlt = 'TestLibrary' + Date.now() + randValue
+        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryNameAlt, CQLLibraryPublisherAlt, false, true)
+
+
+    })
+    afterEach('Logout', () => {
+
+        OktaLogin.Logout()
+
+    })
+    it('Owner is different than current user, library will only appear in "All Libraries" searched list', () => {
+        //log in as user that does not own the Library
+        OktaLogin.Login()
+
+        //navigate to the main CQL Library list page
+        cy.get(Header.cqlLibraryTab).should('exist')
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
+        cy.get(Header.cqlLibraryTab).click()
+        cy.wait('@libraries', { timeout: 60000 })
+
+        //ensure we are on the My Libraries tab
+        cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
+        cy.get(CQLLibraryPage.myLibrariesBtn).should('be.visible')
+        cy.get(CQLLibraryPage.myLibrariesBtn).click()
+
+        //do a search based on the CQL Library name on, both, the "My Libraries" and the "All Libraries" tabs
+        cy.get(CQLLibraryPage.LibFilterTextField).should('exist')
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterTextField).click()
+        cy.get(CQLLibraryPage.LibFilterTextField).clear()
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.focused')
+        cy.get(CQLLibraryPage.LibFilterTextField).type(CQLLibraryNameAlt)
+
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('exist')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.enabled')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).click()
+
+        cy.get(CQLLibraryPage.cqlLibSearchResultsTable).should('be.empty')
+
+        cy.get(CQLLibraryPage.allLibrariesBtn).should('exist')
+        cy.get(CQLLibraryPage.allLibrariesBtn).should('be.visible')
+        cy.get(CQLLibraryPage.allLibrariesBtn).click()
+
+        cy.get(CQLLibraryPage.LibFilterTextField).should('exist')
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterTextField).click()
+        cy.get(CQLLibraryPage.LibFilterTextField).clear()
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.focused')
+        cy.get(CQLLibraryPage.LibFilterTextField).type(CQLLibraryNameAlt)
+
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('exist')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.enabled')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).click()
+
+        CQLLibrariesPage.validateCQLLibraryName(CQLLibraryNameAlt)
+
+    })
+    it('Owner is the same as the current user, library will appear in, both, "All Libraries" and "My Libraries" searched lists', () => {
+        //log in as user that does not own the Library
+        OktaLogin.AltLogin()
+
+        //navigate to the main CQL Library list page
+        cy.get(Header.cqlLibraryTab).should('exist')
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
+        cy.get(Header.cqlLibraryTab).click()
+        cy.wait('@libraries', { timeout: 60000 })
+
+        //ensure we are on the My Libraries tab
+        cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
+        cy.get(CQLLibraryPage.myLibrariesBtn).should('be.visible')
+        cy.get(CQLLibraryPage.myLibrariesBtn).click()
+
+        //do a search based on the CQL Library name on, both, the "My Libraries" and the "All Libraries" tabs
+        cy.get(CQLLibraryPage.LibFilterTextField).should('exist')
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterTextField).click()
+        cy.get(CQLLibraryPage.LibFilterTextField).clear()
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.focused')
+        cy.get(CQLLibraryPage.LibFilterTextField).type(CQLLibraryNameAlt)
+
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('exist')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.enabled')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).click()
+
+        CQLLibrariesPage.validateCQLLibraryName(CQLLibraryNameAlt)
+
+        cy.get(CQLLibraryPage.allLibrariesBtn).should('exist')
+        cy.get(CQLLibraryPage.allLibrariesBtn).should('be.visible')
+        cy.get(CQLLibraryPage.allLibrariesBtn).click()
+
+        cy.get(CQLLibraryPage.LibFilterTextField).should('exist')
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterTextField).click()
+        cy.get(CQLLibraryPage.LibFilterTextField).clear()
+        cy.get(CQLLibraryPage.LibFilterTextField).should('be.focused')
+        cy.get(CQLLibraryPage.LibFilterTextField).type(CQLLibraryNameAlt)
+
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('exist')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.visible')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).should('be.enabled')
+        cy.get(CQLLibraryPage.LibFilterSubmitBtn).click()
+
+        CQLLibrariesPage.validateCQLLibraryName(CQLLibraryNameAlt)
 
     })
 })

--- a/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
@@ -6,7 +6,8 @@ import { Header } from "../../../Shared/Header"
 let CQLLibraryName = 'TestLibrary' + Date.now()
 let newCQLLibraryName = ''
 let CQLLibraryPublisher = 'SemanticBits'
-
+var CQLLibraryNameAlt = ""
+let CQLLibraryPublisherAlt = 'ICFerALTUser'
 
 describe('Edit CQL Library validations', () => {
 
@@ -223,5 +224,45 @@ describe('Edit CQL Library validations', () => {
                 })
             })
         })
+    })
+})
+describe('CQL Library Search Validations -- User ownership', () => {
+
+    beforeEach('Login', () => {
+        var randValue = (Math.floor((Math.random() * 1000) + 1))
+        CQLLibraryNameAlt = 'TestLibrary' + Date.now() + randValue
+        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryNameAlt, CQLLibraryPublisherAlt, false, true)
+
+
+    })
+    afterEach('Logout', () => {
+
+        OktaLogin.Logout()
+
+    })
+    it('Owner is the same as current user, library will appear in, both, "All Libraries" and "My Libraries" lists', () => {
+        //log in as user that does not own the Library
+        OktaLogin.AltLogin()
+
+        //navigate to the main CQL Library list page
+        cy.get(Header.cqlLibraryTab).should('exist')
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
+        cy.get(Header.cqlLibraryTab).click()
+        cy.wait('@libraries', { timeout: 60000 })
+
+        //ensure we are on the My Libraries tab
+        cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
+        cy.get(CQLLibraryPage.myLibrariesBtn).should('be.visible')
+        cy.get(CQLLibraryPage.myLibrariesBtn).click()
+
+        CQLLibrariesPage.validateCQLLibraryName(CQLLibraryNameAlt)
+
+        cy.get(CQLLibraryPage.allLibrariesBtn).should('exist')
+        cy.get(CQLLibraryPage.allLibrariesBtn).should('be.visible')
+        cy.get(CQLLibraryPage.allLibrariesBtn).click()
+
+        CQLLibrariesPage.validateCQLLibraryName(CQLLibraryNameAlt)
+
     })
 })


### PR DESCRIPTION
Created tests that validates that, if current user is not the owner of a Library, the library will only appear under "All Libraries" in, both, the stand-alone list as well as searched list. Likewise, created tests that confirms / validates that if user is the same as the owner of the Library, it will appear in, both, their "My Libraries" and "All Libraries" stand-alone and searched lists.