### PR TITLE
MAT-6146 Update non-unique test name warning message when importing test cases

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -282,6 +282,7 @@ export class TestCasesPage {
     public static readonly importTestCaseCancelBtnOnModal = '[data-testid="test-case-import-cancel-btn"]'
     public static readonly importTestCaseSuccessMessage = '[data-testid="population-criteria-success"]'
     public static readonly importTestCaseAlertMessage = '[class="madie-alert warning"]'
+    public static readonly importTestCaseDetailedAlertMessage = '[class="StatusHandler___StyledSpan-sc-1tujbo9-0 dBOLeU"]'
     public static readonly importTestCaseBtn = '[data-testid=import-test-case-btn]'
     public static readonly testCaseFileImport = '[data-testid=import-file-input]'
     public static readonly testCasesNonBonnieFileImportModal = '[data-testid="test-case-import-content-div"]'

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -723,7 +723,7 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         //verifies alert message at top of page informing user that no test case was imported
         Utilities.waitForElementVisible(TestCasesPage.importTestCaseAlertMessage, 35000)
         cy.get(TestCasesPage.importTestCaseAlertMessage).find('[id="content"]').should('contain.text', '(1) test case(s) were imported. The following (1) test case(s) could not be imported. Please ensure that your formatting is correct and try again.')
-        cy.get(TestCasesPage.importTestCaseAlertMessage).find('[id="content"]').should('contain.text', 'Reason : The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
+        cy.get(TestCasesPage.importTestCaseDetailedAlertMessage).should('contain.text', 'Reason : The Family and Given combination on the Patient resource in the Test Case JSON is already used in another test case on this measure.  The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
     })
 
 })

--- a/cypress/e2e/WebInterface/Test Cases/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Validations/TestCaseValidations.cy.ts
@@ -993,6 +993,5 @@ describe('Duplicate Test Case Title and Group validations', () => {
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.confirmationMsg).should('contain.text', 'The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
-
     })
 })


### PR DESCRIPTION
Updated current automated regression tests to account for updated messaging around duplicated family and group name on test case import and group and title on test case creation and editing.