### PR TITLE
MAT-7211 Updated some QDM Versioning tests to make sure measures had pop criteria

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -500,6 +500,7 @@ export class CreateMeasurePage {
 
             })
         })
+        cy.log(user)
         return user
     }
 

--- a/cypress/e2e/Services/Measure Service/Measure.cy.ts
+++ b/cypress/e2e/Services/Measure Service/Measure.cy.ts
@@ -1054,7 +1054,8 @@ describe('Delete QDM Measure with admin API Key', () => {
         newCQLLibraryName = CqlLibraryNameU + randValue + Date.now()
         let QDMMeasureCQL = MeasureCQL.simpleQDM_CQL
 
-        defaultUser = CreateMeasurePage.CreateQDMMeasureAPI(newMeasureName, newCQLLibraryName, QDMMeasureCQL)
+        defaultUser = CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', true, QDMMeasureCQL)
+
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -1062,15 +1063,26 @@ describe('Delete QDM Measure with admin API Key', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.Logout()
+        sessionStorage.clear()
+        cy.clearAllCookies()
+        cy.clearLocalStorage()
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'd')
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout
 
+        sessionStorage.clear()
         cy.clearAllCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
         cy.clearAllSessionStorage({ log: true })
 
     })
-    //skipping until the versioning for QDM measures becomes available, again -- per the enableQdmRepeatTransfer flag
-    it.skip('Delete versioned QDM Measure with admin API key', () => {
+    it('Delete versioned QDM Measure with admin API key', () => {
 
         //Version Measure
         cy.getCookie('accessToken').then((accessToken) => {


### PR DESCRIPTION
This PR contains a new QDM service level test whereby a validation is done on the response that should return if there is an attempt to version a QDM measure without population criteria. Additionally, updates have been made to some existing tests to add pop criteria to QDM measures so the expected outcome of current test can be achieved.