### PR TITLE
Regression test failure fixes and other timing issue fixes

### DIFF
--- a/cypress/Shared/OktaLogin.ts
+++ b/cypress/Shared/OktaLogin.ts
@@ -1,7 +1,7 @@
-import {Header} from "./Header"
-import {Environment} from "./Environment"
-import {LandingPage} from "./LandingPage"
-import {umlsLoginForm} from "./umlsLoginForm"
+import { Header } from "./Header"
+import { Environment } from "./Environment"
+import { LandingPage } from "./LandingPage"
+import { umlsLoginForm } from "./umlsLoginForm"
 
 //MADiE OKTA Login Class
 export class OktaLogin {
@@ -18,29 +18,27 @@ export class OktaLogin {
 
         cy.visit('/login', { onBeforeLoad: (win) => { win.sessionStorage.clear() } })
 
-        cy.get(this.usernameInput, { timeout: 100000 }).should('be.enabled')
-        cy.get(this.usernameInput, { timeout: 100000 }).should('be.visible')
-        cy.get(this.passwordInput, { timeout: 100000 }).should('be.enabled')
-        cy.get(this.passwordInput, { timeout: 100000 }).should('be.visible')
-
+        cy.get(this.usernameInput, { timeout: 110000 }).should('be.enabled')
+        cy.get(this.usernameInput, { timeout: 110000 }).should('be.visible')
+        cy.get(this.passwordInput, { timeout: 110000 }).should('be.enabled')
+        cy.get(this.passwordInput, { timeout: 110000 }).should('be.visible')
+        cy.wait(3000)
         cy.get(this.usernameInput).type(Environment.credentials().harpUserALT)
         cy.get(this.passwordInput).type(Environment.credentials().passwordALT)
-        cy.get(this.signInButton, { timeout: 100000 }).should('be.enabled')
-        cy.get(this.signInButton, { timeout: 100000 }).should('be.visible')
+        cy.get(this.signInButton, { timeout: 110000 }).should('be.enabled')
+        cy.get(this.signInButton, { timeout: 110000 }).should('be.visible')
 
         //setup for grabbing the measure create call
         cy.intercept('GET', '/api/vsac/umls-credentials/status').as('umls')
 
         cy.get(this.signInButton).click()
 
-        cy.wait('@umls', { timeout: 60000}).then(({response}) => {
+        cy.wait('@umls', { timeout: 110000 }).then(({ response }) => {
 
-            if(response.statusCode === 200)
-            {
+            if (response.statusCode === 200) {
                 //do nothing
             }
-            else
-            {
+            else {
                 umlsLoginForm.UMLSLogin()
             }
 
@@ -58,29 +56,27 @@ export class OktaLogin {
 
         cy.visit('/login', { onBeforeLoad: (win) => { win.sessionStorage.clear() } })
 
-        cy.get(this.usernameInput, { timeout: 100000 }).should('be.enabled')
-        cy.get(this.usernameInput, { timeout: 100000 }).should('be.visible')
-        cy.get(this.passwordInput, { timeout: 100000 }).should('be.enabled')
-        cy.get(this.passwordInput, { timeout: 100000 }).should('be.visible')
-        cy.wait(1000)
+        cy.get(this.usernameInput, { timeout: 110000 }).should('be.enabled')
+        cy.get(this.usernameInput, { timeout: 110000 }).should('be.visible')
+        cy.get(this.passwordInput, { timeout: 110000 }).should('be.enabled')
+        cy.get(this.passwordInput, { timeout: 110000 }).should('be.visible')
+        cy.wait(3000)
         cy.get(this.usernameInput).type(Environment.credentials().harpUser)
         cy.get(this.passwordInput).type(Environment.credentials().password)
-        cy.get(this.signInButton, { timeout: 100000 }).should('be.enabled')
-        cy.get(this.signInButton, { timeout: 100000 }).should('be.visible')
+        cy.get(this.signInButton, { timeout: 110000 }).should('be.enabled')
+        cy.get(this.signInButton, { timeout: 110000 }).should('be.visible')
 
         //setup for grabbing the measure create call
         cy.intercept('GET', '/api/vsac/umls-credentials/status').as('umls')
 
         cy.get(this.signInButton).click()
 
-        cy.wait('@umls', { timeout: 60000}).then(({response}) => {
+        cy.wait('@umls', { timeout: 110000 }).then(({ response }) => {
 
-            if(response.statusCode === 200)
-            {
+            if (response.statusCode === 200) {
                 //do nothing
             }
-            else
-            {
+            else {
                 umlsLoginForm.UMLSLogin()
             }
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
@@ -1,8 +1,8 @@
 import { Environment } from "../../../../Shared/Environment"
 import { OktaLogin } from "../../../../Shared/OktaLogin"
-import {Header} from "../../../../Shared/Header"
-import {CQLLibraryPage} from "../../../../Shared/CQLLibraryPage"
-import {CQLLibrariesPage} from "../../../../Shared/CQLLibrariesPage"
+import { Header } from "../../../../Shared/Header"
+import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
+import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 
 let CQLLibraryName = 'TestLibrary' + Date.now()
 let newCQLLibraryName = ''
@@ -22,6 +22,10 @@ describe('CQL Library Transfer', () => {
         newCQLLibraryName = CQLLibraryName + randValue + randValue + 1
 
         CQLLibraryPage.createCQLLibraryAPI(newCQLLibraryName, CQLLibraryPublisher)
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
     })
 
     afterEach('LogOut', () => {
@@ -31,6 +35,11 @@ describe('CQL Library Transfer', () => {
 
 
     it('Verify transferred CQL Library is viewable under My Libraries tab', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
+        cy.wait(1000)
 
         //Share Measure with ALT User
         cy.getCookie('accessToken').then((accessToken) => {
@@ -63,6 +72,11 @@ describe('CQL Library Transfer', () => {
     it('Verify CQL Library can be edited by the transferred user', () => {
 
         //Share Measure with ALT User
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
                 cy.request({
@@ -102,6 +116,10 @@ describe('CQL Library Transfer - Multiple instances', () => {
         newCQLLibraryName = CQLLibraryName + randValue + randValue + 5
 
         CQLLibraryPage.createAPICQLLibraryWithValidCQL(newCQLLibraryName, CQLLibraryPublisher)
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
         OktaLogin.Login()
     })
 
@@ -143,7 +161,11 @@ describe('CQL Library Transfer - Multiple instances', () => {
         cy.log('Draft Created Successfully')
 
         //Share Measure with ALT User
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
         cy.setAccessTokenCookie()
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
                 cy.request({

--- a/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
@@ -10,7 +10,7 @@ import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import {Header} from "../../../../Shared/Header"
+import { Header } from "../../../../Shared/Header";
 
 let measureName = 'TestMeasure' + Date.now()
 let cqlLibraryName = 'TestCql' + Date.now()
@@ -147,7 +147,11 @@ describe('Measure Sharing - Multiple instances', () => {
 
     beforeEach('Create Measure and Set Access Token', () => {
 
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
         cy.setAccessTokenCookie()
+        cy.wait(1000)
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
         OktaLogin.Login()
@@ -185,7 +189,11 @@ describe('Measure Sharing - Multiple instances', () => {
         cy.log('Draft Created Successfully')
 
         //Share Measure with ALT User
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
         cy.setAccessTokenCookie()
+        cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
                 cy.request({
@@ -219,7 +227,11 @@ describe('Delete Test Case with Shared user', () => {
 
     beforeEach('Create Measure and Set Access Token', () => {
 
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
         cy.setAccessTokenCookie()
+        cy.wait(1000)
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -232,6 +244,11 @@ describe('Delete Test Case with Shared user', () => {
     })
 
     it('Verify Test Case can be deleted by the shared user', () => {
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        //set local user that does not own the measure
+        cy.setAccessTokenCookie()
+        cy.wait(1000)
 
         //Share Measure with ALT User
         cy.getCookie('accessToken').then((accessToken) => {

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMEditMeasureOwnershipValidation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMEditMeasureOwnershipValidation.cy.ts
@@ -40,11 +40,11 @@ describe('Measure Ownership Validations for QDM Measures', () => {
     it('Fields on Population criteria page are not editable by Non Measure Owner', () => {
 
         //navigate to the all measures tab
-        Utilities.waitForElementVisible(LandingPage.allMeasuresTab, 30000)
-        cy.get(LandingPage.allMeasuresTab).should('be.visible')
-        Utilities.waitForElementEnabled(LandingPage.allMeasuresTab, 30000)
-        cy.get(LandingPage.allMeasuresTab).should('be.enabled')
-        cy.get(LandingPage.allMeasuresTab).wait(5000).click()
+        Utilities.waitForElementVisible(LandingPage.allMeasuresTab, 70000)
+        cy.get(LandingPage.allMeasuresTab).should('be.visible').wait(1000)
+        Utilities.waitForElementEnabled(LandingPage.allMeasuresTab, 70000)
+        cy.get(LandingPage.allMeasuresTab).should('be.enabled').wait(1000)
+        cy.get(LandingPage.allMeasuresTab).wait(7000).click()
 
         //click on Edit button to edit measure
         MeasuresPage.measureAction("edit")

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/BaseConfigurationValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/BaseConfigurationValidations.cy.ts
@@ -329,16 +329,16 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
             .should('be.checked')
     })
     //non-owner of measure cannot edit Base Configuration fields
-    it('Non-owner of measure cannot edit any of the the Base Configuration fields', () => {
+    it.only('Non-owner of measure cannot edit any of the the Base Configuration fields', () => {
         //navigate to the main measures page
         cy.get(Header.measures).click()
 
         //click on the "All Measures" tab
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 30000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
-        Utilities.waitForElementEnabled(MeasuresPage.allMeasuresTab, 30000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.enabled')
-        cy.get(MeasuresPage.allMeasuresTab).wait(5000).click()
+        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 70000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(1000)
+        Utilities.waitForElementEnabled(MeasuresPage.allMeasuresTab, 70000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.enabled').wait(1000)
+        cy.get(MeasuresPage.allMeasuresTab).wait(10000).click()
         MeasuresPage.measureAction("edit", true)
 
         //Click on Measure Group tab


### PR DESCRIPTION
Resolved timing and other issues that were causing some recent regression run test failures. Additionally, made other updates to the CQLLibraryTransfer and MeasureSharing test files to, hopefully, prevent these test files from giving us false-failure results.