### PR TITLE
Regression Test fixes and unskipped ProportionPatientQicoreProfileTypes test file

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
@@ -195,7 +195,7 @@ let measureCQL = 'library T771 version \'0.0.000\'\n' +
     '                     or Diagnosis.verificationStatus ~ QICoreCommon."entered-in-error" )\n' +
     '    ) is not null'
 
-describe.skip('FHIR Measure Export for Proportion Patient Measure with QI-Core Profile types', () => {
+describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profile types', () => {
 
     deleteDownloadsFolderBeforeAll()
 
@@ -281,9 +281,12 @@ describe.skip('FHIR Measure Export for Proportion Patient Measure with QI-Core P
 
         MeasuresPage.measureAction('version')
 
+        cy.get(MeasuresPage.versionMeasuresSelectionButton).click()
         cy.get(MeasuresPage.measureVersionMajor).should('exist')
         cy.get(MeasuresPage.measureVersionMajor).click()
 
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).should('exist')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).should('exist')
         cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/DateTimeAndRelatedToAttributes.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/DateTimeAndRelatedToAttributes.cy.ts
@@ -10,7 +10,7 @@ import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
-let measureScoring = 'Cohort'
+let measureScoringProportion = 'Proportion'
 let testCaseTitle = 'Title for Auto Test'
 let testCaseDescription = 'DENOMFail' + Date.now()
 let testCaseSeries = 'SBTestSeries'
@@ -100,7 +100,7 @@ describe('Test Case Attributes', () => {
     beforeEach('Create measure and login', () => {
 
         //Create QDM Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringProportion, false, measureCQL)
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/IntetrvalQuantityAttribute.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/IntetrvalQuantityAttribute.cy.ts
@@ -10,7 +10,7 @@ import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
-let measureScoring = 'Cohort'
+let measureScoringProportion = 'Proportion'
 let testCaseTitle = 'Title for Auto Test'
 let testCaseDescription = 'DENOMFail' + Date.now()
 let testCaseSeries = 'SBTestSeries'
@@ -100,7 +100,7 @@ describe('Quantity Attribute', () => {
     beforeEach('Create measure and login', () => {
 
         //Create QDM Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringProportion, false, measureCQL)
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/PractitionerAttribute.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/PractitionerAttribute.cy.ts
@@ -10,7 +10,7 @@ import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
-let measureScoring = 'Cohort'
+let measureScoringProportion = 'Proportion'
 let testCaseTitle = 'Title for Auto Test'
 let testCaseDescription = 'DENOMFail' + Date.now()
 let testCaseSeries = 'SBTestSeries'
@@ -100,7 +100,7 @@ describe('Practitioner Attribute', () => {
     beforeEach('Create measure and login', () => {
 
         //Create QDM Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringProportion, false, measureCQL)
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/QDMTestCaseAttributevalidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/QDMTestCaseAttributevalidations.cy.ts
@@ -10,7 +10,7 @@ import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMTestLibrary' + Date.now()
-let measureScoring = 'Cohort'
+let measureScoringProportion = 'Proportion'
 let testCaseTitle = 'Title for Auto Test'
 let testCaseDescription = 'DENOMFail' + Date.now()
 let testCaseSeries = 'SBTestSeries'
@@ -100,7 +100,7 @@ describe('Remove Test case attribute', () => {
     beforeEach('Create measure and login', () => {
 
         //Create QDM Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringProportion, false, measureCQL)
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseValidations.cy.ts
@@ -22,7 +22,7 @@ let twoFiftyTwoCharacters = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxy
 let altMeasureName = ''
 let altCqlLibraryName = ''
 let measureCQL = MeasureCQL.QDMHighlightingTab_CQL
-let measureScoring = 'Cohort'
+let measureScoringCohort = 'Cohort'
 let qdmMeasureCQL = MeasureCQL.simpleQDM_CQL
 let qdmMeasureCQLwInvalidValueset = MeasureCQL.simpleQDM_CQL_invalid_valueset
 let qdmMeasureCQLwNonVsacValueset = MeasureCQL.QDMTestCaseCQLNonVsacValueset
@@ -117,7 +117,7 @@ describe('Test Case Ownership Validations for QDM Measures', () => {
         altCqlLibraryName = CqlLibraryName + altRandValue
 
         //Create QDM Measure, PC and Test Case with ALT user
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(altMeasureName, altCqlLibraryName, measureScoring, true, measureCQL, false, true)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(altMeasureName, altCqlLibraryName, measureScoringCohort, true, measureCQL, false, true)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, true, 'IP2')
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, QDMTCJson, false, true)
         OktaLogin.Login()
@@ -312,9 +312,9 @@ describe('Edit Test Case Validations', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //navigate to the details page
-        cy.get(TestCasesPage.detailsTab).click()
+        cy.get(TestCasesPage.detailsTab).click().wait(2000)
 
-        cy.get(TestCasesPage.testCaseTitle).focus()
+        cy.get(TestCasesPage.testCaseTitle).click().focus()
         cy.get(TestCasesPage.testCaseTitle).clear()
         cy.get(TestCasesPage.testCaseSeriesTextBox).click()
 
@@ -472,7 +472,7 @@ describe.skip('QDM Measure / Test Case: Dirty Check on attribute: Quantity Attri
     beforeEach('Create measure, group and login', () => {
 
         //Create QDM Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, measureQDMCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringCohort, false, measureQDMCQL)
         OktaLogin.Login()
         MeasuresPage.measureAction("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -577,7 +577,7 @@ describe('QDM CQM-Execution failure error validations: CQL Errors and missing gr
 
     beforeEach('Create Measure, and Test Case', () => {
         //Create New Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, true, qdmMeasureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringCohort, true, qdmMeasureCQL)
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, QDMTCJson)
 
     })
@@ -674,7 +674,7 @@ describe('QDM CQM-Execution failure error validations: Valueset not found in Vsa
 
     beforeEach('Create Measure, and Test Case', () => {
         //Create New Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, true, qdmMeasureCQLwInvalidValueset)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringCohort, true, qdmMeasureCQLwInvalidValueset)
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, QDMTCJson)
 
 
@@ -735,7 +735,7 @@ describe('QDM CQM-Execution failure error validations: Data transformation- MADi
 
     beforeEach('Create Measure, and Test Case', () => {
         //Create New Measure
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, false, qdmMeasureCQLwNonVsacValueset)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoringCohort, false, qdmMeasureCQLwNonVsacValueset)
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, QDMTCJson)
 
 


### PR DESCRIPTION
This PR contains some fixes to 5 test files concerning QDM Test Case attributes. These Tests were, previously, creating the measures as Cohort but, then, adding Proportion data to the PC / group. Additionally, this PR removes the skip in the file ProportionPatientQicoreProfileTypes test file.