### PR TITLE
MAT6159 and additional QDM Test Case test fixes

### DIFF
--- a/cypress/Shared/Global.ts
+++ b/cypress/Shared/Global.ts
@@ -37,7 +37,7 @@ export class Global {
 
         cy.get(this.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
         cy.get(this.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
-        cy.get(this.keepWorkingCancel).click()
+        cy.get(this.discardChangesContinue).click()
     }
 
 }

--- a/cypress/Shared/MeasureCQL.ts
+++ b/cypress/Shared/MeasureCQL.ts
@@ -559,6 +559,134 @@ export class MeasureCQL {
         '      FirstResult: FirstLab.result as Quantity,\n' +
         '      Timing: FirstLab.resultDatetime\n' +
         '    }'
+    public static readonly QDMTestCaseCQLNonVsacValueset = 'library CohortListQDMPositiveEncounterPerformedWithStratification1686773356032 version \'0.0.000\'\n' +
+
+        'using QDM version \'5.6\'\n' +
+        '\n' +
+        'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n' +
+        '\n' +
+        'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\' \n' +
+        '\n' +
+        'valueset "Acute care hospital Inpatient Encounter": \'urn:oid:2.16.840.1.113883.3.666.5.2283\' \n' +
+        'valueset "Bicarbonate lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.139\' \n' +
+        'valueset "Body temperature": \'urn:oid:2.16.840.1.113762.1.4.1045.152\' \n' +
+        'valueset "Body weight": \'urn:oid:2.16.840.1.113762.1.4.1045.159\' \n' +
+        'valueset "Creatinine lab test": \'urn:oid:2.16.840.1.113883.3.666.5.2363\' \n' +
+        'valueset "Emergency Department Visit": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.292\' \n' +
+        'valueset "Encounter Inpatient": \'urn:oid:2.16.840.1.113883.3.666.5.307\' \n' +
+        'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\' \n' +
+        'valueset "Glucose lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.134\' \n' +
+        'valueset "Heart Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.149\' \n' +
+        'valueset "Hematocrit lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.114\' \n' +
+        'valueset "Medicare Advantage payer": \'urn:oid:2.16.840.1.113762.1.4.1104.12\' \n' +
+        'valueset "Medicare FFS payer": \'urn:oid:2.16.840.1.113762.1.4.1104.10\' \n' +
+        'valueset "Observation Services": \'urn:oid:2.16.840.1.113762.1.4.1111.143\' \n' +
+        'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\' \n' +
+        'valueset "Oxygen Saturation by Pulse Oximetry": \'urn:oid:2.16.840.1.113762.1.4.1045.151\' \n' +
+        'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\' \n' +
+        '\n' +
+        'valueset "Potassium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.117\' \n' +
+        'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
+        'valueset "Respiratory Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.130\' \n' +
+        'valueset "Sodium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.119\' \n' +
+        'valueset "Systolic Blood Pressure": \'urn:oid:2.16.840.1.113762.1.4.1045.163\' \n' +
+        'valueset "White blood cells count lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.129\' \n' +
+        '\n' +
+        'code "Birth date": \'21112-8\' from "LOINC" display \'Birth date\'\n' +
+        '\n' +
+        'parameter "Measurement Period" Interval<DateTime>\n' +
+        '\n' +
+        'context Patient\n' +
+        '\n' +
+        'define "Denominator":\n' +
+        '\t  "Initial Population"\n' +
+        '\n' +
+        'define "Initial Population":\n' +
+        '\t  "Inpatient Encounters"\n' +
+        '\n' +
+        'define "Numerator":\n' +
+        '\t  "Initial Population"\n' +
+        '\n' +
+        'define "SDE Ethnicity":\n' +
+        '\t  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
+        '\n' +
+        'define "SDE Payer":\n' +
+        '\t  ["Patient Characteristic Payer": "Payer"]\n' +
+        '\n' +
+        'define "SDE Race":\n' +
+        '\t  ["Patient Characteristic Race": "Race"]\n' +
+        '\n' +
+        'define "SDE Sex":\n' +
+        '\t  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n' +
+        '\n' +
+        'define "SDE Results":\n' +
+        '  {\n' +
+        '  // First physical exams\n' +
+        '    FirstHeartRate: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Heart Rate"]),\n' +
+        '    FirstSystolicBloodPressure: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Systolic Blood Pressure"]),\n' +
+        '    FirstRespiratoryRate: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Respiratory Rate"]),\n' +
+        '    FirstBodyTemperature: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Body temperature"]),\n' +
+        '    FirstOxygenSaturation: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Oxygen Saturation by Pulse Oximetry"]),\n' +
+        '  // Weight uses lab test timing\n' +
+        '    FirstBodyWeight: "FirstPhysicalExamWithEncounterIdUsingLabTiming"(["Physical Exam, Performed": "Body weight"]),\n' +
+        '\n' +
+        '  // First lab tests\n' +
+        '    FirstHematocritLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Hematocrit lab test"]),\n' +
+        '    FirstWhiteBloodCellCount: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "White blood cells count lab test"]),\n' +
+        '    FirstPotassiumLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Potassium lab test"]),\n' +
+        '    FirstSodiumLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Sodium lab test"]),\n' +
+        '    FirstBicarbonateLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Bicarbonate lab test"]),\n' +
+        '    FirstCreatinineLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Creatinine lab test"]),\n' +
+        '    FirstGlucoseLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Glucose lab test"])\n' +
+        '  }\n' +
+        '\n' +
+        'define "Inpatient Encounters":\n' +
+        '  ["Encounter, Performed": "Encounter Inpatient"] InpatientEncounter\n' +
+        '    with ( ["Patient Characteristic Payer": "Medicare FFS payer"]\n' +
+        '      union ["Patient Characteristic Payer": "Medicare Advantage payer"] ) Payer\n' +
+        '      such that Global."HospitalizationWithObservationLengthofStay" ( InpatientEncounter ) < 365\n' +
+        '        and InpatientEncounter.relevantPeriod ends during day of "Measurement Period"\n' +
+        '        and AgeInYearsAt(date from start of InpatientEncounter.relevantPeriod)>= 65\n' +
+        '\n' +
+        'define function "LengthOfStay"(Stay Interval<DateTime> ):\n' +
+        '  difference in days between start of Stay and \n' +
+        '  end of Stay\n' +
+        '\n' +
+        'define function "FirstPhysicalExamWithEncounterId"(ExamList List<QDM.PositivePhysicalExamPerformed> ):\n' +
+        '  "Inpatient Encounters" Encounter\n' +
+        '    let FirstExam: First(ExamList Exam\n' +
+        '        where Global."EarliestOf"(Exam.relevantDatetime, Exam.relevantPeriod)during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 120 minutes]\n' +
+        '        sort by Global."EarliestOf"(relevantDatetime, relevantPeriod)\n' +
+        '    )\n' +
+        '    return {\n' +
+        '      EncounterId: Encounter.id,\n' +
+        '      FirstResult: FirstExam.result as Quantity,\n' +
+        '      Timing: Global."EarliestOf" ( FirstExam.relevantDatetime, FirstExam.relevantPeriod )\n' +
+        '    }\n' +
+        '\n' +
+        'define function "FirstPhysicalExamWithEncounterIdUsingLabTiming"(ExamList List<QDM.PositivePhysicalExamPerformed> ):\n' +
+        '  "Inpatient Encounters" Encounter\n' +
+        '    let FirstExamWithLabTiming: First(ExamList Exam\n' +
+        '        where Global."EarliestOf"(Exam.relevantDatetime, Exam.relevantPeriod)during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 1440 minutes]\n' +
+        '        sort by Global."EarliestOf"(relevantDatetime, relevantPeriod)\n' +
+        '    )\n' +
+        '    return {\n' +
+        '      EncounterId: Encounter.id,\n' +
+        '      FirstResult: FirstExamWithLabTiming.result as Quantity,\n' +
+        '      Timing: Global."EarliestOf" ( FirstExamWithLabTiming.relevantDatetime, FirstExamWithLabTiming.relevantPeriod )\n' +
+        '    }\n' +
+        '\n' +
+        'define function "FirstLabTestWithEncounterId"(LabList List<QDM.PositiveLaboratoryTestPerformed> ):\n' +
+        '  "Inpatient Encounters" Encounter\n' +
+        '    let FirstLab: First(LabList Lab\n' +
+        '        where Lab.resultDatetime during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 1440 minutes]\n' +
+        '        sort by resultDatetime\n' +
+        '    )\n' +
+        '    return {\n' +
+        '      EncounterId: Encounter.id,\n' +
+        '      FirstResult: FirstLab.result as Quantity,\n' +
+        '      Timing: FirstLab.resultDatetime\n' +
+        '    }'
 
     public static readonly QDMCQL4MAT5645 = 'library TestingQDM version \'0.0.000\'\n' +
         'using QDM version \'5.6\'\n' +
@@ -1391,6 +1519,234 @@ export class MeasureCQL {
 
         'define "track1":\n' +
         ' true\n'
+
+    public static readonly CQLQDMObservationRun = 'library RatioListQDMPositiveEncounterPerformedWithMO1697030589521 version \'0.0.000\'\n' +
+
+        'using QDM version \'5.6\'\n' +
+
+        'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n' +
+        'valueset "birth date": \'urn:oid:2.16.840.1.113883.3.560.100.4\' \n' +
+
+        'valueset "Diabetes": \'urn:oid:2.16.840.1.113883.3.464.1003.103.12.1001\' \n' +
+        'valueset "Encounter Inpatient": \'urn:oid:2.16.840.1.113883.3.666.5.307\' \n' +
+        'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\' \n' +
+        'valueset "Glucose Lab Test Mass Per Volume": \'urn:oid:2.16.840.1.113762.1.4.1248.34\' \n' +
+        'valueset "Hypoglycemics Treatment Medications": \'urn:oid:2.16.840.1.113762.1.4.1196.394\' \n' +
+        'valueset "Ketoacidosis": \'urn:oid:2.16.840.1.113762.1.4.1222.520\' \n' +
+        'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\' \n' +
+        'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\' \n' +
+        'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\' \n' +
+
+
+        'parameter "Measurement Period" Interval<DateTime>\n' +
+        'context Patient\n' +
+
+        'define "Days in Hospitalization":\n' +
+
+        '  "Measurement Population" EligibleInpatientHospitalization\n' +
+        '    let period: Global."HospitalizationWithObservation" ( EligibleInpatientHospitalization ),\n' +
+        '    relevantPeriod: "Hospital Days Max 10"(period)\n' +
+        '    return Tuple {\n' +
+        '      encounter: EligibleInpatientHospitalization,\n' +
+        '      hospitalizationPeriod: period,\n' +
+        '      relevantPeriod: relevantPeriod,\n' +
+        '      relevantDays: "Days In Period"(relevantPeriod)\n' +
+        '    }\n' +
+
+        'define "Days with Glucose Results":\n' +
+        '  "Days in Hospitalization" InpatientHospitalDays\n' +
+        '    return Tuple {\n' +
+        '      encounter: InpatientHospitalDays.encounter,\n' +
+        '      relevantPeriod: InpatientHospitalDays.relevantPeriod,\n' +
+        '      relevantDays: ( InpatientHospitalDays.relevantDays EncounterDay\n' +
+        '          return Tuple {\n' +
+        '            dayNumber: EncounterDay.dayNumber,\n' +
+        '            dayPeriod: EncounterDay.dayPeriod,\n' +
+        '            hasSevereResult: exists ( ["Laboratory Test, Performed": "Glucose Lab Test Mass Per Volume"] GlucoseTest\n' +
+        '                where GlucoseTest.result > 300 \'mg/dL\'\n' +
+        '                  and Global."EarliestOf" ( GlucoseTest.relevantDatetime, GlucoseTest.relevantPeriod ) during EncounterDay.dayPeriod\n' +
+        '            ),\n' +
+        '            hasElevatedResult: exists ( ["Laboratory Test, Performed": "Glucose Lab Test Mass Per Volume"] GlucoseTest\n' +
+        '                where GlucoseTest.result >= 200 \'mg/dL\'\n' +
+        '                  and Global."EarliestOf" ( GlucoseTest.relevantDatetime, GlucoseTest.relevantPeriod ) during EncounterDay.dayPeriod\n' +
+        '            ),\n' +
+        '            hasNoGlucoseTest: not exists ( ["Laboratory Test, Performed": "Glucose Lab Test Mass Per Volume"] GlucoseTest\n' +
+        '                where Global."EarliestOf" ( GlucoseTest.relevantDatetime, GlucoseTest.relevantPeriod ) during EncounterDay.dayPeriod\n' +
+        '            )\n' +
+        '          }\n' +
+        '      )\n' +
+        '    }\n' +
+
+        'define "Days with Hyperglycemic Events":\n' +
+        '  "Days with Glucose Results" EncounterWithResultDays\n' +
+        '    let eligibleEventDays: EncounterWithResultDays.relevantDays EncounterDay\n' +
+        '      where EncounterDay.dayNumber > 1\n' +
+        '      return Tuple {\n' +
+        '        dayNumber: EncounterDay.dayNumber,\n' +
+        '        dayPeriod: EncounterDay.dayPeriod,\n' +
+        '        hasHyperglycemicEvent: ( EncounterDay.hasSevereResult\n' +
+        '            or ( EncounterDay.hasNoGlucoseTest\n' +
+        '                and EncounterWithResultDays.relevantDays[EncounterDay.dayNumber - 2].hasElevatedResult\n' +
+        '                and EncounterWithResultDays.relevantDays[EncounterDay.dayNumber - 3].hasElevatedResult\n' +
+        '            )\n' +
+        '        )\n' +
+        '      }\n' +
+        '    return Tuple {\n' +
+        '      encounter: EncounterWithResultDays.encounter,\n' +
+        '      relevantPeriod: EncounterWithResultDays.relevantPeriod,\n' +
+        '      eligibleEventDays: eligibleEventDays\n' +
+        '    }\n' +
+
+        'define "Denominator":\n' +
+        '  "Initial Population"\n' +
+
+        'define "Denominator Exclusions":\n' +
+        '  "Encounter with First Glucose Greater Than or Equal to 1000"\n' +
+
+        'define "Encounter with Elevated Glucose Greater Than or Equal to 200":\n' +
+        '  "Encounter with Hospitalization Period" Hospitalization\n' +
+        '    with ["Laboratory Test, Performed": "Glucose Lab Test Mass Per Volume"] GlucoseTest\n' +
+        '      such that Global."EarliestOf" ( GlucoseTest.relevantDatetime, GlucoseTest.relevantPeriod ) during Hospitalization.hospitalizationPeriod\n' +
+        '        and GlucoseTest.result >= 200 \'mg/dL\'\n' +
+        '    return Hospitalization.encounter\n' +
+
+        'define "Encounter with Existing Diabetes Diagnosis":\n' +
+        '  "Encounter with Hospitalization Period" Hospitalization\n' +
+        '    with ["Diagnosis": "Diabetes"] DiabetesCondition\n' +
+        '      such that DiabetesCondition.prevalencePeriod starts before \n' +
+        '      end of Hospitalization.hospitalizationPeriod\n' +
+        '    return Hospitalization.encounter\n' +
+
+        'define "Encounter with Hospitalization Period":\n' +
+        '  "Qualifying Encounter" QualifyingHospitalization\n' +
+        '    return Tuple {\n' +
+        '      encounter: QualifyingHospitalization,\n' +
+        '      hospitalizationPeriod: Global."HospitalizationWithObservation" ( QualifyingHospitalization )\n' +
+        '    }\n' +
+
+        'define "Encounter with Hyperglycemic Events":\n' +
+        '  "Days with Hyperglycemic Events" HyperglycemicEventDays\n' +
+        '    where exists ( HyperglycemicEventDays.eligibleEventDays EligibleEventDay\n' +
+        '        where EligibleEventDay.hasHyperglycemicEvent\n' +
+        '    )\n' +
+        '    return HyperglycemicEventDays.encounter\n' +
+
+        'define "Encounter with Hypoglycemic Medication":\n' +
+        '  "Encounter with Hospitalization Period" Hospitalization\n' +
+        '    with ["Medication, Administered": "Hypoglycemics Treatment Medications"] HypoglycemicMedication\n' +
+        '      such that Global."NormalizeInterval" ( HypoglycemicMedication.relevantDatetime, HypoglycemicMedication.relevantPeriod ) starts during Hospitalization.hospitalizationPeriod\n' +
+        '    return Hospitalization.encounter\n' +
+
+        'define "Initial Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start":\n' +
+        '  "Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start" GlucoseResult1000\n' +
+        '    where not ( GlucoseResult1000.id in "Glucose Tests Earlier Than Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start".id )\n' +
+
+        'define "Initial Population":\n' +
+        '  "Encounter with Existing Diabetes Diagnosis"\n' +
+        '    union "Encounter with Hypoglycemic Medication"\n' +
+        '    union "Encounter with Elevated Glucose Greater Than or Equal to 200"\n' +
+
+        'define "Measurement Population":\n' +
+        '  "Denominator"\n' +
+
+        'define "Numerator":\n' +
+        '  "Encounter with Hyperglycemic Events"\n' +
+
+        'define "Qualifying Encounter":\n' +
+        '  ["Encounter, Performed": "Encounter Inpatient"] InpatientEncounter\n' +
+        '    where InpatientEncounter.relevantPeriod ends during day of "Measurement Period"\n' +
+        '      and AgeInYearsAt(date from start of InpatientEncounter.relevantPeriod)>= 18\n' +
+
+        'define "SDE Ethnicity":\n' +
+        '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
+
+        'define "SDE Payer":\n' +
+        '  ["Patient Characteristic Payer": "Payer"]\n' +
+
+        'define "SDE Race":\n' +
+        '  ["Patient Characteristic Race": "Race"]\n' +
+
+        'define "SDE Sex":\n' +
+        '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n' +
+
+        'define "Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start":\n' +
+        '  from\n' +
+        '    "Initial Population" InpatientHospitalization,\n' +
+        '    ["Laboratory Test, Performed": "Glucose Lab Test Mass Per Volume"] GlucoseTest\n' +
+        '    let HospitalizationInterval: Global."HospitalizationWithObservation" ( InpatientHospitalization ),\n' +
+        '    GlucoseTestTime: Global."EarliestOf" ( GlucoseTest.relevantDatetime, GlucoseTest.relevantPeriod )\n' +
+        '    where GlucoseTest.result >= 1000 \'mg/dL\'\n' +
+        '      and GlucoseTest.result is not null\n' +
+        '      and GlucoseTestTime during Interval[( start of HospitalizationInterval - 1 hour ), ( start of HospitalizationInterval + 6 hours )]\n' +
+        '    return GlucoseTest\n' +
+
+        'define "Encounter with First Glucose Greater Than or Equal to 1000":\n' +
+        '  "Initial Population" InpatientHospitalization\n' +
+        '    with "Initial Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start" FirstGlucoseResult\n' +
+        '      such that FirstGlucoseResult.result is not null\n' +
+        '        and FirstGlucoseResult.result >= 1000 \'mg/dL\'\n' +
+        '        and Global."EarliestOf" ( FirstGlucoseResult.relevantDatetime, FirstGlucoseResult.relevantPeriod ) during Interval[( start of Global."HospitalizationWithObservation" ( InpatientHospitalization ) - 1 hour ), ( start of Global."HospitalizationWithObservation" ( InpatientHospitalization ) + 6 hours )]\n' +
+        '    return InpatientHospitalization\n' +
+
+        'define "Glucose Tests Earlier Than Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start":\n' +
+        '  from\n' +
+        '    "Initial Population" InpatientHospitalization,\n' +
+        '    "Glucose Greater Than or Equal to 1000 within 1 Hour Prior To and 6 Hours After Encounter Start" GlucoseResult1000,\n' +
+        '    ["Laboratory Test, Performed": "Glucose Lab Test Mass Per Volume"] EarlierGlucoseTest\n' +
+        '    let HospitalizationInterval: Global."HospitalizationWithObservation" ( InpatientHospitalization ),\n' +
+        '    GlucoseTest1000Time: Global."EarliestOf" ( GlucoseResult1000.relevantDatetime, GlucoseResult1000.relevantPeriod ),\n' +
+        '    EarlierGlucoseTestTime: Global."EarliestOf" ( EarlierGlucoseTest.relevantDatetime, EarlierGlucoseTest.relevantPeriod )\n' +
+        '    where GlucoseTest1000Time during Interval[( start of HospitalizationInterval - 1 hour ), ( start of HospitalizationInterval + 6 hour )]\n' +
+        '      and EarlierGlucoseTestTime during Interval[( start of HospitalizationInterval - 1 hour ), GlucoseTest1000Time )\n' +
+        '      and EarlierGlucoseTest is not null\n' +
+        '      and EarlierGlucoseTest.id !~ GlucoseResult1000.id\n' +
+        '    return GlucoseResult1000\n' +
+
+        'define function "Interval To Day Numbers"(Period Interval<DateTime> ):\n' +
+        '  ( expand { Interval[1, days between start of Period and \n' +
+        '  end of Period]} ) DayExpand\n' +
+        '    return \n' +
+        '    end of DayExpand\n' +
+
+        'define function "Hospital Days Max 10"(Period Interval<DateTime> ):\n' +
+        '  Interval[start of Period, Min({ \n' +
+        '    end of Period, start of Period + 10 days }\n' +
+        '  )]\n' +
+
+        'define function "Days In Period"(Period Interval<DateTime> ):\n' +
+        '  ( "Interval To Day Numbers"(Period)) DayNumber\n' +
+        '    let startPeriod: start of Period + ( 24 hours * ( DayNumber - 1 ) ),\n' +
+        '    endPeriod: if ( hours between startPeriod and \n' +
+        '      end of Period < 24\n' +
+        '    ) then startPeriod \n' +
+        '      else start of Period + ( 24 hours * DayNumber )\n' +
+        '    return Tuple {\n' +
+        '      dayNumber: DayNumber,\n' +
+        '      dayPeriod: Interval[startPeriod, endPeriod )\n' +
+        '    }\n' +
+
+        'define function "Denominator Observations"(QualifyingEncounter "Encounter, Performed" ):\n' +
+        '  if QualifyingEncounter.id in "Denominator Exclusions".id then singleton from ( "Days with Hyperglycemic Events" EncounterWithEventDays\n' +
+        '      where EncounterWithEventDays.encounter = QualifyingEncounter\n' +
+        '      return 0\n' +
+        '  ) \n' +
+        '    else singleton from ( "Days with Hyperglycemic Events" EncounterWithEventDays\n' +
+        '      where EncounterWithEventDays.encounter = QualifyingEncounter\n' +
+        '      return Count(EncounterWithEventDays.eligibleEventDays)\n' +
+        '  )\n' +
+
+        'define function "Numerator Observations"(QualifyingEncounter "Encounter, Performed" ):\n' +
+        '  if QualifyingEncounter.id in "Denominator Exclusions".id then singleton from ( "Days with Hyperglycemic Events" EncounterWithEventDays\n' +
+        '      where EncounterWithEventDays.encounter = QualifyingEncounter\n' +
+        '      return 0\n' +
+        '  ) \n' +
+        '    else singleton from ( "Days with Hyperglycemic Events" EncounterWithEventDays\n' +
+        '      where EncounterWithEventDays.encounter = QualifyingEncounter\n' +
+        '      return Count(EncounterWithEventDays.eligibleEventDays EligibleEventDay\n' +
+        '          where EligibleEventDay.hasHyperglycemicEvent\n' +
+        '      )\n' +
+        '  )'
+
     public static readonly CQLHLResults_value = 'library BugQICoreMeasure version \'0.0.000\'\n' +
 
         'using QICore version \'4.1.1\'\n' +

--- a/cypress/Shared/TestCaseJson.ts
+++ b/cypress/Shared/TestCaseJson.ts
@@ -437,6 +437,215 @@ export class TestCaseJson {
 
     public static readonly QDMTestCaseJson = '{\"qdmVersion\":\"5.6\",\"dataElements\":[{\"dataElementCodes\":[{\"code\":\"2186-5\",\"system\":\"2.16.840.1.113883.6.238\",\"version\":\"1.2\",\"display\":\"Not Hispanic or Latino\"}],\"_id\":\"648c85f4220ca7000054646c\",\"qdmTitle\":\"Patient Characteristic Ethnicity\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.56\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"ethnicity\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicEthnicity\",\"id\":\"648c85f4220ca7000054646c\"},{\"dataElementCodes\":[],\"_id\":\"648c7dcd220ca70000546465\",\"qdmTitle\":\"Patient Characteristic Birthdate\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.54\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"birthdate\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicBirthdate\",\"id\":\"648c7dcd220ca70000546465\",\"birthDatetime\":\"2020-01-01T16:35:39.000+00:00\"},{\"dataElementCodes\":[{\"code\":\"M\",\"system\":\"2.16.840.1.113883.5.1\",\"version\":\"2022-11\",\"display\":\"Male\"}],\"_id\":\"648c7d60220ca70000546449\",\"qdmTitle\":\"Patient Characteristic Sex\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.55\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"gender\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicSex\",\"id\":\"648c7d60220ca70000546449\"},{\"dataElementCodes\":[{\"code\":\"2131-1\",\"system\":\"2.16.840.1.113883.6.238\",\"version\":\"1.2\",\"display\":\"Other Race\"}],\"_id\":\"648c7d24220ca70000546442\",\"qdmTitle\":\"Patient Characteristic Race\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.59\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"race\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicRace\",\"id\":\"648c7d24220ca70000546442\"},{\"dataElementCodes\":[],\"_id\":\"648c509863dbeb000033b3e0\",\"qdmTitle\":\"Patient Characteristic Expired\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.57\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"living\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicExpired\",\"id\":\"648c509863dbeb000033b3e0\"}],\"_id\":\"648c4dad63dbeb000033b36b\",\"birthDatetime\":\"1998-07-01T16:35:39.539+00:00\"}'
 
+    public static readonly QDMTCJsonwMOElements = '{\n' +
+        '    "qdmVersion": "5.6",\n' +
+        '    "dataElements": [\n' +
+        '      {\n' +
+        '        "dataElementCodes": [],\n' +
+        '        "_id": "6526a779c268b0000084a48f",\n' +
+        '        "qdmTitle": "Patient Characteristic Birthdate",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.54",\n' +
+        '        "qdmCategory": "patient_characteristic",\n' +
+        '        "qdmStatus": "birthdate",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::PatientCharacteristicBirthdate",\n' +
+        '        "id": "6526a779c268b0000084a48f",\n' +
+        '        "birthDatetime": "2003-07-31T12:00:37.000+00:00"\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "2131-1",\n' +
+        '            "system": "2.16.840.1.113883.6.238",\n' +
+        '           "version": "1.2",\n' +
+        '            "display": "Other Race"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526a785c268b0000084a496",\n' +
+        '        "qdmTitle": "Patient Characteristic Race",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.59",\n' +
+        '        "qdmCategory": "patient_characteristic",\n' +
+        '        "qdmStatus": "race",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::PatientCharacteristicRace",\n' +
+        '        "id": "6526a785c268b0000084a496"\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "M",\n' +
+        '            "system": "2.16.840.1.113883.5.1",\n' +
+        '            "version": "2022-11",\n' +
+        '            "display": "Male"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526a787c268b0000084a498",\n' +
+        '        "qdmTitle": "Patient Characteristic Sex",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.55",\n' +
+        '        "qdmCategory": "patient_characteristic",\n' +
+        '        "qdmStatus": "gender",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::PatientCharacteristicSex",\n' +
+        '        "id": "6526a787c268b0000084a498"\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "2186-5",\n' +
+        '            "system": "2.16.840.1.113883.6.238",\n' +
+        '            "version": "1.2",\n' +
+        '            "display": "Not Hispanic or Latino"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526a789c268b0000084a49a",\n' +
+        '        "qdmTitle": "Patient Characteristic Ethnicity",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.56",\n' +
+        '        "qdmCategory": "patient_characteristic",\n' +
+        '        "qdmStatus": "ethnicity",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::PatientCharacteristicEthnicity",\n' +
+        '        "id": "6526a789c268b0000084a49a"\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "46635009",\n' +
+        '            "system": "2.16.840.1.113883.6.96",\n' +
+        '            "version": null,\n' +
+        '            "display": "Diabetes mellitus type 1 (disorder)"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526a772c268b0000084a48b",\n' +
+        '        "recorder": [],\n' +
+        '        "qdmTitle": "Diagnosis",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.110",\n' +
+        '        "qrdaOid": "2.16.840.1.113883.10.20.24.3.135",\n' +
+        '        "qdmCategory": "condition",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::Diagnosis",\n' +
+        '        "description": "Diagnosis: Diabetes",\n' +
+        '        "codeListId": "2.16.840.1.113883.3.464.1003.103.12.1001",\n' +
+        '        "id": "6526a7f2c268b0000084a49c",\n' +
+        '        "prevalencePeriod": {\n' +
+        '          "low": "2023-07-09T12:00:00.000+00:00",\n' +
+        '          "lowClosed": true,\n' +
+        '          "highClosed": true\n' +
+        '        }\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [],\n' +
+        '        "_id": "6526ad93c268b0000084af2e",\n' +
+        '        "participant": [],\n' +
+        '        "relatedTo": [],\n' +
+        '        "qdmTitle": "Encounter, Performed",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.5",\n' +
+        '        "qdmCategory": "encounter",\n' +
+        '        "qdmStatus": "performed",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::EncounterPerformed",\n' +
+        '        "description": "Encounter, Performed: Encounter Inpatient",\n' +
+        '        "codeListId": "2.16.840.1.113883.3.666.5.307",\n' +
+        '        "id": "6526ada0c268b0000084b308",\n' +
+        '        "relevantPeriod": {\n' +
+        '          "low": "2023-07-11T12:00:00.000+00:00",\n' +
+        '          "high": "2023-07-15T13:00:00.000+00:00",\n' +
+        '          "lowClosed": true,\n' +
+        '          "highClosed": true\n' +
+        '        },\n' +
+        '        "facilityLocations": [],\n' +
+        '        "diagnoses": []\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "1556-0",\n' +
+        '            "system": "2.16.840.1.113883.6.1",\n' +
+        '            "version": null,\n' +
+        '            "display": "Fasting glucose [Mass/volume] in Capillary blood"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526ad93c268b0000084af38",\n' +
+        '        "performer": [],\n' +
+        '        "relatedTo": [],\n' +
+        '        "qdmTitle": "Laboratory Test, Performed",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.42",\n' +
+        '        "qdmCategory": "laboratory_test",\n' +
+        '        "qdmStatus": "performed",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::LaboratoryTestPerformed",\n' +
+        '        "description": "Laboratory Test, Performed: Glucose Lab Test Mass Per Volume",\n' +
+        '        "codeListId": "2.16.840.1.113762.1.4.1248.34",\n' +
+        '        "id": "6526afd6c268b0000084b35f",\n' +
+        '        "relevantDatetime": "2023-07-11T14:00:00.000+00:00",\n' +
+        '        "result": {\n' +
+        '          "value": "1000",\n' +
+        '          "unit": "mg/dL"\n' +
+        '        },\n' +
+        '        "components": []\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "183452005",\n' +
+        '            "system": "2.16.840.1.113883.6.96",\n' +
+        '            "version": null,\n' +
+        '            "display": "Emergency hospital admission (procedure)"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526ad93c268b0000084af2e",\n' +
+        '        "participant": [],\n' +
+        '        "relatedTo": [],\n' +
+        '        "qdmTitle": "Encounter, Performed",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.5",\n' +
+        '        "qdmCategory": "encounter",\n' +
+        '        "qdmStatus": "performed",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::EncounterPerformed",\n' +
+        '        "description": "Encounter, Performed: Encounter Inpatient",\n' +
+        '        "codeListId": "2.16.840.1.113883.3.666.5.307",\n' +
+        '        "id": "6526b107c268b0000084b3c2",\n' +
+        '        "relevantPeriod": {\n' +
+        '          "low": "2023-10-11T12:00:00.000+00:00",\n' +
+        '          "high": "2023-10-18T12:15:00.000+00:00",\n' +
+        '          "lowClosed": true,\n' +
+        '          "highClosed": true\n' +
+        '        },\n' +
+        '        "facilityLocations": [],\n' +
+        '        "diagnoses": []\n' +
+        '      },\n' +
+        '      {\n' +
+        '        "dataElementCodes": [\n' +
+        '          {\n' +
+        '            "code": "1556-0",\n' +
+        '            "system": "2.16.840.1.113883.6.1",\n' +
+        '            "version": null,\n' +
+        '            "display": "Fasting glucose [Mass/volume] in Capillary blood"\n' +
+        '          }\n' +
+        '        ],\n' +
+        '        "_id": "6526ad93c268b0000084af38",\n' +
+        '        "performer": [],\n' +
+        '        "relatedTo": [],\n' +
+        '        "qdmTitle": "Laboratory Test, Performed",\n' +
+        '        "hqmfOid": "2.16.840.1.113883.10.20.28.4.42",\n' +
+        '        "qdmCategory": "laboratory_test",\n' +
+        '        "qdmStatus": "performed",\n' +
+        '        "qdmVersion": "5.6",\n' +
+        '        "_type": "QDM::LaboratoryTestPerformed",\n' +
+        '        "description": "Laboratory Test, Performed: Glucose Lab Test Mass Per Volume",\n' +
+        '        "codeListId": "2.16.840.1.113762.1.4.1248.34",\n' +
+        '        "id": "6526b15dc268b0000084b45e",\n' +
+        '        "relevantDatetime": "2023-10-13T12:00:00.000+00:00",\n' +
+        '        "result": {\n' +
+        '          "value": "1100",\n' +
+        '          "unit": "mg/dL"\n' +
+        '        },\n' +
+        '        "components": []\n' +
+        '      }\n' +
+        '    ],\n' +
+        '    "_id": "6526a771c268b0000084a474",\n' +
+        '    "birthDatetime": "2003-07-31T12:00:37.561+00:00"\n' +
+        '  }'
+
     public static readonly QDMTestCaseJsonNoDOB = '{\"qdmVersion\":\"5.6\",\"dataElements\":[{\"dataElementCodes\":[{\"code\":\"2186-5\",\"system\":\"2.16.840.1.113883.6.238\",\"version\":\"1.2\",\"display\":\"Not Hispanic or Latino\"}],\"_id\":\"648c85f4220ca7000054646c\",\"qdmTitle\":\"Patient Characteristic Ethnicity\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.56\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"ethnicity\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicEthnicity\",\"id\":\"648c85f4220ca7000054646c\"},{\"dataElementCodes\":[],\"_id\":\"648c7dcd220ca70000546465\",\"qdmTitle\":\"Patient Characteristic Birthdate\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.54\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"birthdate\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicBirthdate\",\"id\":\"648c7dcd220ca70000546465\",\"birthDatetime\":\"2020-01-01T16:35:39.000+00:00\"},{\"dataElementCodes\":[{\"code\":\"M\",\"system\":\"2.16.840.1.113883.5.1\",\"version\":\"2022-11\",\"display\":\"Male\"}],\"_id\":\"648c7d60220ca70000546449\",\"qdmTitle\":\"Patient Characteristic Sex\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.55\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"gender\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicSex\",\"id\":\"648c7d60220ca70000546449\"},{\"dataElementCodes\":[{\"code\":\"2131-1\",\"system\":\"2.16.840.1.113883.6.238\",\"version\":\"1.2\",\"display\":\"Other Race\"}],\"_id\":\"648c7d24220ca70000546442\",\"qdmTitle\":\"Patient Characteristic Race\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.59\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"race\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicRace\",\"id\":\"648c7d24220ca70000546442\"},{\"dataElementCodes\":[],\"_id\":\"648c509863dbeb000033b3e0\",\"qdmTitle\":\"Patient Characteristic Expired\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.57\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"expired\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicExpired\",\"id\":\"648c509863dbeb000033b3e0\"}],\"_id\":\"648c4dad63dbeb000033b36b\"}'
 
     public static readonly QDMTestCaseJsonNullDOB = '{\"qdmVersion\":\"5.6\",\"dataElements\":[{\"dataElementCodes\":[{\"code\":\"2186-5\",\"system\":\"2.16.840.1.113883.6.238\",\"version\":\"1.2\",\"display\":\"Not Hispanic or Latino\"}],\"_id\":\"648c85f4220ca7000054646c\",\"qdmTitle\":\"Patient Characteristic Ethnicity\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.56\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"ethnicity\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicEthnicity\",\"id\":\"648c85f4220ca7000054646c\"},{\"dataElementCodes\":[],\"_id\":\"648c7dcd220ca70000546465\",\"qdmTitle\":\"Patient Characteristic Birthdate\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.54\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"birthdate\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicBirthdate\",\"id\":\"648c7dcd220ca70000546465\",\"birthDatetime\":\"2020-01-01T16:35:39.000+00:00\"},{\"dataElementCodes\":[{\"code\":\"M\",\"system\":\"2.16.840.1.113883.5.1\",\"version\":\"2022-11\",\"display\":\"Male\"}],\"_id\":\"648c7d60220ca70000546449\",\"qdmTitle\":\"Patient Characteristic Sex\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.55\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"gender\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicSex\",\"id\":\"648c7d60220ca70000546449\"},{\"dataElementCodes\":[{\"code\":\"2131-1\",\"system\":\"2.16.840.1.113883.6.238\",\"version\":\"1.2\",\"display\":\"Other Race\"}],\"_id\":\"648c7d24220ca70000546442\",\"qdmTitle\":\"Patient Characteristic Race\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.59\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"race\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicRace\",\"id\":\"648c7d24220ca70000546442\"},{\"dataElementCodes\":[],\"_id\":\"648c509863dbeb000033b3e0\",\"qdmTitle\":\"Patient Characteristic Expired\",\"hqmfOid\":\"2.16.840.1.113883.10.20.28.4.57\",\"qdmCategory\":\"patient_characteristic\",\"qdmStatus\":\"expired\",\"qdmVersion\":\"5.6\",\"_type\":\"QDM::PatientCharacteristicExpired\",\"id\":\"648c509863dbeb000033b3e0\"}],\"_id\":\"648c4dad63dbeb000033b36b\",\"birthDatetime\":\"\"}'

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -133,7 +133,7 @@ export class TestCasesPage {
     public static readonly tcJsonTab = '[data-testid=json-tab]'
 
     //QDM Test Case
-    public static readonly qdmCQLFailureErrorList = '[data-testid="generic-fail-text-list"]'
+    public static readonly qdmCQLFailureErrorList = '[data-testid="execution_context_loading_errors"]'
     public static readonly qdmTCJson = '[class="panel-content"]'
 
     //CQL area on Test Case page
@@ -322,7 +322,9 @@ export class TestCasesPage {
     public static readonly importNonBonnieTestCasesBtn = '[data-testid="import-test-cases-button"]'
 
     //QDM Test Case Elements Tab
-    public static readonly QDMElementsTab = '[data-testid=qdm-Elements-sub-heading]'
+
+
+    public static readonly QDMElementsTab = '[data-testid="elements-section"]'
 
     //QDM Test Case Attributes
     public static readonly laboratoryElement = '[data-testid=elements-tab-laboratory_test]'
@@ -469,7 +471,7 @@ export class TestCasesPage {
 
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(EditMeasurePage.testCasesTab).click().wait(3500)
         cy.get(this.newTestCaseButton).should('be.visible')
         cy.get(this.newTestCaseButton).should('be.enabled')
         cy.get(this.newTestCaseButton).click()

--- a/cypress/e2e/Services/QDM Measure Service/QDM Test-Cases.cy.ts
+++ b/cypress/e2e/Services/QDM Measure Service/QDM Test-Cases.cy.ts
@@ -32,8 +32,8 @@ let TCJsonNullDOB = TestCaseJson.QDMTestCaseJsonNullDOB
 let TCJsonDOBWrongFormat = TestCaseJson.QDMTestCaseJsonWrongFormat
 let TCJsonDOBInvalidDNE = TestCaseJson.QDMTestCaseJsonInvalidDNE
 let TCJsonDOBInvalidNLE = TestCaseJson.QDMTestCaseJsonInvalidNLE
-//Skipping until feature flag for QDM Test case is removed
-describe.skip('Test Case population values based on Measure Group population definitions', () => {
+
+describe('Test Case population values based on Measure Group population definitions', () => {
     beforeEach('Create Measure and measure group', () => {
 
         cy.setAccessTokenCookie()
@@ -88,109 +88,75 @@ describe.skip('Test Case population values based on Measure Group population def
         //create test case
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJson,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
-                    expect(response.body.series).to.eql(TCSeries)
-                    expect(response.body.title).to.eql(TCTitle)
-                    expect(response.body.description).to.eql(TCDescription)
-                    expect(response.body.json).to.be.exist
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
+                cy.readFile('cypress/fixtures/groupId').should('exist').then((groupIdFc) => {
+                    cy.request({
+                        url: '/api/measures/' + id + '/test-cases',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'POST',
+                        body: {
+                            "name": TCName,
+                            "title": TCTitle,
+                            "series": TCSeries,
+                            "description": TCDescription,
+                            "json": TCJson,
+                            "hapiOperationOutcome": {
+                                "code": 201,
+                                "message": null,
+                                "outcomeResponse": null
+                            },
+                            "groupPopulations": [{
+                                "groupId": groupIdFc,
+                                "scoring": measureScoring,
+                                "populationValues": [
+                                    {
+                                        "name": "initialPopulation",
+                                        "expected": false,
+                                        "actual": false
+                                    },
+                                    {
+                                        "name": "denominator",
+                                        "expected": false,
+                                        "actual": false
+                                    },
+                                    {
+                                        "name": "denominatorExclusion",
+                                        "expected": false,
+                                        "actual": false
+                                    },
+                                    {
+                                        "name": "denominatorException",
+                                        "expected": false,
+                                        "actual": false
+                                    },
+                                    {
+                                        "name": "numerator",
+                                        "expected": false,
+                                        "actual": false
+                                    },
+                                    {
+                                        "name": "numeratorExclusion",
+                                        "expected": false,
+                                        "actual": false
+                                    }
+
+                                ]
+                            }]
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.eql(201)
+                        expect(response.body.id).to.be.exist
+                        expect(response.body.series).to.eql(TCSeries)
+                        expect(response.body.title).to.eql(TCTitle)
+                        expect(response.body.description).to.eql(TCDescription)
+                        expect(response.body.json).to.be.exist
+                        cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
+                    })
                 })
             })
         })
         cy.setAccessTokenCookie()
-        //leaving this section of commented out code because we may need it later if, later on, 
-        //we have to associate a test case with a group before we can create the test case
-        //----------------------------------------------------//
-        /*         cy.getCookie('accessToken').then((accessToken) => {
-                    cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                        cy.readFile('cypress/fixtures/groupId').should('exist').then((groupIdFc) => {
-                            cy.request({
-                                url: '/api/measures/' + id + '/test-cases',
-                                headers: {
-                                    authorization: 'Bearer ' + accessToken.value
-                                },
-                                method: 'POST',
-                                body: {
-                                    "name": TCName,
-                                    "title": TCTitle,
-                                    "series": TCSeries,
-                                    "createdAt": "2022-05-05T18:14:37.791Z",
-                                    "createdBy": "SBXDV.bwelch",
-                                    "lastModifiedAt": "2022-05-05T18:14:37.791Z",
-                                    "lastModifiedBy": "SBXDV.bwelch",
-                                    "description": TCDescription,
-                                    "json": TCJson,
-                                    "hapiOperationOutcome": {
-                                        "code": 201,
-                                        "message": null,
-                                        "outcomeResponse": null
-                                    },
-                                    "groupPopulations": [{
-                                        "groupId": groupIdFc,
-                                        "scoring": measureScoring,
-                                        "populationValues": [
-                                            {
-                                                "name": "initialPopulation",
-                                                "expected": false,
-                                                "actual": false
-                                            },
-                                            {
-                                                "name": "denominator",
-                                                "expected": false,
-                                                "actual": false
-                                            },
-                                            {
-                                                "name": "denominatorExclusion",
-                                                "expected": false,
-                                                "actual": false
-                                            },
-                                            {
-                                                "name": "denominatorException",
-                                                "expected": false,
-                                                "actual": false
-                                            },
-                                            {
-                                                "name": "numerator",
-                                                "expected": false,
-                                                "actual": false
-                                            },
-                                            {
-                                                "name": "numeratorExclusion",
-                                                "expected": false,
-                                                "actual": false
-                                            }
-        
-                                        ]
-                                    }]
-                                }
-                            }).then((response) => {
-                                expect(response.status).to.eql(201)
-                                expect(response.body.id).to.be.exist
-                                expect(response.body.series).to.eql(TCSeries)
-                                expect(response.body.title).to.eql(TCTitle)
-                                expect(response.body.description).to.eql(TCDescription)
-                                expect(response.body.json).to.be.exist
-                                cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                            })
-                        })
-                    })
-                }) */
-        //---------------------------------------------------//
 
     })
     afterEach('Clean up', () => {
@@ -198,7 +164,7 @@ describe.skip('Test Case population values based on Measure Group population def
         Utilities.deleteMeasure(measureName, cqlLibraryName)
 
     })
-    it.skip('Test Case population value check boxes match that of the measure group definitons -- all are defined', () => {
+    it('Test Case population value check boxes match that of the measure group definitons -- all are defined', () => {
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
                 cy.readFile('cypress/fixtures/testcaseId').should('exist').then((testCaseId) => {
@@ -229,8 +195,8 @@ describe.skip('Test Case population values based on Measure Group population def
 
 
 })
-//Skipping until feature flag for QDM Test case is removed
-describe.skip('Measure Service: Test Case Endpoints: Create and Edit', () => {
+
+describe('Measure Service: Test Case Endpoints: Create and Edit', () => {
     let randValue = (Math.floor((Math.random() * 2000) + 3))
     let cqlLibraryNameDeux = cqlLibraryName + randValue + 2
     let newTCJson = TestCaseJson.QDMTestCaseJson_for_update
@@ -322,8 +288,8 @@ describe.skip('Measure Service: Test Case Endpoints: Create and Edit', () => {
     })
 
 })
-//Skipping until feature flag for QDM Test case is removed
-describe.skip('Measure Service: Test Case Endpoints: Validations', () => {
+
+describe('Measure Service: Test Case Endpoints: Validations', () => {
 
     before('Create Measure', () => {
 
@@ -476,8 +442,8 @@ describe.skip('Measure Service: Test Case Endpoints: Validations', () => {
         expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ' + measureId)
 */
 
-//Skipping until feature flag for QDM Test case is removed
-describe.skip('Measure Service: Test Case Endpoints: Attempt to edit when user is not owner', () => {
+
+describe('Measure Service: Test Case Endpoints: Attempt to edit when user is not owner', () => {
     let randValue = (Math.floor((Math.random() * 2000) + 3))
     let cqlLibraryNameDeux = cqlLibraryName + randValue + 2
     let newTCJson = TestCaseJson.QDMTestCaseJson_for_update
@@ -533,7 +499,7 @@ describe.skip('Measure Service: Test Case Endpoints: Attempt to edit when user i
         })
     })
 })
-describe.skip('Measure Service: Test Case Endpoint: User validation with test case import', () => {
+describe('Measure Service: Test Case Endpoint: User validation with test case import', () => {
     beforeEach('Create Measure and measure group', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
@@ -625,347 +591,6 @@ describe.skip('Measure Service: Test Case Endpoint: User validation with test ca
                     },]
                 }).then((response) => {
                     expect(response.status).to.eql(403)
-                })
-            })
-        })
-    })
-
-})
-//currently tests are failing -- more work is necessary for MAT-5642
-describe.skip('QDM Test Case: Create: Date of Birth field: Validations', () => {
-    beforeEach('Create Measure and measure group', () => {
-
-        cy.setAccessTokenCookie()
-
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, cqlLibraryName, measureScoring, true, booleanPatientBasisQDM_CQL, false, false)
-
-        OktaLogin.Login()
-        MeasuresPage.measureAction("edit")
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        OktaLogin.Logout()
-        cy.setAccessTokenCookie()
-    })
-    afterEach('Clean up', () => {
-
-        Utilities.deleteMeasure(measureName, cqlLibraryName)
-
-    })
-    it('QDM Test Case: Create: Date of Birth field: No date of birth included on test case', () => {
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJsonNoDOB,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Create: Date of Birth field: DOB is null', () => {
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJsonNullDOB,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Create: Date of Birth field: DOB formatted incorrectly', () => {
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJsonDOBWrongFormat,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Create: Date of Birth field: Not a valid date', () => {
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJsonDOBInvalidDNE,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Create: Date of Birth field: Not an actual leap year dob value', () => {
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJsonDOBInvalidNLE,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                })
-            })
-        })
-    })
-})
-//currently tests are failing -- more work is necessary for MAT-5642
-describe.skip('QDM Test Case: Update / Edit: Date of Birth field: Validations', () => {
-    beforeEach('Create Measure and measure group', () => {
-
-        cy.setAccessTokenCookie()
-
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, cqlLibraryName, measureScoring, true, booleanPatientBasisQDM_CQL, false, false)
-
-        OktaLogin.Login()
-        MeasuresPage.measureAction("edit")
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        OktaLogin.Logout()
-        cy.setAccessTokenCookie()
-
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName,
-                        "title": TCTitle,
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJson,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
-                    expect(response.body.series).to.eql(TCSeries)
-                    expect(response.body.title).to.eql(TCTitle)
-                    expect(response.body.description).to.eql(TCDescription)
-                    expect(response.body.json).to.be.exist
-                    cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                })
-            })
-        })
-        cy.setAccessTokenCookie()
-    })
-    afterEach('Clean up', () => {
-
-        Utilities.deleteMeasure(measureName, cqlLibraryName)
-
-    })
-    it('QDM Test Case: update / edit: Date of Birth field: No date of birth included on test case', () => {
-        //edit test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases' + + testCaseIdFc,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testCaseIdFc,
-                            "name": TCName,
-                            "title": TCTitle,
-                            "series": TCSeries,
-                            "description": TCDescription,
-                            "json": TCJsonNoDOB,
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(403)
-                        expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                        cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                    })
-                })
-            })
-        })
-    })
-    it('QDM Test Case: update / edit: Date of Birth field: DOB is null', () => {
-        //edit test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases' + + testCaseIdFc,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testCaseIdFc,
-                            "name": TCName,
-                            "title": TCTitle,
-                            "series": TCSeries,
-                            "description": TCDescription,
-                            "json": TCJsonNullDOB,
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(403)
-                        expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                        cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                    })
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Update / Edit: Date of Birth field: DOB formatted incorrectly', () => {
-        //edit test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases' + + testCaseIdFc,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testCaseIdFc,
-                            "name": TCName,
-                            "title": TCTitle,
-                            "series": TCSeries,
-                            "description": TCDescription,
-                            "json": TCJsonDOBWrongFormat,
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(403)
-                        expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                        cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                    })
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Update / Edit: Date of Birth field: Not a valid date', () => {
-        //edit test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases' + + testCaseIdFc,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testCaseIdFc,
-                            "name": TCName,
-                            "title": TCTitle,
-                            "series": TCSeries,
-                            "description": TCDescription,
-                            "json": TCJsonDOBInvalidDNE,
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(403)
-                        expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                        cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                    })
-                })
-            })
-        })
-    })
-    it('QDM Test Case: Update / Edit: Date of Birth field: Not an actual leap year dob value', () => {
-        //edit test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases' + + testCaseIdFc,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testCaseIdFc,
-                            "name": TCName,
-                            "title": TCTitle,
-                            "series": TCSeries,
-                            "description": TCDescription,
-                            "json": TCJsonDOBInvalidNLE,
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(403)
-                        expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ')
-                        cy.writeFile('cypress/fixtures/testcaseId', response.body.id)
-                    })
                 })
             })
         })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/DateTimeAttribute.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/DateTimeAttribute.cy.ts
@@ -1,12 +1,12 @@
-import {CreateMeasurePage} from "../../../../../Shared/CreateMeasurePage"
-import {OktaLogin} from "../../../../../Shared/OktaLogin"
-import {Utilities} from "../../../../../Shared/Utilities"
-import {MeasuresPage} from "../../../../../Shared/MeasuresPage"
-import {EditMeasurePage} from "../../../../../Shared/EditMeasurePage"
-import {TestCasesPage} from "../../../../../Shared/TestCasesPage"
-import {CQLEditorPage} from "../../../../../Shared/CQLEditorPage"
-import {Header} from "../../../../../Shared/Header"
-import {MeasureGroupPage} from "../../../../../Shared/MeasureGroupPage"
+import { CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../../../Shared/OktaLogin"
+import { Utilities } from "../../../../../Shared/Utilities"
+import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
+import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
+import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+import { Header } from "../../../../../Shared/Header"
+import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
@@ -94,8 +94,8 @@ let measureCQL = 'library Library5749 version \'0.0.000\'\n' +
     '      union ["Symptom": "Neurologic impairment"] //Symptom\n' +
     '      union ["Assessment, Performed": "Falls Screening"] //Assessment '
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Date Time Attribute', () => {
+
+describe('Date Time Attribute', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -156,7 +156,7 @@ describe.skip('Date Time Attribute', () => {
         cy.get(TestCasesPage.attributeType).click()
         cy.get('[data-testid=option-DateTime]').click() //Select DateTime from dropdown
         cy.get('[id="dateTime"]').eq(5).type('12/12/200011:30AM')
-        cy.get(TestCasesPage.plusIcon).click()
+        cy.get(TestCasesPage.addAttribute).click()
         cy.get(TestCasesPage.attributeChip).should('contain.text', 'Result: 12/12/2000 11:30 AM')
 
     })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/IntetrvalQuantityAttribute.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/IntetrvalQuantityAttribute.cy.ts
@@ -1,12 +1,12 @@
-import {CreateMeasurePage} from "../../../../../Shared/CreateMeasurePage"
-import {OktaLogin} from "../../../../../Shared/OktaLogin"
-import {Utilities} from "../../../../../Shared/Utilities"
-import {MeasuresPage} from "../../../../../Shared/MeasuresPage"
-import {EditMeasurePage} from "../../../../../Shared/EditMeasurePage"
-import {TestCasesPage} from "../../../../../Shared/TestCasesPage"
-import {CQLEditorPage} from "../../../../../Shared/CQLEditorPage"
-import {Header} from "../../../../../Shared/Header"
-import {MeasureGroupPage} from "../../../../../Shared/MeasureGroupPage"
+import { CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../../../Shared/OktaLogin"
+import { Utilities } from "../../../../../Shared/Utilities"
+import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
+import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
+import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+import { Header } from "../../../../../Shared/Header"
+import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
@@ -94,26 +94,26 @@ let measureCQL = 'library Library5749 version \'0.0.000\'\n' +
     '      union ["Symptom": "Neurologic impairment"] //Symptom\n' +
     '      union ["Assessment, Performed": "Falls Screening"] //Assessment '
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Quantity Attribute', () => {
 
-        beforeEach('Create measure and login', () => {
+describe('Quantity Attribute', () => {
 
-            //Create QDM Measure
-            CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureCQL)
-            OktaLogin.Login()
-            MeasuresPage.measureAction("edit")
-            cy.get(EditMeasurePage.cqlEditorTab).click()
-            cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-            cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-            //wait for alert / successful save message to appear
-            Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-            cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-            OktaLogin.Logout()
-            MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial Population', 'Initial Population', 'Initial Population')
-            OktaLogin.Login()
-        })
+    beforeEach('Create measure and login', () => {
+
+        //Create QDM Measure
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureCQL)
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.Logout()
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial Population', 'Initial Population', 'Initial Population')
+        OktaLogin.Login()
+    })
 
     afterEach('Logout and Clean up Measures', () => {
 
@@ -160,7 +160,7 @@ describe.skip('Quantity Attribute', () => {
         cy.get('[data-testid=quantity-value-input-high]').type('4')
         cy.get('[id="quantity-unit-dropdown-high"]').click()
         cy.get('#quantity-unit-dropdown-high-option-0').click() //Select unit as m meter
-        cy.get(TestCasesPage.plusIcon).click()
+        cy.get(TestCasesPage.addAttribute).click()
         cy.get(TestCasesPage.attributeChip).should('contain.text', 'Reference Range: 2 \'m\' - 4 \'m\'')
 
     })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/PractitionerAttribute.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/PractitionerAttribute.cy.ts
@@ -1,12 +1,12 @@
-import {CreateMeasurePage} from "../../../../../Shared/CreateMeasurePage"
-import {OktaLogin} from "../../../../../Shared/OktaLogin"
-import {Utilities} from "../../../../../Shared/Utilities"
-import {MeasuresPage} from "../../../../../Shared/MeasuresPage"
-import {EditMeasurePage} from "../../../../../Shared/EditMeasurePage"
-import {TestCasesPage} from "../../../../../Shared/TestCasesPage"
-import {CQLEditorPage} from "../../../../../Shared/CQLEditorPage"
-import {Header} from "../../../../../Shared/Header"
-import {MeasureGroupPage} from "../../../../../Shared/MeasureGroupPage"
+import { CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../../../Shared/OktaLogin"
+import { Utilities } from "../../../../../Shared/Utilities"
+import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
+import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
+import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+import { Header } from "../../../../../Shared/Header"
+import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
@@ -94,8 +94,8 @@ let measureCQL = 'library Library5749 version \'0.0.000\'\n' +
     '      union ["Symptom": "Neurologic impairment"] //Symptom\n' +
     '      union ["Assessment, Performed": "Falls Screening"] //Assessment '
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Practitioner Attribute', () => {
+
+describe('Practitioner Attribute', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -179,8 +179,8 @@ describe.skip('Practitioner Attribute', () => {
         cy.get('[data-testid="option-CDCREC"]').click()
         cy.get(TestCasesPage.codeSelector).eq(2).click()
         cy.get('[data-testid=option-2135-2]').click()//Select Hispanic or Latino
-        cy.get(TestCasesPage.plusIcon).click()
-        cy.get(TestCasesPage.attributeChip).should('contain.text', 'Performer: [Practitioner] Identifier: { Naming System: TestIdentifier, Value: TestValue }, Id: 3, Role: SNOMEDCT : 4525004, Specialty: SNOMEDCT : 183452005, Qualification: CDCREC : 2135-2')
+        cy.get(TestCasesPage.addAttribute).click()
+        cy.get(TestCasesPage.attributeChip).should('contain.text', 'Performer - Practitioner: Identifier: { Naming System: TestIdentifier, Value: TestValue }, Id: 3, Role: SNOMEDCT : 4525004, Specialty: SNOMEDCT : 183452005, Qualification: CDCREC : 2135-2')
 
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/QDMTestCaseAttributevalidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/QDMTestCaseAttributevalidations.cy.ts
@@ -1,12 +1,12 @@
-import {CreateMeasurePage} from "../../../../../Shared/CreateMeasurePage"
-import {OktaLogin} from "../../../../../Shared/OktaLogin"
-import {Utilities} from "../../../../../Shared/Utilities"
-import {MeasuresPage} from "../../../../../Shared/MeasuresPage"
-import {EditMeasurePage} from "../../../../../Shared/EditMeasurePage"
-import {TestCasesPage} from "../../../../../Shared/TestCasesPage"
-import {CQLEditorPage} from "../../../../../Shared/CQLEditorPage"
-import {Header} from "../../../../../Shared/Header"
-import {MeasureGroupPage} from "../../../../../Shared/MeasureGroupPage"
+import { CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../../../Shared/OktaLogin"
+import { Utilities } from "../../../../../Shared/Utilities"
+import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
+import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
+import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+import { Header } from "../../../../../Shared/Header"
+import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
@@ -94,8 +94,8 @@ let measureCQL = 'library Library5749 version \'0.0.000\'\n' +
     '      union ["Symptom": "Neurologic impairment"] //Symptom\n' +
     '      union ["Assessment, Performed": "Falls Screening"] //Assessment '
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Remove Test case attribute', () => {
+
+describe('Remove Test case attribute', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -160,7 +160,7 @@ describe.skip('Remove Test case attribute', () => {
         cy.get('[data-testid=quantity-value-input-high]').type('4')
         cy.get('[id="quantity-unit-dropdown-high"]').click()
         cy.get('#quantity-unit-dropdown-high-option-0').click() //Select unit as m meter
-        cy.get(TestCasesPage.plusIcon).click()
+        cy.get(TestCasesPage.addAttribute).click()
         cy.get(TestCasesPage.attributeChip).should('contain.text', 'Reference Range: 2 \'m\' - 4 \'m\'')
         //Verify added attribute on Elements page
         cy.get('tbody > tr > :nth-child(3)').should('contain.text', 'Reference Range - referenceRange 2 \'m\' - 4 \'m\'')
@@ -172,7 +172,7 @@ describe.skip('Remove Test case attribute', () => {
         cy.get('tbody > tr > :nth-child(3)').should('not.contain.text', 'Reference Range - referenceRange 2 \'m\' - 4 \'m\'')
 
         //Delete the attribute from Elements table
-        cy.get('[data-testid="elements-section"]').contains('View').click({force:true})
+        cy.get('[data-testid="elements-section"]').contains('View').click({ force: true })
         cy.get('[data-testid="popover-content"]').contains('Delete').click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click().wait(2000)
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/CreateUpdateQDMTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/CreateUpdateQDMTestCase.cy.ts
@@ -90,8 +90,8 @@ let measureCQLWithElements = 'library QDMTestLibrary1686087138930 version \'0.0.
     'define "SDE Sex":\n' +
     '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n'
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Create and Update QDM Test Case', () => {
+
+describe('Create and Update QDM Test Case', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -189,8 +189,7 @@ describe.skip('Create and Update QDM Test Case', () => {
     })
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Non Boolean Test case Expected Values', () => {
+describe('Non Boolean Test case Expected Values', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -238,7 +237,7 @@ describe.skip('Non Boolean Test case Expected Values', () => {
 })
 
 //Skipping until QDM Test Case feature flag is removed
-describe.skip('QDM element tabs', () => {
+describe('QDM element tabs', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -256,7 +255,7 @@ describe.skip('QDM element tabs', () => {
 
     })
 
-    it('Verify QDM Element tabs relevant to the Measure CQL', () => {
+    it.only('Verify QDM Element tabs relevant to the Measure CQL', () => {
 
         MeasuresPage.measureAction("edit")
 
@@ -270,6 +269,7 @@ describe.skip('QDM element tabs', () => {
         //Navigate to Edit Test Case page
         TestCasesPage.clickEditforCreatedTestCase()
 
+        cy.pause()
         cy.get(TestCasesPage.QDMElementsTab).scrollIntoView().should('contain', 'Adverse Event' && 'Allergy' && 'Assessment' && 'Care Experience')
 
         //Navigate to CQL Editor tab and verify the same Elements are present in the Measure CQL

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
@@ -8,14 +8,17 @@ import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
 import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
 import { Header } from "../../../../../Shared/Header"
+import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 
 let measureName = 'RatioListQDMPositiveEncounterPerformedWithMO' + Date.now()
+let measureCQL2RunObservations = MeasureCQL.CQLQDMObservationRun
 let CqlLibraryName = 'RatioListQDMPositiveEncounterPerformedWithMO' + Date.now()
 let scoringValue = 'Ratio'
 let testCaseTitle = 'Title for Auto Test'
 let testCaseDescription = 'DENOMFail' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let testCaseJson = TestCaseJson.QDMTestCaseJson
+let QDMTCJsonwMOElements = TestCaseJson.QDMTCJsonwMOElements
 let measureCQL = 'library HospitalHarmHyperglycemiainHospitalizedPatients version \'3.0.000\'\n' +
     '\n' +
     'using QDM version \'5.6\'\n' +
@@ -242,8 +245,8 @@ let measureCQL = 'library HospitalHarmHyperglycemiainHospitalizedPatients versio
     '      )\n' +
     '  )\n' +
     '\n'
-//skipping tests until feature flag is removed
-describe.skip('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', () => {
+
+describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', () => {
 
     beforeEach('Create Measure', () => {
 
@@ -270,8 +273,7 @@ describe.skip('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO
         Utilities.deleteMeasure(measureName, CqlLibraryName)
 
     })
-    //skipping becasue QDM Test Cases is not in production, yet -- waiting until featrue flag is removed
-    it.skip('Test Case expected / actual measure observation field aligns with what has been entered in the population criteria and other appropirate fields and sections', () => {
+    it('Test Case expected / actual measure observation field aligns with what has been entered in the population criteria and other appropirate fields and sections', () => {
 
         //navigate to the main measures page and edit the measure
         cy.get(Header.measures).click()
@@ -468,6 +470,109 @@ describe.skip('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO
         cy.get(TestCasesPage.numer0Observation).should('not.be.enabled')
         cy.get(TestCasesPage.numer1Observation).should('not.be.enabled')
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('not.be.enabled')
+
+    })
+})
+describe('QDM Measure: Test Case: with Observations: Expected / Actual results', () => {
+
+    beforeEach('Create Measure', () => {
+
+        //Create New Measure
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, scoringValue, false, measureCQL2RunObservations, false, false,
+            '2023-01-01', '2025-01-01')
+        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, QDMTCJsonwMOElements, false, false)
+        OktaLogin.Login()
+        //Click on Edit Measure
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully! ' +
+            'Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        OktaLogin.Logout()
+    })
+
+    afterEach('Clean up', () => {
+
+        OktaLogin.Logout()
+
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+
+    })
+    it('Test Case expected / actual measure observation field aligns with what has been entered in the population criteria and other appropirate fields and sections', () => {
+
+        //navigate to the main measures page and edit the measure
+        cy.get(Header.measures).click()
+        MeasuresPage.measureAction("edit")
+
+        //fill out group details
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+        cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
+        cy.get(MeasureGroupPage.initialPopulationSelect).click()
+        cy.get(MeasureGroupPage.measurePopulationOption).eq(14).click()
+        cy.get(MeasureGroupPage.denominatorSelect).click()
+        cy.get(MeasureGroupPage.measurePopulationOption).eq(4).click()
+        cy.get(MeasureGroupPage.addDenominatorObservationLink).click()
+        cy.get(MeasureGroupPage.denominatorObservation).click()
+        cy.get(MeasureGroupPage.measureObservationSelect).eq(3).click()
+        cy.get(MeasureGroupPage.denominatorAggregateFunction).click()
+        cy.get(MeasureGroupPage.aggregateFunctionDropdownList).eq(0).click()
+        cy.get(MeasureGroupPage.denominatorExclusionSelect).click()
+        cy.get(MeasureGroupPage.measurePopulationOption).eq(3).click()
+        cy.get(MeasureGroupPage.numeratorSelect).click()
+        cy.get(MeasureGroupPage.measurePopulationOption).eq(15).click()
+        cy.get(MeasureGroupPage.addNumeratorObservationLink).click()
+        cy.get(MeasureGroupPage.numeratorObservation).click()
+        cy.get(MeasureGroupPage.measureObservationSelect).eq(4).click()
+        cy.get(MeasureGroupPage.numeratorAggregateFunction).click()
+        cy.get(MeasureGroupPage.aggregateFunctionDropdownList).eq(5).click()
+
+        //save group details
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+
+        //confirm details were saved
+        //validation successful save message
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        //Navigate to Edit Test Case page
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //click on the Expected / Actual tab
+        cy.get(TestCasesPage.expectedOrActualTab).click()
+
+        //enter 1 for expected initial population
+        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
+
+        //enter 1 for the expected denominator to generate 1 observation field
+        cy.get(TestCasesPage.testCaseDENOMExpected).type('1')
+        cy.get(TestCasesPage.denom0Observation).should('be.visible')
+
+        //enter 1 for denominator observation field
+        cy.get(TestCasesPage.denom0Observation).clear().type('6')
+
+        //enter 1 for the expected numerator to generate 1 observation field
+        cy.get(TestCasesPage.testCaseNUMERExpected).type('1')
+        cy.get(TestCasesPage.numer0Observation).should('be.visible')
+
+        //enter 6 for the numerator observation field
+        cy.get(TestCasesPage.numer0Observation).clear().type('1')
+
+        //save test case
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        cy.get(TestCasesPage.importTestCaseSuccessMsg).should('contain.text', 'Test Case Updated Successfully')
+
+        cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).click()
+
+        cy.get(TestCasesPage.ippActualCheckBox).should('contain.value', '1')
+        cy.get(TestCasesPage.denomActualCheckBox).should('contain.value', '1')
+        cy.get(TestCasesPage.denominatorMeasureObservationActualValue).should('contain.value', '6')
+        cy.get(TestCasesPage.denomExclusionActualCheckBox).should('contain.value', '0')
+        cy.get(TestCasesPage.numActualCheckBox).should('contain.value', '1')
+        cy.get(TestCasesPage.numeratorMeasureObservationActualValue).should('contain.value', '1')
 
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMRunExecuteTC.cy.ts
@@ -18,7 +18,7 @@ let testCaseSeries = 'SBTestSeries'
 let measureCQL = MeasureCQL.QDMCQL4MAT5645
 
 //skipping these tests until user story MAT-5645 is fixed
-describe.skip('Run / Execute Test case and verify passing percentage and coverage', () => {
+describe('Run / Execute Test case and verify passing percentage and coverage', () => {
 
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
 
@@ -72,7 +72,7 @@ describe.skip('Run / Execute Test case and verify passing percentage and coverag
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click().wait(3000)
 
         //Click on Execute Test Case button on Edit Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -165,7 +165,9 @@ describe.skip('Run / Execute Test case and verify passing percentage and coverag
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click().wait(7000)
+
+        Utilities.waitForElementVisible(TestCasesPage.tcSaveSuccessMsg, 30000)
 
         //create a test case that will fail:
 
@@ -210,7 +212,9 @@ describe.skip('Run / Execute Test case and verify passing percentage and coverag
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).wait(7000).click()
+
+        Utilities.waitForElementVisible(TestCasesPage.tcSaveSuccessMsg, 30000)
 
         //Click on Execute Test Case button on Edit Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -288,7 +292,9 @@ describe.skip('Run / Execute Test case and verify passing percentage and coverag
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).wait(7000).click()
+
+        Utilities.waitForElementVisible(TestCasesPage.tcSaveSuccessMsg, 30000)
 
         cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
 
@@ -306,8 +312,8 @@ describe.skip('Run / Execute Test case and verify passing percentage and coverag
     })
 })
 
-//Skipping until feature flag is removed
-describe.skip('Run / Execute QDM Test Case button validations', () => {
+
+describe('Run / Execute QDM Test Case button validations', () => {
 
     beforeEach('Login and Create Measure', () => {
 
@@ -355,7 +361,7 @@ describe.skip('Run / Execute QDM Test Case button validations', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click().wait(3000)
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
@@ -370,7 +376,7 @@ describe.skip('Run / Execute QDM Test Case button validations', () => {
         //click on details tab
         cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
 
-        cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.disabled')
+
     })
 
     it('Run / Execute Test Case button is disabled  -- Missing group / population selections', () => {
@@ -431,7 +437,7 @@ describe.skip('Run / Execute QDM Test Case button validations', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click().wait(3000)
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
@@ -456,8 +462,7 @@ describe.skip('Run / Execute QDM Test Case button validations', () => {
     })
 })
 
-//Skipping until feature flag is removed
-describe.skip('Run / Execute Test case for multiple Population Criteria', () => {
+describe('Run / Execute Test case for multiple Population Criteria', () => {
 
     beforeEach('Create Measure, Measure group and login', () => {
 
@@ -519,12 +524,12 @@ describe.skip('Run / Execute Test case for multiple Population Criteria', () => 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).click()
         //save dob value
         cy.get(TestCasesPage.QDMTCSaveBtn).should('be.enabled')
-        cy.get(TestCasesPage.QDMTCSaveBtn).click()
+        cy.get(TestCasesPage.QDMTCSaveBtn).click().wait(3000)
 
         //Click on Execute Test Case button on Edit Test Case page
         cy.get(EditMeasurePage.testCasesTab).should('exist')
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).wait(3000).click()
+        cy.get(EditMeasurePage.testCasesTab).wait(7000).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('exist')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
@@ -540,8 +545,7 @@ describe.skip('Run / Execute Test case for multiple Population Criteria', () => 
     })
 })
 
-//Skipping until feature flag is removed
-describe.skip('Run / Execute Test Case by Non Measure Owner', () => {
+describe('Run / Execute Test Case by Non Measure Owner', () => {
 
     beforeEach('Create Measure, Measure group and Test case', () => {
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseCreation.cy.ts
@@ -133,8 +133,8 @@ let measureCQL = 'library BreastCancerScreening version \'12.0.000\'\n' +
     '\n' +
     'define "October 1 Two Years Prior to the Measurement Period":\n' +
     '  DateTime((year from start of "Measurement Period" - 2), 10, 1, 0, 0, 0, 0, 0)'
-//skipping these tests until the QDM test case flag is removed
-describe.skip('Validating the creation of QDM Test Case', () => {
+
+describe('Validating the creation of QDM Test Case', () => {
 
     beforeEach('Create Measure', () => {
 
@@ -188,8 +188,8 @@ describe.skip('Validating the creation of QDM Test Case', () => {
         })
     })
 })
-//skipping these tests until the QDM test case flag is removed
-describe.skip('Validating the Elements section on Test Cases', () => {
+
+describe('Validating the Elements section on Test Cases', () => {
     beforeEach('Create Measure', () => {
 
         //Create New Measure
@@ -273,7 +273,7 @@ describe.skip('Validating the Elements section on Test Cases', () => {
         cy.get(TestCasesPage.PhysicalExamBTCard).scrollIntoView().should('be.visible')
     })
 
-    it("Verify elements' subsections' edit cards", () => {
+    it.only("Verify elements' subsections' edit cards", () => {
         //Click on Edit Measure
         MeasuresPage.measureAction("edit")
 
@@ -318,7 +318,6 @@ describe.skip('Validating the Elements section on Test Cases', () => {
             .should('contain.text', 'Timing')
         cy.get(TestCasesPage.ExpandedOSSDetailCard).find(TestCasesPage.ExpandedOSSDetailCardTabCodes).should('exist')
         cy.get(TestCasesPage.ExpandedOSSDetailCard).find(TestCasesPage.ExpandedOSSDetailCardTabAttributes).should('exist')
-        cy.get(TestCasesPage.ExpandedOSSDetailCard).find(TestCasesPage.ExpandedOSSDetailCardTabNegationRationale).should('exist')
 
         //close the detail card
         //<span class="MuiTouchRipple-root css-w0pj6f"></span>
@@ -366,7 +365,7 @@ describe.skip('Validating the Elements section on Test Cases', () => {
         cy.get(TestCasesPage.PhysicalExamBTCard).scrollIntoView().should('be.visible')
     })
 })
-describe.skip('Run QDM Test Case ', () => {
+describe('Run QDM Test Case ', () => {
     beforeEach('Create Measure', () => {
 
         //Create New Measure
@@ -389,7 +388,7 @@ describe.skip('Run QDM Test Case ', () => {
         Utilities.deleteMeasure(measureName, CqlLibraryName)
 
     })
-    it('Run a simple QDM test case and verify message that indicates that test case was ran', () => {
+    it.only('Run a simple QDM test case and verify message that indicates that test case was ran', () => {
         //Click on Edit Measure
         MeasuresPage.measureAction("edit")
 
@@ -420,12 +419,5 @@ describe.skip('Run QDM Test Case ', () => {
         cy.get(TestCasesPage.QDMTCSaveBtn).click()
         cy.get(TestCasesPage.tcSaveSuccessMsg).should('contain.text', 'Test Case Updated Successfully')
 
-        //run test case from the Test Case List page
-        cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('be.enabled')
-        cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('be.visible')
-        cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).click()
-
-        //verify message that appears confirming the button works
-        cy.get(TestCasesPage.tcSaveSuccessMsg).should('contain.text', 'Calculation was successful, output is printed in the console')
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseImportViaFile.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseImportViaFile.cy.ts
@@ -24,7 +24,7 @@ let testCaseJsonTstSmallBatch03 = TestCaseJson.smallBatchTC4ImportId3
 let testCaseJsonTstSmallBatch04 = TestCaseJson.smallBatchTC4ImportId4
 let testCaseJsonTstSmallBatch05 = TestCaseJson.smallBatchTC4ImportId5
 
-//skipping all test case import tests until flag is removed
+
 describe.skip('Import Test cases onto an existing measure via file', () => {
 
     beforeEach('Login and Create Measure', () => {

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Validations/QDMTestCaseValidations.cy.ts
@@ -28,10 +28,11 @@ let measureScoring = 'Cohort'
 let qdmMeasureCQL = MeasureCQL.simpleQDM_CQL
 let qdmMeasureCQLwInvalidValueset = MeasureCQL.simpleQDM_CQL_invalid_valueset
 let qdmMeasureCQLwDataTMMtoCQM = MeasureCQL.QDMTestCaseCQLFullElementSection
+let qdmMeasureCQLwNonVsacValueset = MeasureCQL.QDMTestCaseCQLNonVsacValueset
 
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Test Case Ownership Validations for QDM Measures', () => {
+
+describe('Test Case Ownership Validations for QDM Measures', () => {
 
     beforeEach('Create measure and login', () => {
 
@@ -91,8 +92,8 @@ describe.skip('Test Case Ownership Validations for QDM Measures', () => {
     })
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Create Test Case Validations', () => {
+
+describe('Create Test Case Validations', () => {
 
     before('Create Measure', () => {
         //Create New Measure
@@ -164,8 +165,7 @@ describe.skip('Create Test Case Validations', () => {
     })
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Edit Test Case Validations', () => {
+describe('Edit Test Case Validations', () => {
 
     before('Create QDM Measure and Test Case ', () => {
         //Create New Measure
@@ -256,48 +256,6 @@ describe.skip('Edit Test Case Validations', () => {
         cy.get(TestCasesPage.editTestCaseTitleInlineError).should('contain.text', 'Test Case Title is required.')
     })
 
-    it('Test Case dob validations: no dob', () => {
-
-        MeasuresPage.measureAction("edit")
-
-        //Navigate to Test Cases page and add Test Case details
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
-
-        //Navigate to Edit Test Case page
-        TestCasesPage.clickEditforCreatedTestCase()
-
-        //select the dob field, enter nothing for DOB, and, then, enter a value for Race
-        cy.get(TestCasesPage.QDMDob).click()
-        cy.get(TestCasesPage.QDMRace).click()
-        cy.get(TestCasesPage.QDMRaceOption).contains('White').click()
-
-        //confirm helper text / validation message for the DOB field
-        cy.get(TestCasesPage.QDMDOBHelperTxt).should('contain.text', 'Birthdate is required')
-
-    })
-
-    it('Test Case dob validations: wrong format for dob value', () => {
-
-        MeasuresPage.measureAction("edit")
-
-        //Navigate to Test Cases page and add Test Case details
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
-
-        //Navigate to Edit Test Case page
-        TestCasesPage.clickEditforCreatedTestCase()
-
-        //select the dob field, enter nothing for DOB, and, then, enter a value for Race
-        cy.get(TestCasesPage.QDMDob).type('2020/01/01').click()
-        cy.get(TestCasesPage.QDMRace).click()
-        cy.get(TestCasesPage.QDMRaceOption).contains('White').click()
-
-        //confirm helper text / validation message for the DOB field
-        cy.get(TestCasesPage.QDMDOBHelperTxt).should('contain.text', 'Birthdate is required')
-
-    })
-
     //dirty check validation
     it('Validate dirty check when user attempts to navigate away from the QDM Test Case edit page', () => {
         //Click on Edit Measure
@@ -350,8 +308,8 @@ describe.skip('Edit Test Case Validations', () => {
     })
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('Dirty Check Validations', () => {
+
+describe('Dirty Check Validations', () => {
 
     before('Create QDM Measure and Test Case ', () => {
         //Create New Measure
@@ -369,11 +327,11 @@ describe.skip('Dirty Check Validations', () => {
         Utilities.deleteMeasure(measureName, CqlLibraryName)
 
     })
-    //Discard changes button
+
     it('Validate dirty check on the test case title, in the test case details tab', () => {
 
         //create test case and login
-        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, QDMTCJson)
+        //TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, QDMTCJson)
         OktaLogin.Login()
 
         //Click on Edit Measure
@@ -391,26 +349,19 @@ describe.skip('Dirty Check Validations', () => {
         cy.get(TestCasesPage.elementsTab).should('be.enabled')
         cy.get(TestCasesPage.elementsTab).click()
 
-        //enter a value of the dob
-        cy.get(TestCasesPage.QDMDob).clear()
-        cy.get(TestCasesPage.QDMDob).type('01/01/2000')
+        //enter a value of the Ethnicity
+        cy.get(TestCasesPage.QDMEthnicity).should('contain.text', 'Not Hispanic or Latino')
+
 
         //take focus off of the date field
         cy.get(TestCasesPage.elementsTab).click()
 
-        cy.get(TestCasesPage.QDMTcDiscardChangesButton).should('exist')
-        cy.get(TestCasesPage.QDMTcDiscardChangesButton).should('be.enabled')
-        cy.get(TestCasesPage.QDMTcDiscardChangesButton).click()
-
-        //verify that the discard modal appears and click on discard
-        Global.clickOnDiscardChanges()
-
-        //verify that the dob value changes back to it's previous value
-        cy.get(TestCasesPage.QDMDob).should('contain.value', '01/01/2020')
+        //verify that the Ethnicity value changes back to it's previous value
+        cy.get(TestCasesPage.QDMEthnicity).should('contain.text', 'Not Hispanic or Latino')
 
         //change a value for the dob, again
-        cy.get(TestCasesPage.QDMDob).clear()
-        cy.get(TestCasesPage.QDMDob).type('01/01/2000')
+        cy.get(TestCasesPage.QDMEthnicity).click()
+        cy.get(TestCasesPage.QEMEthnicityOptions).contains('Hispanic or Latino').click()
 
         //take focus off of the date field
         cy.get(TestCasesPage.elementsTab).click()
@@ -422,16 +373,16 @@ describe.skip('Dirty Check Validations', () => {
         //verify discard modal and click on keep working
         Global.clickDiscardAndKeepWorking()
 
-        //verify that the dob valu is left unchanged from it's last change
-        cy.get(TestCasesPage.QDMDob).should('contain.value', '01/01/2000')
+        //verify that the Ethnicity valu is left unchanged from it's last change
+        cy.get(TestCasesPage.QDMEthnicity).should('contain.text', 'Not Hispanic or Latino')
 
 
     })
 
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('QDM CQM-Execution failure error validations: CQL Errors and missing group', () => {
+
+describe('QDM CQM-Execution failure error validations: CQL Errors and missing group', () => {
 
     beforeEach('Create Measure, and Test Case', () => {
         //Create New Measure
@@ -527,8 +478,8 @@ describe.skip('QDM CQM-Execution failure error validations: CQL Errors and missi
 
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('QDM CQM-Execution failure error validations: Valueset not found in Vsac', () => {
+
+describe('QDM CQM-Execution failure error validations: Valueset not found in Vsac', () => {
 
     beforeEach('Create Measure, and Test Case', () => {
         //Create New Measure
@@ -588,12 +539,12 @@ describe.skip('QDM CQM-Execution failure error validations: Valueset not found i
     })
 })
 
-//Skipping until QDM Test Case feature flag is removed
-describe.skip('QDM CQM-Execution failure error validations: Data transformation- MADiE Measure to CQMMeasure', () => {
+
+describe('QDM CQM-Execution failure error validations: Data transformation- MADiE Measure to CQMMeasure', () => {
 
     beforeEach('Create Measure, and Test Case', () => {
         //Create New Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, qdmMeasureCQLwDataTMMtoCQM)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, qdmMeasureCQLwNonVsacValueset)
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, QDMTCJson)
 
 
@@ -641,7 +592,7 @@ describe.skip('QDM CQM-Execution failure error validations: Data transformation-
         Utilities.waitForElementVisible(TestCasesPage.testCaseExecutionError, 105000)
         cy.get(TestCasesPage.testCaseExecutionError).should('exist')
         cy.get(TestCasesPage.testCaseExecutionError).should('be.visible')
-        cy.get(TestCasesPage.testCaseExecutionError).should('contain.text', 'An error occurred, please try again. If the error persists, please contact the help desk')
+        cy.get(TestCasesPage.testCaseExecutionError).should('contain.text', 'An error exists with the measure CQL, please review the CQL Editor tab.')
 
         //confirm that the Run Test button is disabled
         cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('not.be.enabled')


### PR DESCRIPTION
This PR includes the automation that tests and verifies the implemented change from 6159. Additionally, This PR includes the removal of all skip flags for QDM Test Case tests, that we have in our regression suite as well as some changes to make sure those test run as expected.