### PR TITLE
Minor smoke regression test update

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/ProportionPatient.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/ProportionPatient.cy.ts
@@ -235,7 +235,7 @@ describe('Measure Creation: Proportion Patient Based', () => {
         //add Timing Relevant Period DateTime
         QDMElements.addTimingRelevantPeriodDateTime('10/26/2012 08:00 AM', '10/26/2012 08:15 AM')
         //add Code
-        QDMElements.addCode('ICD10PCS', '0HTT0ZZ')
+        QDMElements.addCode('Icd10PCS', '0HTT0ZZ')
         //Close the Element
         QDMElements.closeElement()
 
@@ -245,7 +245,7 @@ describe('Measure Creation: Proportion Patient Based', () => {
         //add Timing Relevant Period DateTime
         QDMElements.addTimingRelevantPeriodDateTime('10/26/2012 08:00 AM', '10/26/2012 08:15 AM')
         //add Code
-        QDMElements.addCode('ICD10PCS', '0HTT0ZZ')
+        QDMElements.addCode('Icd10PCS', '0HTT0ZZ')
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()


### PR DESCRIPTION
This PR contains an update to the ProportionPatient smoke test to expect code "Icd10PCS", as opposed to "ICD10PCS".