### PR TITLE
MAT5984 Remove Automated Tests validating Program Use Context is gone on Measures

### DIFF
--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
@@ -47,10 +47,6 @@ describe('Edit Measure: Add Meta Data', () => {
         //Click on Edit Measure
         MeasuresPage.measureAction("edit")
 
-        //Enter meta data
-
-        //Endorser Fields on Name, Version & ID page
-
         //Verify that the Endorsement Number field is disabled before adding Endorsement Organization
         cy.get(EditMeasurePage.endorsementNumber).should('be.disabled')
         //Save Endorsement Organization
@@ -58,15 +54,6 @@ describe('Edit Measure: Add Meta Data', () => {
         cy.get(EditMeasurePage.endorsingOrganizationOption).click()
         cy.get(EditMeasurePage.endorsementNumber).should('be.enabled')
         cy.get(EditMeasurePage.endorsementNumber).type('345678')
-        cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('exist')
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('be.visible')
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
-
-        //Program Use Context on Name, Version & ID page
-        cy.get(EditMeasurePage.programUseContextTextBox).click()
-        cy.get(EditMeasurePage.programUseContextTextBox).type('EH/CAH')
-        cy.get(EditMeasurePage.programUseContextOption).click()
         cy.get(EditMeasurePage.measurementInformationSaveButton).click()
         cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('exist')
         cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('be.visible')
@@ -135,8 +122,6 @@ describe('Edit Measure: Add Meta Data', () => {
         //Click on Edit Measure
         MeasuresPage.measureAction("edit")
 
-        //verification of data entry
-
         //Endorsing Organization and number on Name, Version & ID page
         cy.get(EditMeasurePage.endorsingOrganizationTextBox).invoke('val').then(endorsingOrg => {
             cy.get(EditMeasurePage.endorsementNumber).invoke('val').then(endorsementNumber => {
@@ -145,12 +130,6 @@ describe('Edit Measure: Add Meta Data', () => {
             })
         })
         cy.log('Endorsing Organization and number added successfully')
-
-        //Program Use Context on Name, Version & ID page
-        cy.get(EditMeasurePage.programUseContextTextBox).invoke('val').then(val => {
-            expect(val).to.eql('EH/CAH')
-        })
-        cy.log('Program Use Context added successfully')
 
         //steward
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()


### PR DESCRIPTION
Updated existing tests to no longer validate and using the Program Use Context field, on Measures. Further validations was conducted manually to make sure the field no longer exists.