### PR TITLE
Added non-owner test case export tests

### DIFF
--- a/cypress/e2e/Services/Measure Service/TestCaseExport.cy.ts
+++ b/cypress/e2e/Services/Measure Service/TestCaseExport.cy.ts
@@ -46,9 +46,6 @@ describe('QI-Core Single Test Case Export', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         OktaLogin.Logout()
-        cy.clearCookies()
-        cy.clearLocalStorage()
-        cy.setAccessTokenCookie()
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -61,6 +58,35 @@ describe('QI-Core Single Test Case Export', () => {
     })
 
     it('Export single QI-Core Test case', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookie()
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
+                    cy.request({
+                        url: '/api/measures/' + id + '/test-cases/exports',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'PUT',
+                        body: [
+                            testCaseId
+                        ]
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body).is.not.empty
+                    })
+                })
+            })
+        })
+
+    })
+
+    it('Non-owner of Measure: Export single QI-Core Test case', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookieALT()
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
                 cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
@@ -138,9 +164,7 @@ describe('QI-Core Multiple Test Case Export', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         OktaLogin.Logout()
-        cy.clearCookies()
-        cy.clearLocalStorage()
-        cy.setAccessTokenCookie()
+
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -153,6 +177,36 @@ describe('QI-Core Multiple Test Case Export', () => {
     })
 
     it('Export All QI-Core Test cases', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookie()
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
+                    cy.readFile('cypress/fixtures/testcaseId2').should('exist').then((testCaseId2) => {
+                        cy.request({
+                            url: '/api/measures/' + id + '/test-cases/exports',
+                            headers: {
+                                authorization: 'Bearer ' + accessToken.value
+                            },
+                            method: 'PUT',
+                            body: [
+                                testCaseId, testCaseId2
+                            ]
+                        }).then((response) => {
+                            expect(response.status).to.eql(200)
+                            expect(response.body).is.not.empty
+                        })
+                    })
+                })
+            })
+        })
+    })
+
+    it('Non-owner of Measure: Export All QI-Core Test cases', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookieALT()
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
                 cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {

--- a/cypress/e2e/WebInterface/Test Cases/Validations/TestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Validations/TestCaseExport.cy.ts
@@ -89,6 +89,66 @@ describe('QI-Core Single Test Case Export', () => {
         })
 
     })
+
+    it('Non-owner of Measure: Export single QI-Core Test case', () => {
+        let testCasePIdPath = 'cypress/fixtures/testCasePId'
+
+        MeasuresPage.measureAction("edit")
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.testCaseAction('edit')
+        //navigate to the details page
+        cy.get(TestCasesPage.detailsTab).scrollIntoView()
+        cy.get(TestCasesPage.detailsTab).should('exist')
+        cy.get(TestCasesPage.detailsTab).should('be.enabled')
+        cy.get(TestCasesPage.detailsTab).click()
+
+        //Update Test Case Description
+        cy.get(TestCasesPage.testCaseDescriptionTextBox).clear()
+
+        //save changes to description
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+
+        //verify message appears indicating that test case was saved
+        cy.get(TestCasesPage.confirmationMsg).should('have.text', 'Test case updated successfully with warnings in JSON')
+
+        cy.get(EditMeasurePage.measureDetailsTab).click()
+        Utilities.waitForElementVisible(EditMeasurePage.measureNameTextBox, 35000)
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        OktaLogin.Logout()
+        OktaLogin.AltLogin()
+
+        cy.get(MeasuresPage.allMeasuresTab).click()
+        MeasuresPage.measureAction("edit")
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.testCaseAction('export')
+
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip')).should('exist')
+        cy.log('Successfully verified zip file export')
+
+        // unzipping the Test Case Export
+        cy.task('unzipFile', { zipFile: 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip', path: downloadsFolder })
+            .then(results => {
+                cy.log('unzipFile Task finished')
+            })
+        cy.readFile(testCasePIdPath).should('exist').then((patientId) => {
+            //Verify all files exist in exported zip file
+            cy.readFile(path.join(downloadsFolder, 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip')).should('contain', 'eCQMTitle-v0.0.000-SBTestSeries-Title for Auto Test.json' &&
+                patientId, 'README.txt')
+        })
+
+    })
+
+
 })
 
 describe('QI-Core Test Case Export for all test cases', () => {
@@ -165,6 +225,93 @@ describe('QI-Core Test Case Export for all test cases', () => {
 
         cy.get(EditMeasurePage.measureDetailsTab).click()
         Utilities.waitForElementVisible(EditMeasurePage.measureNameTextBox, 35000)
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        cy.get(TestCasesPage.exportTestCasesBtn).click()
+
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip')).should('exist')
+        cy.log('Successfully verified zip file export')
+
+        // unzipping the Test Case Export
+        cy.task('unzipFile', { zipFile: 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip', path: downloadsFolder })
+            .then(results => {
+                cy.log('unzipFile Task finished')
+            })
+        cy.readFile(testCasePIdPath).should('exist').then((patientId) => {
+            //Verify all files exist in exported zip file
+            cy.readFile(path.join(downloadsFolder, 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip')).should('contain', 'eCQMTitle-v0.0.000-SBTestSeries-Title for Auto Test.json' &&
+                patientId, 'README.txt')
+        })
+        cy.readFile(testCasePIdPathSecnD).should('exist').then((patientId2) => {
+            //Verify all files exist in exported zip file
+            cy.readFile(path.join(downloadsFolder, 'eCQMTitle-v0.0.000-FHIR4-TestCases.zip')).should('contain', 'eCQMTitle-v0.0.000-SBTestSeries2-Title for Auto Test2.json' &&
+                patientId2)
+        })
+
+    })
+
+    it('Non-owner of Measure: Export All QI-Core Test cases', () => {
+        let testCasePIdPath = 'cypress/fixtures/testCasePId'
+        let testCasePIdPathSecnD = 'cypress/fixtures/testCasePId2'
+
+        MeasuresPage.measureAction("edit")
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.testCaseAction('edit')
+        //navigate to the details page
+        cy.get(TestCasesPage.detailsTab).scrollIntoView()
+        cy.get(TestCasesPage.detailsTab).should('exist')
+        cy.get(TestCasesPage.detailsTab).should('be.enabled')
+        cy.get(TestCasesPage.detailsTab).click()
+
+        //Update Test Case Description
+        cy.get(TestCasesPage.testCaseDescriptionTextBox).clear()
+
+        //save changes to description
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+
+        //verify message appears indicating that test case was saved
+        cy.get(TestCasesPage.confirmationMsg).should('have.text', 'Test case updated successfully with warnings in JSON')
+
+        cy.get(EditMeasurePage.measureDetailsTab).click()
+        Utilities.waitForElementVisible(EditMeasurePage.measureNameTextBox, 35000)
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.testCaseAction('edit', true)
+        //navigate to the details page
+        cy.get(TestCasesPage.detailsTab).scrollIntoView()
+        cy.get(TestCasesPage.detailsTab).should('exist')
+        cy.get(TestCasesPage.detailsTab).should('be.enabled')
+        cy.get(TestCasesPage.detailsTab).click()
+
+        //Update Test Case Description
+        cy.get(TestCasesPage.testCaseDescriptionTextBox).clear()
+
+        //save changes to description
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+
+        //verify message appears indicating that test case was saved
+        cy.get(TestCasesPage.confirmationMsg).should('have.text', 'Test case updated successfully with warnings in JSON')
+
+        cy.get(EditMeasurePage.measureDetailsTab).click()
+        Utilities.waitForElementVisible(EditMeasurePage.measureNameTextBox, 35000)
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        OktaLogin.Logout()
+        OktaLogin.AltLogin()
+
+        cy.get(MeasuresPage.allMeasuresTab).click()
+        MeasuresPage.measureAction("edit")
 
         //Navigate to Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()


### PR DESCRIPTION
This is to replace PR #967, as the changes related to the smoke tests were not necessary. This PR contains only the changes for the Test Case export and the tests concerning a non-owner of the measure being able to do an export.