### PR TITLE
MAT-6010 Delete All Test Cases new API end point

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -3,8 +3,6 @@ import { Environment } from "./Environment"
 import { Utilities } from "./Utilities"
 
 export class TestCasesPage {
-    // <div role="alert" aria-label="Create Alert" data-testid="create-test-case-alert" class="EditTestCase__Alert-sc-16c4ee9-2 kIeWWj">The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.<button data-testid="close-create-test-case-alert" type="button" data-bs-dismiss="alert" aria-label="Close Alert" class="EditTestCase___StyledButton-sc-16c4ee9-5 iOuUIr"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg></button></div>
-
     //observaion fields
     public static readonly denom0Observation = '[id="denominatorObservation0-expected-cb"]'
     public static readonly denom1Observation = '[id="denominatorObservation1-expected-cb"]'

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -3,6 +3,8 @@ import { Environment } from "./Environment"
 import { Utilities } from "./Utilities"
 
 export class TestCasesPage {
+    // <div role="alert" aria-label="Create Alert" data-testid="create-test-case-alert" class="EditTestCase__Alert-sc-16c4ee9-2 kIeWWj">The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.<button data-testid="close-create-test-case-alert" type="button" data-bs-dismiss="alert" aria-label="Close Alert" class="EditTestCase___StyledButton-sc-16c4ee9-5 iOuUIr"><svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11 " role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg></button></div>
+
     //observaion fields
     public static readonly denom0Observation = '[id="denominatorObservation0-expected-cb"]'
     public static readonly denom1Observation = '[id="denominatorObservation1-expected-cb"]'
@@ -75,6 +77,7 @@ export class TestCasesPage {
     //QDM misc test case page objects
     public static readonly QDMTCSaveBtn = '[data-testid="edit-test-case-save-button"]'
     public static readonly tcSaveSuccessMsg = '[class="toast success"]'
+    public static readonly tcSaveAlertDangerMsg = '[class="toast danger"]'
     public static readonly editTestCaseDescriptionInlineError = '[data-testid="test-case-description-helper-text"]'
     public static readonly QDMTcDiscardChangesButton = '[data-testid="ds-btn"]'
     public static readonly QDMRunTestCasefrmTestCaseListPage = '[data-testid="qdm-test-case-run-button"]'

--- a/cypress/e2e/Services/Measure Service/DeleteTest-Case.cy.ts
+++ b/cypress/e2e/Services/Measure Service/DeleteTest-Case.cy.ts
@@ -1,18 +1,28 @@
-import {TestCaseJson} from "../../../Shared/TestCaseJson"
-import {CreateMeasurePage} from "../../../Shared/CreateMeasurePage"
-import {TestCasesPage} from "../../../Shared/TestCasesPage"
-import {Utilities} from "../../../Shared/Utilities"
-import {Environment} from "../../../Shared/Environment"
+import { TestCaseJson } from "../../../Shared/TestCaseJson"
+import { CreateMeasurePage } from "../../../Shared/CreateMeasurePage"
+import { TestCasesPage } from "../../../Shared/TestCasesPage"
+import { Utilities } from "../../../Shared/Utilities"
+import { Environment } from "../../../Shared/Environment"
+import { OktaLogin } from "../../../Shared/OktaLogin"
+import { MeasuresPage } from "../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
+import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
+import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
+import { Header } from "../../../Shared/Header"
+import { MeasureCQL } from "../../../Shared/MeasureCQL"
 
+let measureSharingAPIKey = Environment.credentials().measureSharing_API_Key
+let harpUserALT = Environment.credentials().harpUserALT
 let measureName = 'TestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
-let testCaseTitle = 'Title for Auto Test'
-let testCaseDescription = 'DENOMFail' + Date.now()
-let testCaseSeries = 'SBTestSeries'
+let testCaseTitle = 'Passing Test Case'
+let testCaseDescription = 'DENOMPass' + Date.now()
+let testCaseSeries = 'SBTestSeriesP'
 let testCaseJson = TestCaseJson.TestCaseJson_Valid
+let measureCQLPFTests = MeasureCQL.CQL_Populations
 let harpUser = Environment.credentials().harpUserALT
 
-describe('Delete test Case', () => {
+describe('Delete test Case: Older end point / url that takes id and title in the body of DELETE request', () => {
 
     beforeEach('Create Measure, Test Case and set access token', () => {
 
@@ -24,31 +34,31 @@ describe('Delete test Case', () => {
 
     })
 
-    afterEach('Clean up',() => {
+    afterEach('Clean up', () => {
 
         Utilities.deleteMeasure(measureName, CqlLibraryName)
 
     })
 
-    it('Delete test Case - Success scenario', () => {
+    it('Delete test Case - Success scenario - Old end point', () => {
 
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
                 cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
-                cy.request({
-                    url: '/api/measures/' + measureId + '/test-cases/' + testCaseId,
-                    method: 'DELETE',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    body: {
-                        "id": testCaseId,
-                        "title": testCaseTitle
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql('Test case deleted successfully: ' + testCaseId)
-                })
+                    cy.request({
+                        url: '/api/measures/' + measureId + '/test-cases/' + testCaseId,
+                        method: 'DELETE',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        body: {
+                            "id": testCaseId,
+                            "title": testCaseTitle
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body).to.eql('Test case deleted successfully: ' + testCaseId)
+                    })
                 })
             })
         })
@@ -83,4 +93,261 @@ describe('Delete test Case', () => {
             })
         })
     })
+})
+describe('Delete test Case: Newer end point / url that takes an list array of test case ids', () => {
+
+    beforeEach('Create Measure, Group, Test Case and set access token', () => {
+
+        cy.setAccessTokenCookie()
+        //Create Measure
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests, false)
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.Logout()
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
+        //Create Test case
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'a', testCaseDescription + ' a', testCaseSeries + 'a', testCaseJson, false, false)
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'b', testCaseDescription + ' b', testCaseSeries + 'b', testCaseJson, false, true)
+        OktaLogin.Login()
+        Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
+        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
+        cy.get(Header.cqlLibraryTab).click().wait(3000)
+
+        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
+        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
+        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+        cy.get(MeasureGroupPage.QDMPopCriteria1Desc)
+            .click()
+            .type('Some description')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMsg, 35000)
+        cy.get(MeasureGroupPage.successfulSaveMsg).should('contain.text', 'Population details for this group updated successfully.')
+        Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
+        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
+        cy.get(Header.cqlLibraryTab).click().wait(3000)
+
+        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
+        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
+        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        MeasuresPage.measureAction("edit")
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.testCaseAction('edit')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        cy.get(TestCasesPage.detailsTab).click()
+        cy.get(TestCasesPage.confirmationMsg).should('contain.text', 'Test case updated successfully ' +
+            'with warnings in JSON')
+        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
+        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
+        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        MeasuresPage.measureAction("edit")
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.testCaseAction('edit', true)
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        cy.get(TestCasesPage.detailsTab).click()
+        cy.get(TestCasesPage.confirmationMsg).should('contain.text', 'Test case updated successfully ' +
+            'with warnings in JSON')
+        OktaLogin.Logout()
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookie()
+    })
+
+    afterEach('Clean up', () => {
+
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+
+    })
+
+    it('Delete test Case - Success scenario - New Delete End Point', () => {
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
+                    cy.readFile('cypress/fixtures/testCaseId2').should('exist').then((testCaseId2) => {
+                        cy.request({
+                            url: '/api/measures/' + measureId + '/test-cases',
+                            method: 'DELETE',
+                            headers: {
+                                authorization: 'Bearer ' + accessToken.value
+                            },
+                            body:
+                                [
+                                    testCaseId, testCaseId2
+                                ]
+
+                        }).then((response) => {
+                            expect(response.status).to.eql(200)
+                            expect(response.body).to.eql('Succesfully deleted provided test cases')
+                        })
+                    })
+                })
+            })
+        })
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
+                    cy.request({
+                        failOnStatusCode: false,
+                        url: '/api/measures/' + id + '/test-cases/' + testCaseId,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+                    }).then((response) => {
+                        expect(response.status).to.eql(404)
+                        expect(response.body.message).to.eql('Could not find Test Case with id: ' + testCaseId)
+                    })
+                })
+            })
+        })
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.readFile('cypress/fixtures/testcaseId2').should('exist').then((testCaseId2) => {
+                    cy.request({
+                        failOnStatusCode: false,
+                        url: '/api/measures/' + id + '/test-cases/' + testCaseId2,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+                    }).then((response) => {
+                        expect(response.status).to.eql(404)
+                        expect(response.body.message).to.eql('Could not find Test Case with id: ' + testCaseId2)
+                    })
+                })
+            })
+        })
+
+    })
+    it('Delete test Case - user trying to delete is not owner of measure', () => {
+
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookieALT()
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
+                    cy.readFile('cypress/fixtures/testCaseId2').should('exist').then((testCaseId2) => {
+                        cy.request({
+                            failOnStatusCode: false,
+                            url: '/api/measures/' + measureId + '/test-cases',
+                            method: 'DELETE',
+                            headers: {
+                                authorization: 'Bearer ' + accessToken.value
+                            },
+                            body:
+                                [
+                                    testCaseId, testCaseId2
+                                ]
+
+                        }).then((response) => {
+                            expect(response.status).to.eql(403)
+                            expect(response.body.message).contains('User ReUser6408 is not authorized for Measure with ID ')
+                        })
+                    })
+                })
+            })
+        })
+    })
+    it('Delete test Case - user has had measure shared with them', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //Share Measure with ALT User
+        cy.setAccessTokenCookie()
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.request({
+                    url: '/api/measures/' + id + '/grant?userid=' + harpUserALT,
+                    headers: {
+                        authorization: 'Bearer ' + accessToken.value,
+                        'api-key': measureSharingAPIKey
+                    },
+                    method: 'PUT'
+
+                }).then((response) => {
+                    expect(response.status).to.eql(200)
+                    expect(response.body).to.eql(harpUserALT + ' granted access to Measure successfully.')
+                })
+            })
+        })
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookieALT()
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
+                    cy.readFile('cypress/fixtures/testCaseId2').should('exist').then((testCaseId2) => {
+                        cy.request({
+                            url: '/api/measures/' + measureId + '/test-cases',
+                            method: 'DELETE',
+                            headers: {
+                                authorization: 'Bearer ' + accessToken.value
+                            },
+                            body:
+                                [
+                                    testCaseId, testCaseId2
+                                ]
+
+                        }).then((response) => {
+                            expect(response.status).to.eql(200)
+                            expect(response.body).to.eql('Succesfully deleted provided test cases')
+                        })
+                    })
+                })
+            })
+            cy.getCookie('accessToken').then((accessToken) => {
+                cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
+                        cy.request({
+                            failOnStatusCode: false,
+                            url: '/api/measures/' + id + '/test-cases/' + testCaseId,
+                            headers: {
+                                authorization: 'Bearer ' + accessToken.value
+                            },
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.status).to.eql(404)
+                            expect(response.body.message).to.eql('Could not find Test Case with id: ' + testCaseId)
+                        })
+                    })
+                })
+            })
+            cy.getCookie('accessToken').then((accessToken) => {
+                cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.readFile('cypress/fixtures/testcaseId2').should('exist').then((testCaseId2) => {
+                        cy.request({
+                            failOnStatusCode: false,
+                            url: '/api/measures/' + id + '/test-cases/' + testCaseId2,
+                            headers: {
+                                authorization: 'Bearer ' + accessToken.value
+                            },
+                            method: 'GET',
+                        }).then((response) => {
+                            expect(response.status).to.eql(404)
+                            expect(response.body.message).to.eql('Could not find Test Case with id: ' + testCaseId2)
+                        })
+                    })
+                })
+            })
+        })
+    })
+
+
+
 })

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseExportImport/TestCaseImport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseExportImport/TestCaseImport.cy.ts
@@ -10,7 +10,6 @@ import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { Header } from "../../../../Shared/Header"
 import { Environment } from "../../../../Shared/Environment"
-import { LandingPage } from "../../../../Shared/LandingPage"
 
 let measureSharingAPIKey = Environment.credentials().measureSharing_API_Key
 let harpUserALT = Environment.credentials().harpUserALT

--- a/cypress/e2e/WebInterface/Test Cases/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Validations/TestCaseValidations.cy.ts
@@ -8,6 +8,8 @@ import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
 import { Global } from "../../../../Shared/Global"
+import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { Header } from "../../../../Shared/Header"
 
 let measureName = 'TestMeasure' + Date.now()
 let newMeasureName = ''
@@ -313,7 +315,7 @@ describe('Duplicate Test Case Title and Group validations', () => {
 
     beforeEach('Create Measure, Test case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
 
@@ -357,7 +359,7 @@ describe('Duplicate Test Case Title and Group validations', () => {
 
         cy.get(TestCasesPage.createTestCaseSaveButton).click()
 
-        cy.get(TestCasesPage.duplicateTCNameValidation).should('contain.text', 'An error occurred while creating the test case: The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
+        cy.get(TestCasesPage.tcSaveAlertDangerMsg).should('contain.text', 'An error occurred while creating the test case: The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
     })
 
     it('Edit Test Case: Verify error message when the Test case Title and group names are duplicate', () => {
@@ -379,7 +381,7 @@ describe('Duplicate Test Case Title and Group validations', () => {
         cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
-        cy.get(TestCasesPage.createTestCaseTitleInput).type('SecondTestCase'.toString())
+        cy.get(TestCasesPage.createTestCaseTitleInput).wait(2000).type('SecondTestCase'.toString())
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
@@ -387,20 +389,20 @@ describe('Duplicate Test Case Title and Group validations', () => {
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCaseDescription)
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-        cy.get(TestCasesPage.createTestCaseGroupInput).type('SecondTestCaseGroup').type('{enter}')
+        cy.get(TestCasesPage.createTestCaseGroupInput).wait(1000).type('SecondTestCaseGroup').type('{enter}')
 
         cy.get(TestCasesPage.createTestCaseSaveButton).click()
 
         //Edit First Test case
         TestCasesPage.clickEditforCreatedTestCase()
         cy.get(TestCasesPage.detailsTab).click()
-        cy.get(TestCasesPage.testCaseTitle).clear().type('SecondTestCase'.toString())
+        cy.get(TestCasesPage.testCaseTitle).clear().wait(2000).type('{selectall}{backspace}{selectall}{backspace}').type('SecondTestCase'.toString())
         cy.get(TestCasesPage.testCaseSeriesTextBox).should('exist')
         cy.get(TestCasesPage.testCaseSeriesTextBox).should('be.visible')
-        cy.get(TestCasesPage.testCaseSeriesTextBox).clear().type('SecondTestCaseGroup').type('{enter}')
+        cy.get(TestCasesPage.testCaseSeriesTextBox).clear().wait(1000).type('SecondTestCaseGroup').type('{enter}')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.editDuplicateTCNameValidation).should('contain.text', 'The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
+        cy.get(TestCasesPage.confirmationMsg).should('contain.text', 'The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
 
     })
 })


### PR DESCRIPTION
Updated some other tests but main focus of this PR was to add tests to the DeleteTest-Case automated regression test file to include tests for the new Delete All Test Cases API end point.