### PR TITLE
QRDA Check file contents for HTML file continued

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/QRDATestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/QRDATestCaseExport.cy.ts
@@ -10,11 +10,11 @@ import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
 
 
 let qdmMeasureCQL = MeasureCQL.CQLQDMObservationRun
-let measureName = 'QDMTestMeasure' //+ Date.now()
-let CqlLibraryName = 'QDMCQLLibrary' //+ Date.now()
+let measureName = 'QDMTestMeasure' + Date.now()
+let CqlLibraryName = 'QDMCQLLibrary' + Date.now()
 let firstTestCaseTitle = 'PDxNotPsych60MinsDepart'
 let anotherTestCaseTitle = 'PDxNotPsych60MinsDepart2nd'
-let testCaseDescription = 'IPPStrat1Pass' //+ Date.now()
+let testCaseDescription = 'IPPStrat1Pass' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let anotherTestCaseSeries = 'SBTestSeries2nd'
 let baseHTMLFile = 'cypress/fixtures/baseQRDAHTMLfile.txt'


### PR DESCRIPTION
This PR updates the recent code that validates the QRDA export's HTML file's content. The date extension to the created measure name needed to be uncommented / added back to the step to create measure.