### PR TITLE
Refining regression tests to avoid future false failures

### DIFF
--- a/cypress/e2e/Services/Measure Service/DeleteTest-Case.cy.ts
+++ b/cypress/e2e/Services/Measure Service/DeleteTest-Case.cy.ts
@@ -3,12 +3,7 @@ import { CreateMeasurePage } from "../../../Shared/CreateMeasurePage"
 import { TestCasesPage } from "../../../Shared/TestCasesPage"
 import { Utilities } from "../../../Shared/Utilities"
 import { Environment } from "../../../Shared/Environment"
-import { OktaLogin } from "../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
 import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
-import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
-import { Header } from "../../../Shared/Header"
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 
 let measureSharingAPIKey = Environment.credentials().measureSharing_API_Key
@@ -41,9 +36,14 @@ describe('Delete test Case: Older end point / url that takes id and title in the
     })
 
     it('Delete test Case - Success scenario - Old end point', () => {
-
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
                     cy.request({
                         url: '/api/measures/' + measureId + '/test-cases/' + testCaseId,
@@ -70,9 +70,10 @@ describe('Delete test Case: Older end point / url that takes id and title in the
         cy.clearLocalStorage()
         //set local user that does not own the measure
         cy.setAccessTokenCookieALT()
-
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
                     cy.request({
                         failOnStatusCode: false,
@@ -87,7 +88,7 @@ describe('Delete test Case: Older end point / url that takes id and title in the
                         }
                     }).then((response) => {
                         expect(response.status).to.eql(403)
-                        expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ' + measureId)
+                        expect(response.body.message).to.include('User ' + harpUser + ' is not authorized for Measure with ID ' + measureId)
                     })
                 })
             })
@@ -97,14 +98,15 @@ describe('Delete test Case: Older end point / url that takes id and title in the
 describe('Delete test Case: Newer end point / url that takes an list array of test case ids', () => {
 
     beforeEach('Create Measure, Group, Test Case and set access token', () => {
-
+        cy.clearCookies()
+        cy.clearLocalStorage()
         cy.setAccessTokenCookie()
         //Create Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests, false)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
         //Create Test case
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'a', testCaseDescription + ' a', testCaseSeries + 'a', testCaseJson, false, false)
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'b', testCaseDescription + ' b', testCaseSeries + 'b', testCaseJson, false, true)
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'a', testCaseDescription + ' a', testCaseSeries + 'a', testCaseJson, false, false, false)
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'b', testCaseDescription + ' b', testCaseSeries + 'b', testCaseJson, false, true, false)
 
     })
 
@@ -115,10 +117,16 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
     })
 
     it('Delete test Case - Success scenario - New Delete End Point', () => {
-
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
+                    cy.wait(1000)
                     cy.readFile('cypress/fixtures/testCaseId2').should('exist').then((testCaseId2) => {
                         cy.request({
                             url: '/api/measures/' + measureId + '/test-cases',
@@ -142,6 +150,7 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
 
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
                     cy.request({
                         failOnStatusCode: false,
@@ -159,6 +168,7 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
         })
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testcaseId2').should('exist').then((testCaseId2) => {
                     cy.request({
                         failOnStatusCode: false,
@@ -182,10 +192,12 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
         cy.clearLocalStorage()
         //set local user that does not own the measure
         cy.setAccessTokenCookieALT()
-
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
+                    cy.wait(1000)
                     cy.readFile('cypress/fixtures/testCaseId2').should('exist').then((testCaseId2) => {
                         cy.request({
                             failOnStatusCode: false,
@@ -201,7 +213,7 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
 
                         }).then((response) => {
                             expect(response.status).to.eql(403)
-                            expect(response.body.message).contains('User ' + harpUser + ' is not authorized for Measure with ID ')
+                            expect(response.body.message).to.include('User ' + harpUser + ' is not authorized for Measure with ID ')
                         })
                     })
                 })
@@ -213,6 +225,7 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
         cy.clearLocalStorage()
         //Share Measure with ALT User
         cy.setAccessTokenCookie()
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
                 cy.request({
@@ -233,10 +246,12 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
         cy.clearLocalStorage()
         //set local user that does not own the measure
         cy.setAccessTokenCookieALT()
-
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
+                cy.wait(1000)
                 cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
+                    cy.wait(1000)
                     cy.readFile('cypress/fixtures/testCaseId2').should('exist').then((testCaseId2) => {
                         cy.request({
                             url: '/api/measures/' + measureId + '/test-cases',
@@ -258,6 +273,7 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
             })
             cy.getCookie('accessToken').then((accessToken) => {
                 cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.wait(1000)
                     cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
                         cy.request({
                             failOnStatusCode: false,
@@ -275,6 +291,7 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
             })
             cy.getCookie('accessToken').then((accessToken) => {
                 cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    cy.wait(1000)
                     cy.readFile('cypress/fixtures/testcaseId2').should('exist').then((testCaseId2) => {
                         cy.request({
                             failOnStatusCode: false,
@@ -292,7 +309,4 @@ describe('Delete test Case: Newer end point / url that takes an list array of te
             })
         })
     })
-
-
-
 })

--- a/cypress/e2e/Services/Measure Service/MeasureVersion.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureVersion.cy.ts
@@ -94,7 +94,7 @@ describe('Measure Versioning', () => {
                         method: 'PUT'
                     }).then((response) => {
                         expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.0.000')
+                        expect(response.body.version).to.include('1.0.000')
                     })
                 })
             })
@@ -114,7 +114,7 @@ describe('Measure Versioning', () => {
                     method: 'PUT'
                 }).then((response) => {
                     expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ' + measureId2)
+                    expect(response.body.message).to.include('User ' + harpUser + ' is not authorized for Measure with ID ' + measureId2)
                 })
             })
         })
@@ -151,7 +151,7 @@ describe('Version Measure without CQL', () => {
                     method: 'PUT'
                 }).then((response) => {
                     expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has no CQL.')
+                    expect(response.body.message).to.include('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has no CQL.')
                 })
             })
         })
@@ -193,7 +193,7 @@ describe('Version Measure with invalid CQL', () => {
                 console.log(response)
                 expect(response.status).to.eql(201)
                 expect(response.body.id).to.be.exist
-                expect(response.body.errors[0]).to.eql('ERRORS_ELM_JSON')
+                expect(response.body.errors[0]).to.include('ERRORS_ELM_JSON')
 
                 cy.writeFile('cypress/fixtures/measureId', response.body.id)
                 cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
@@ -221,7 +221,7 @@ describe('Version Measure with invalid CQL', () => {
                     method: 'PUT'
                 }).then((response) => {
                     expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has CQL errors.')
+                    expect(response.body.message).to.include('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has CQL errors.')
                 })
             })
         })
@@ -253,7 +253,7 @@ describe('Version Measure with invalid test case Json', () => {
                     method: 'PUT'
                 }).then((response) => {
                     expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql('1.0.000')
+                    expect(response.body.version).to.include('1.0.000')
                 })
             })
         })
@@ -274,6 +274,9 @@ describe('Edit validations for versioned Measure', () => {
 
     beforeEach('Set Access Token', () => {
 
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
         cy.setAccessTokenCookie()
     })
 
@@ -283,6 +286,7 @@ describe('Edit validations for versioned Measure', () => {
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
                 cy.readFile('cypress/fixtures/versionId').should('exist').then((vId) => {
+                    cy.wait(1000)
                     cy.request({
                         url: '/api/measures/' + measureId + '/version?versionType=major',
                         headers: {
@@ -295,6 +299,7 @@ describe('Edit validations for versioned Measure', () => {
                     })
 
                     cy.log('Verify error message on editing Measure details')
+                    cy.wait(1000)
                     cy.request({
                         failOnStatusCode: false,
                         url: '/api/measures/' + measureId,
@@ -317,10 +322,11 @@ describe('Edit validations for versioned Measure', () => {
                         }
                     }).then((response) => {
                         expect(response.status).to.eql(409)
-                        expect(response.body.message).to.eql('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
+                        expect(response.body.message).to.include('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
                     })
 
                     cy.log('Verify error message on editing Measure group')
+                    cy.wait(1000)
                     cy.request({
                         failOnStatusCode: false,
                         url: '/api/measures/' + measureId + '/groups',
@@ -360,11 +366,12 @@ describe('Edit validations for versioned Measure', () => {
                         }
                     }).then((response) => {
                         expect(response.status).to.eql(409)
-                        expect(response.body.message).to.eql('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
+                        expect(response.body.message).to.include('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
                     })
 
                     cy.log('Verify error message on editing Test case')
                     cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testcaseid) => {
+                        cy.wait(1000)
                         cy.request({
                             failOnStatusCode: false,
                             url: '/api/measures/' + measureId + '/test-cases/' + testcaseid,
@@ -382,7 +389,7 @@ describe('Edit validations for versioned Measure', () => {
                             }
                         }).then((response) => {
                             expect(response.status).to.eql(409)
-                            expect(response.body.message).to.eql('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
+                            expect(response.body.message).to.include('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
                         })
                     })
                 })
@@ -405,6 +412,9 @@ describe('Delete validations for versioned Measure', () => {
 
     beforeEach('Set Access Token', () => {
 
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
         cy.setAccessTokenCookie()
     })
 
@@ -414,6 +424,7 @@ describe('Delete validations for versioned Measure', () => {
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
                 cy.readFile('cypress/fixtures/versionId').should('exist').then((vId) => {
+                    cy.wait(1000)
                     cy.request({
                         url: '/api/measures/' + measureId + '/version?versionType=major',
                         headers: {
@@ -422,10 +433,11 @@ describe('Delete validations for versioned Measure', () => {
                         method: 'PUT'
                     }).then((response) => {
                         expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.0.000')
+                        expect(response.body.version).to.include('1.0.000')
                     })
 
                     cy.log('Verify error message on delete Measure')
+                    cy.wait(1000)
                     cy.request({
                         failOnStatusCode: false,
                         url: '/api/measures/' + measureId,
@@ -448,11 +460,12 @@ describe('Delete validations for versioned Measure', () => {
                         }
                     }).then((response) => {
                         expect(response.status).to.eql(409)
-                        expect(response.body.message).to.eql('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
+                        expect(response.body.message).to.include('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
                     })
 
                     cy.log('Verify error message on delete Measure group')
                     cy.readFile('cypress/fixtures/groupId').should('exist').then((groupId) => {
+                        cy.wait(1000)
                         cy.request({
                             failOnStatusCode: false,
                             url: '/api/measures/' + measureId + '/groups/' + groupId,
@@ -486,12 +499,13 @@ describe('Delete validations for versioned Measure', () => {
                             }
                         }).then((response) => {
                             expect(response.status).to.eql(409)
-                            expect(response.body.message).to.eql('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
+                            expect(response.body.message).to.include('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
                         })
                     })
 
                     cy.log('Verify error message on delete Test case')
                     cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testcaseid) => {
+                        cy.wait(1000)
                         cy.request({
                             failOnStatusCode: false,
                             url: '/api/measures/' + measureId + '/test-cases/' + testcaseid,
@@ -505,7 +519,7 @@ describe('Delete validations for versioned Measure', () => {
                             }
                         }).then((response) => {
                             expect(response.status).to.eql(409)
-                            expect(response.body.message).to.eql('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
+                            expect(response.body.message).to.include('Response could not be completed for measure with ID ' + measureId + ', since the measure is not in a draft status')
                         })
                     })
                 })


### PR DESCRIPTION
Refining and beefing up some of the lines of automation code in the DeleteTest-Case.cy.ts and MeasureVersion.cy.ts service level test files, to avoid false failures in the future.