### PR TITLE
MAT-6736 QDM Manifest - Retrieve Manifest options from VSAC

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -141,6 +141,13 @@ export class TestCasesPage {
     //QDM Test Case
     public static readonly qdmCQLFailureErrorList = '[data-testid="execution_context_loading_errors"]'
     public static readonly qdmTCJson = '[class="panel-content"]'
+    public static readonly qdmExpansionRadioOptionGroup = '[data-testid="manifest-expansion-radio-buttons-group"]'
+    public static readonly qdmExpansionSubTab = '[data-testid="nav-link-expansion"]'
+    public static readonly qdmManifestSelectDropDownBox = '[id="manifest-select"]'
+    public static readonly qdmManifestFirstOption = '[data-value="ecqm-update-4q2017-eh"]'
+    public static readonly qdmManifestSaveBtn = '[data-testid="manifest-expansion-save-button"]'
+    public static readonly qdmManifestDiscardBtn = '[data-testid="manifest-expansion-discard-changes-button"]'
+    public static readonly qdmManifestSuccess = '[data-testid="manifest-expansion-success-text"]'
 
     //CQL area on Test Case page
     public static readonly tcCQLArea = '[data-testid="test-case-cql-editor"]'

--- a/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
@@ -8,7 +8,7 @@ import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import {Header} from "../../../../Shared/Header";
+import { Header } from "../../../../Shared/Header";
 
 let measureName = 'TestMeasure' + Date.now()
 let filePath = 'cypress/fixtures/measureId'
@@ -674,5 +674,32 @@ describe('QDM: Configuration sub tab', () => {
         Utilities.waitForElementVisible(TestCasesPage.newTestCaseButton, 60000)
         cy.get(TestCasesPage.configurationSubTab).should('not.exist')
 
+    })
+})
+
+//"manifestExpansion": false
+describe('QDM: Expansion Manifest sub-tab / section is not available when flag is set to false', () => {
+    let randValue = (Math.floor((Math.random() * 1000) + 1))
+    let newMeasureName = 'TestMeasure' + Date.now() + randValue
+    let newCqlLibraryName = 'MeasureTypeTestLibrary' + Date.now() + randValue
+
+    before('Create Measure and Login', () => {
+
+        //Create New Measure
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCqlLibraryName, 'Cohort', true, measureCQL)
+        OktaLogin.Login()
+
+    })
+
+    after('Logout and cleanup', () => {
+
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
+
+    })
+    it('"Expansion" is not an avaialble side sub-tab option, on the Test Case list page', () => {
+        MeasuresPage.measureAction('edit')
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.qdmExpansionSubTab).should('not.exist')
     })
 })


### PR DESCRIPTION
Added test to cover the new manifest sub tab section for QDM Test Cases, for the test case list page. Additionally, added a negative feature flag test because this is gonna reside behind a feature flag. New test is, currently, being skipped because it is behind that feature flag and it will be set to false, in production.