### PR TITLE
Versioning Smoke Test Failure Fix

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -195,12 +195,12 @@ export class CreateMeasurePage {
                 expect(response.body.id).to.be.exist
                 if (twoMeasures === true) {
                     cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
                 }
                 else {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
                 }
 
@@ -284,12 +284,12 @@ export class CreateMeasurePage {
                 expect(response.body.id).to.be.exist
                 if (twoMeasures === true) {
                     cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
                 }
                 else {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
                 }
 
@@ -373,12 +373,12 @@ export class CreateMeasurePage {
                 expect(response.body.id).to.be.exist
                 if (twoMeasures === true) {
                     cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
                 }
                 else {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
                 }
 
@@ -464,12 +464,12 @@ export class CreateMeasurePage {
                 expect(response.body.id).to.be.exist
                 if (twoMeasures === true) {
                     cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
                 }
                 else {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
+                    //cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
                     cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
                 }
 

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -448,6 +448,8 @@ export class MeasureGroupPage {
                         },
                         "measureGroupTypes": [
                             "Outcome"
+                        ],
+                        "stratifications": [
                         ]
                     }
                 }).then((response) => {
@@ -529,6 +531,8 @@ export class MeasureGroupPage {
                         ],
                         "measureGroupTypes": [
                             "Outcome"
+                        ],
+                        "stratifications": [
                         ]
                     }
                 }).then((response) => {
@@ -588,6 +592,8 @@ export class MeasureGroupPage {
                         ],
                         "measureGroupTypes": [
                             "Outcome"
+                        ],
+                        "stratifications": [
                         ]
                     }
                 }).then((response) => {

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
@@ -194,7 +194,7 @@ let measureCQL = 'library T771 version \'0.0.000\'\n' +
     '                     or Diagnosis.verificationStatus ~ QICoreCommon."entered-in-error" )\n' +
     '    ) is not null'
 
-describe.skip('FHIR Measure Export for Proportion Patient Measure with QI-Core Profile types', () => {
+describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profile types', () => {
 
     deleteDownloadsFolderBeforeAll()
 
@@ -202,10 +202,11 @@ describe.skip('FHIR Measure Export for Proportion Patient Measure with QI-Core P
 
         //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
+
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)


### PR DESCRIPTION
Updated utility functions that we use in our automated tests to contain an empty stratification array, when there is no need to have stratification on the PC or Group, on a given measure.