### PR TITLE
Removed unnecessary QRDA export test

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/QRDATestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/QRDATestCaseExport.cy.ts
@@ -7,8 +7,6 @@ import { Utilities } from "../../../../../Shared/Utilities"
 import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
-import { Header } from "../../../../../Shared/Header"
-import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
 
 
 let qdmMeasureCQL = MeasureCQL.CQLQDMObservationRun
@@ -20,15 +18,10 @@ let testCaseDescription = 'IPPStrat1Pass' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let anotherTestCaseSeries = 'SBTestSeries2nd'
 
-let SecondTestCaseTitle = 'PDxNotPsych60MinsDepart(){}[]<>/|"\':;,.~`!@#$%^&*_+='
-let SecondtestCaseDescription = 'IPPStrat1Pass' + Date.now()
-let SecondtestCaseSeries = 'SBTestSeries(){}[]<>/|"\':;,.~`!@#$%^&*_+='
-
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
 
-// skipping until 'TestCaseExport' flag is removed
 describe('QDM Test Cases : Export Test Case', () => {
 
     deleteDownloadsFolderBeforeAll()
@@ -53,7 +46,6 @@ describe('QDM Test Cases : Export Test Case', () => {
     })
 
     it('Successful QRDA Export for QDM Test Cases', () => {
-        let testCasePIdPath = 'cypress/fixtures/testCasePId'
 
         //Click on Edit Button
         MeasuresPage.measureAction("edit")
@@ -122,68 +114,7 @@ describe('QDM Test Cases : Export Test Case', () => {
     })
 })
 
-// skipping until 'TestCaseExport' flag is removed
-// tests ensuring that invalid characters in, either, the group or title of the test case prevents test case export
-describe('QDM Test Cases : Export Test Case: Invalid / Special characters in the series or in title prevents export', () => {
 
-    deleteDownloadsFolderBeforeAll()
-
-    beforeEach('Create Measure, Measure Group, Test cases and Log in', () => {
-
-        //Create New Measure and Test case
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, 'Cohort', false, qdmMeasureCQL)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
-        TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateQDMTestCaseAPI(SecondTestCaseTitle, SecondtestCaseSeries, SecondtestCaseDescription, null, true)
-
-        OktaLogin.Login()
-    })
-
-    afterEach('Log out and Clean up', () => {
-
-        OktaLogin.Logout()
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
-
-    })
-
-    it('Attempt to generate QRDA Export, for QDM Test Cases, when special characters are in one of the test case\'s title and series values', () => {
-
-        //Click on Edit Button
-        MeasuresPage.measureAction("edit")
-
-        //Save CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
-
-        //Navigate to test case page
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
-
-        //Run the Test cases
-        cy.get(TestCasesPage.executeTestCaseButton).click()
-
-        cy.get(TestCasesPage.testcaseQRDAExportBtn).click()
-        cy.get('[class="btn-container"]').contains('QRDA').click()
-
-        cy.get(MeasureGroupPage.CQLPCMismatchError)
-            .find('[id="content"]')
-            .find('[data-testid="execution_context_loading_errors"]')
-            .find('[data-testid="error-special-char-title"]')
-            .should('contain.text', 'Test Cases can not be exported some titles or groups contain special characters.')
-
-        cy.get(MeasureGroupPage.CQLPCMismatchError)
-            .find('[id="content"]')
-            .find('[data-testid="execution_context_loading_errors"]')
-            .find('[data-testid="error-special-char"]')
-            .should('contain.text', 'SBTestSeries(){}[]<>/|"\':;,.~`!@#$%^&*_+= PDxNotPsych60MinsDepart(){}[]<>/|"\':;,.~`!@#$%^&*_+=')
-    })
-})
-
-// skipping until 'TestCaseExport' flag is removed
 describe('Export Test cases by Non Measure Owner', () => {
 
 


### PR DESCRIPTION
This PR removes extra comment lines as well as an unnecessary test from the QRDATestCaseExport file.