### PR TITLE
Regression Failure fixes around library page loading

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -3,6 +3,7 @@ import { Environment } from "./Environment"
 import { Utilities } from "./Utilities"
 import { v4 as uuidv4 } from 'uuid'
 
+
 export class CQLLibraryPage {
     public static readonly cqlLibrarySuccessfulDeleteMsgBox = '[data-testid="cql-library-list-snackBar"]'
     public static readonly cqlLibraryDeleteDialogContinueBtn = '[data-testid="delete-dialog-continue-button"]'

--- a/cypress/e2e/WebInterface/CQL Library/CQLLibrarySearch.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQLLibrarySearch.cy.ts
@@ -2,6 +2,7 @@ import { OktaLogin } from "../../../Shared/OktaLogin"
 import { Header } from "../../../Shared/Header"
 import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
+import { Utilities } from "../../../Shared/Utilities"
 
 var CQLLibraryName = ""
 let CQLLibraryPublisher = 'ICFer'
@@ -26,9 +27,9 @@ describe('CQL Library Search Validations', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
@@ -57,9 +58,9 @@ describe('CQL Library Search Validations', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
@@ -86,9 +87,9 @@ describe('CQL Library Search Validations', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
@@ -135,9 +136,9 @@ describe('CQL Library Search Validations', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
@@ -192,9 +193,9 @@ describe('CQL Library Search Validations -- User ownership', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')
@@ -242,9 +243,9 @@ describe('CQL Library Search Validations -- User ownership', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')

--- a/cypress/e2e/WebInterface/CQL Library/CreateCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CreateCQLLibraryValidations.cy.ts
@@ -29,12 +29,9 @@ describe('CQL Library Validations', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')
@@ -82,11 +79,9 @@ describe('CQL Library Validations', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')
@@ -131,11 +126,9 @@ describe('CQL Library Validations', () => {
     it('CQL Library Name Validations', () => {
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')
@@ -197,11 +190,9 @@ describe('CQL Library Validations', () => {
         //Verify error message for empty CQL Library Model
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')
@@ -224,11 +215,9 @@ describe('CQL Library Validations', () => {
         //navigate to the CQL Library page and create new CQL Library
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')
@@ -254,11 +243,9 @@ describe('CQL Library Validations', () => {
         //navigate to the CQL Library page and create new CQL Library
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')
@@ -286,11 +273,9 @@ describe('CQL Library Validations', () => {
         //navigate to the CQL Library page and create new CQL Library
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
-
         cy.get(Header.cqlLibraryTab).click()
 
-        cy.wait('@libraries', { timeout: 60000 })
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.createCQLLibraryBtn).should('be.enabled')

--- a/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
@@ -2,6 +2,7 @@ import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { OktaLogin } from "../../../Shared/OktaLogin"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 import { Header } from "../../../Shared/Header"
+import { Utilities } from "../../../Shared/Utilities"
 
 let CQLLibraryName = 'TestLibrary' + Date.now()
 let newCQLLibraryName = ''
@@ -162,9 +163,9 @@ describe('CQL Library Validations -- User ownership', () => {
         //navigate to the main CQL Library list page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.intercept('GET', '/api/cql-libraries?currentUser=true').as('libraries')
         cy.get(Header.cqlLibraryTab).click()
-        cy.wait('@libraries', { timeout: 60000 })
+
+        Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
 
         //ensure we are on the My Libraries tab
         cy.get(CQLLibraryPage.myLibrariesBtn).should('exist')


### PR DESCRIPTION
Updated some tests around CQL Library page to validate / confirm that the page has loaded another way than what was used to avoid test failures.