### PR TITLE
MAT-7246 Remove Value Set version from CQL

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -4,6 +4,10 @@ export class CQLEditorPage {
 
     //button to save CQL
     public static readonly saveCQLButton = '[data-testid="save-cql-btn"]'
+
+    //message that appears for various alerts that occur at successful saving
+    public static readonly saveAlertMessage = '[id="status-handler"]'
+
     //error toast message when a CQL change has an affect on PC
     public static readonly measureErrorToast = '[class="toast danger"]'
 

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -539,55 +539,55 @@ export class TestCasesPage {
             cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled').wait(1000)
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="view-edit-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="view-edit-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     break
                 }
                 case 'export': {
                     cy.scrollTo('top')
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-test-case-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="export-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-test-case-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="export-test-case-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="export-test-case-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     cy.get(this.tcSaveSuccessMsg).should('contain.text', 'Test case exported successfully')
                     break
                 }
                 case 'exporttransaction': {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-transaction-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="export-transaction-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     cy.get(this.tcSaveSuccessMsg).should('contain.text', 'Test case exported successfully')
                     break
                 }
                 case 'exportcollection': {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-collection-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="export-collection-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     cy.get(this.tcSaveSuccessMsg).should('contain.text', 'Test case exported successfully')
                     break
                 }
                 case 'delete': {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="delete-test-case-btn-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="delete-test-case-btn-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
+                    cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     break
                 }
                 default: { }

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -496,7 +496,7 @@ export class TestCasesPage {
                     cy.get('[data-testid="edit-element-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="edit-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="edit-element-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="edit-element-' + fileContents + '"]').wait(2000).click()
+                    cy.get('[data-testid="edit-element-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     break
                 }
                 case 'clone': {
@@ -507,7 +507,7 @@ export class TestCasesPage {
                     cy.get('[data-testid="clone-element-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="clone-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="clone-element-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="clone-element-' + fileContents + '"]').wait(2000).click()
+                    cy.get('[data-testid="clone-element-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     break
                 }
                 case 'delete': {
@@ -517,7 +517,7 @@ export class TestCasesPage {
                     cy.get('[data-testid="delete-element-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="delete-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-element-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="delete-element-' + fileContents + '"]').wait(3000).click()
+                    cy.get('[data-testid="delete-element-' + fileContents + '"]').scrollIntoView().click({ force: true })
                     break
                 }
                 default: { }

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -372,10 +372,10 @@ export class TestCasesPage {
     public static readonly QDMElementsTab = '[data-testid="elements-section"]'
 
     //QDM Test Case Attributes
-    public static readonly laboratoryElement = '[data-testid=elements-tab-laboratory_test]'
+    public static readonly laboratoryElement = '[data-testid="elements-tab-laboratory_test"]'
     public static readonly plusIcon = '[data-testid=AddCircleOutlineIcon]'
     public static readonly addAttribute = '[data-testid="add-attribute-button"]'
-    public static readonly attributesTab = '[data-testid=sub-navigation-tab-attributes]'
+    public static readonly attributesTab = '[data-testid="sub-navigation-tab-attributes"]'
     public static readonly selectAttributeDropdown = '[id="attribute-select"]'
     public static readonly referenceRangeAttribute = '[data-testid="option-Reference Range"]'
     public static readonly interpretationAttribute = '[data-testid="option-Interpretation"]'
@@ -489,30 +489,35 @@ export class TestCasesPage {
             cy.get('[data-testid="view-element-btn-' + fileContents + '"]').should('be.enabled').wait(1000)
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
-                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').wait(3000).click({ force: true })
+                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').scrollIntoView()
+                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="edit-element-' + fileContents + '"]', 55000)
+                    cy.get('[data-testid="edit-element-' + fileContents + '"]').scrollIntoView()
                     cy.get('[data-testid="edit-element-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="edit-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="edit-element-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="edit-element-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="edit-element-' + fileContents + '"]').wait(2000).click()
                     break
                 }
                 case 'clone': {
-                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').wait(3000).click({ force: true })
+                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').scrollIntoView()
+                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="clone-element-' + fileContents + '"]', 55000)
+                    cy.get('[data-testid="clone-element-' + fileContents + '"]').scrollIntoView()
                     cy.get('[data-testid="clone-element-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="clone-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="clone-element-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="clone-element-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="clone-element-' + fileContents + '"]').wait(2000).click()
                     break
                 }
                 case 'delete': {
-                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').wait(3000).click({ force: true })
+                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').scrollIntoView()
+                    cy.get('[data-testid="view-element-btn-' + fileContents + '"]').click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="delete-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-element-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="delete-element-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-element-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="delete-element-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="delete-element-' + fileContents + '"]').wait(3000).click()
                     break
                 }
                 default: { }
@@ -534,55 +539,55 @@ export class TestCasesPage {
             cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled').wait(1000)
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="view-edit-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="view-edit-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="view-edit-test-case-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
                     break
                 }
                 case 'export': {
                     cy.scrollTo('top')
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-test-case-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="export-test-case-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-test-case-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="export-test-case-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="export-test-case-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
                     cy.get(this.tcSaveSuccessMsg).should('contain.text', 'Test case exported successfully')
                     break
                 }
                 case 'exporttransaction': {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-transaction-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="export-transaction-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="export-transaction-bundle-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
                     cy.get(this.tcSaveSuccessMsg).should('contain.text', 'Test case exported successfully')
                     break
                 }
                 case 'exportcollection': {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-collection-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="export-collection-bundle-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="export-collection-bundle-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
                     cy.get(this.tcSaveSuccessMsg).should('contain.text', 'Test case exported successfully')
                     break
                 }
                 case 'delete': {
-                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="select-action-' + fileContents + '"]').wait(3000).scrollIntoView().wait(2000).click({ force: true })
                     Utilities.waitForElementVisible('[data-testid="delete-test-case-btn-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="delete-test-case-btn-' + fileContents + '"]', 55000)
                     cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').should('be.enabled')
-                    cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').scrollIntoView().click({ force: true })
+                    cy.get('[data-testid="delete-test-case-btn-' + fileContents + '"]').wait(2000).scrollIntoView().wait(2000).click({ force: true })
                     break
                 }
                 default: { }

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMRemoveValueSetVersion.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMRemoveValueSetVersion.cy.ts
@@ -1,0 +1,61 @@
+import { OktaLogin } from "../../../../Shared/OktaLogin"
+import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
+import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import { Utilities } from "../../../../Shared/Utilities"
+import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { TestCasesPage } from "../../../../Shared/TestCasesPage"
+import { MeasureCQL } from "../../../../Shared/MeasureCQL"
+import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
+
+let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
+let measureName = 'ProportionPatient' + Date.now()
+let measureQDMManifestName = 'QDMManifestTest' + Date.now()
+let CqlLibraryName = 'ProportionPatient' + Date.now()
+
+
+
+describe('Validating that the valueset version is removed and message appears, once user attempts to save CQL whom has a valueset version listed', () => {
+
+    beforeEach('Create Measure', () => {
+
+        //Create New Measure
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureQDMManifestName, CqlLibraryName, 'Proportion', false, qdmManifestTestCQL, false, false,
+            '2025-01-01', '2025-12-31')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(false, false, 'Initial Population', '', 'Denominator Exceptions', 'Numerator', '', 'Denominator')
+        TestCasesPage.CreateQDMTestCaseAPI('QDMManifestTC', 'QDMManifestTCGroup', 'QDMManifestTC', '', false, false)
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        //logout of MADiE
+        OktaLogin.UILogout()
+    })
+
+    afterEach('Clean up', () => {
+
+        OktaLogin.Logout()
+
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+
+    })
+    it('Valueset version removed and user is informed', () => {
+
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click().wait(2000)
+        //add new valueset and also specify a version
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}valueset \"Adolescent depression screening assessment with version\":  \'urn:oid:2.16.840.1.113762.1.4.1260.162\' version \'urn:hl7:version:20240307\'')
+
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        Utilities.waitForElementVisible(CQLEditorPage.saveAlertMessage, 35000)
+        cy.get(CQLEditorPage.saveAlertMessage).find('[class="madie-alert success"]').find('[id="content"]').find('[data-testid="library-warning"]').should('contain.text', 'MADiE does not currently support use of value set version directly in measures at this time. Your value set versions have been removed. Please use the relevant manifest for value set expansion for testing.')
+
+        //confirm that the CQL does not include the version
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('include.text', ' version \'0.0.000\'using QDM version \'5.6\'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Globalinclude TJCOverallQDM version \'8.0.000\' called TJCvalueset "Antithrombotic Therapy for Ischemic Stroke": \'urn:oid:2.16.840.1.113762.1.4.1110.62\'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'valueset "Medical Reason For Not Providing Treatment": \'urn:oid:2.16.840.1.113883.3.117.1.7.1    .473\'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'valueset "Patient Refusal": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.93\'valueset "Payer Type": \'urn:oid:2.16.840.1.114222.4.11.3591\'valueset "Pharmacological Contraindications For Antithrombotic Therapy": \'urn:oid:2.16.840.1    .113762.1.4.1110.52\'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'valueset "Adolescent depression screening assessment with version": \'urn:oid:2.16.840.1.113762    .1.4.1260.162\'context Patientdefine "SDE Ethnicity":  ["Patient Characteristic Ethnicity": "Ethnicity"]define "SDE Payer":  ["Patient Characteristic Payer": "Payer Type"]define "SDE Race":  ["Patient Characteristic Race": "Race"]define "SDE Sex":  ["Patient Characteristic Sex": "ONC Administrative Sex"]define "Denominator Exclusions":  TJC."Ischemic Stroke Encounters with Discharge Disposition"    union TJC."Encounter with Comfort Measures during Hospitalization"define "Encounter with Pharmacological Contraindications for Antithrombotic Therapy at     Discharge":  TJC."Ischemic Stroke Encounter" IschemicStrokeEncounter    with ["Medication, Discharge": "Pharmacological Contraindications For Antithrombotic         Therapy"] Pharmacological      such that Pharmacological.authorDatetime during IschemicStrokeEncounter.relevantPerioddefine "Reason for Not Giving Antithrombotic at Discharge":  ["Medication, Not Discharged": "Antithrombotic Therapy for Ischemic Stroke"]       NoAntithromboticDischarge    where NoAntithromboticDischarge.negationRationale in "Medical Reason For Not Providing         Treatment"')
+
+    })
+
+})

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -374,7 +374,6 @@ describe('Run QDM Test Case ', () => {
     })
 })
 
-// skipping until the manifestExpansion is removed / permanently set to true
 describe('Validating Expansion -> Manifest selections / navigation functionality', () => {
 
     beforeEach('Create Measure', () => {
@@ -438,7 +437,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         TestCasesPage.qdmTestCaseElementAction('edit')
         //add negation
         cy.get(TestCasesPage.negationTab).click()
-        cy.get(TestCasesPage.valueSetDirectRefCode).click()
+        cy.get(TestCasesPage.valueSetDirectRefCode).scrollIntoView().wait(2000).click()
         cy.get(TestCasesPage.valueSetOptionValue).click()
         cy.get('[id="code-system-selector"]').click()
         cy.get('[data-testid="option-SNOMEDCT"]').click()
@@ -453,7 +452,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.QDMTCSaveBtn).click()
         //add element - code system to TC
         //Element - Encounter:Performed: Nonelective Inpatient Encounter
-        cy.get('[data-testid="elements-tab-encounter"]').click()
+        cy.get('[data-testid="elements-tab-encounter"]').scrollIntoView().click()
         cy.get('[data-testid="data-type-Encounter, Performed: Nonelective Inpatient Encounter"]').click()
         cy.get('[id="dateTime"]').eq(0).type('06/01/2025 01:00 PM')
         cy.get('[id="dateTime"]').eq(1).type('06/02/2025 01:00 PM')
@@ -467,7 +466,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.attributesTab).click()
         cy.get(TestCasesPage.selectAttributeDropdown).click()
         cy.get('[data-testid="option-Diagnoses"]').click()
-        cy.get('[data-testid="value-set-selector"]').click()
+        cy.get('[data-testid="value-set-selector"]').scrollIntoView().wait(2000).click()
         cy.get('[data-testid="option-2.16.840.1.113883.3.117.1.7.1.247"]').click() //Select IschemicStroke from dropdown
         cy.get('[id="code-system-selector"]').click()
         cy.get('[data-testid="option-SNOMEDCT"]').click()
@@ -515,7 +514,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
 
         OktaLogin.Logout()
 
-        //Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
 
     })
     it('Verify Expansion -> Manifest: When code does not exist on value set, test case will fail. When value set does contain code, and all other expected equals actual then test case passes.', () => {
@@ -565,5 +564,24 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
 
         //verify the results row
         cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'FailQDMManifestTCGroupQDMManifestTCQDMManifestTCSelect')
+
     })
+
+    it('Verify Expansion -> Manifest: When code does not exist on value set, test case will fail. When value set does contain code, and all other expected equals actual then test case passes.', () => {
+
+        OktaLogin.Login()
+        MeasuresPage.measureAction("edit")
+        cy.get(EditMeasurePage.cqlEditorTab).click().wait(2000)
+        //add new valueset and also specify a version
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}valueset \"Adolescent depression screening assessment with version\":  \'urn:oid:2.16.840.1.113762.1.4.1260.162\' version \'urn:hl7:version:20240307\'')
+
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        Utilities.waitForElementVisible(CQLEditorPage.saveAlertMessage, 35000)
+        cy.get(CQLEditorPage.saveAlertMessage).find('[class="madie-alert success"]').find('[id="content"]').find('[data-testid="library-warning"]').should('contain.text', 'MADiE does not currently support use of value set version directly in measures at this time. Your value set versions have been removed. Please use the relevant manifest for value set expansion for testing.')
+
+        //confirm that the CQL does not include the version
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('include.text', ' version \'0.0.000\'using QDM version \'5.6\'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Globalinclude TJCOverallQDM version \'8.0.000\' called TJCvalueset "Antithrombotic Therapy for Ischemic Stroke": \'urn:oid:2.16.840.1.113762.1.4.1110.62\'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'valueset "Medical Reason For Not Providing Treatment": \'urn:oid:2.16.840.1.113883.3.117.1.7.1    .473\'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'valueset "Patient Refusal": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.93\'valueset "Payer Type": \'urn:oid:2.16.840.1.114222.4.11.3591\'valueset "Pharmacological Contraindications For Antithrombotic Therapy": \'urn:oid:2.16.840.1    .113762.1.4.1110.52\'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'valueset "Adolescent depression screening assessment with version": \'urn:oid:2.16.840.1.113762    .1.4.1260.162\'context Patientdefine "SDE Ethnicity":  ["Patient Characteristic Ethnicity": "Ethnicity"]define "SDE Payer":  ["Patient Characteristic Payer": "Payer Type"]define "SDE Race":  ["Patient Characteristic Race": "Race"]define "SDE Sex":  ["Patient Characteristic Sex": "ONC Administrative Sex"]define "Denominator Exclusions":  TJC."Ischemic Stroke Encounters with Discharge Disposition"    union TJC."Encounter with Comfort Measures during Hospitalization"define "Encounter with Pharmacological Contraindications for Antithrombotic Therapy at     Discharge":  TJC."Ischemic Stroke Encounter" IschemicStrokeEncounter    with ["Medication, Discharge": "Pharmacological Contraindications For Antithrombotic         Therapy"] Pharmacological      such that Pharmacological.authorDatetime during IschemicStrokeEncounter.relevantPerioddefine "Reason for Not Giving Antithrombotic at Discharge":  ["Medication, Not Discharged": "Antithrombotic Therapy for Ischemic Stroke"]       NoAntithromboticDischarge    where NoAntithromboticDischarge.negationRationale in "Medical Reason For Not Providing         Treatment"')
+
+    })
+
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -567,21 +567,4 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
 
     })
 
-    it('Verify Expansion -> Manifest: When code does not exist on value set, test case will fail. When value set does contain code, and all other expected equals actual then test case passes.', () => {
-
-        OktaLogin.Login()
-        MeasuresPage.measureAction("edit")
-        cy.get(EditMeasurePage.cqlEditorTab).click().wait(2000)
-        //add new valueset and also specify a version
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}{upArrow}valueset \"Adolescent depression screening assessment with version\":  \'urn:oid:2.16.840.1.113762.1.4.1260.162\' version \'urn:hl7:version:20240307\'')
-
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementVisible(CQLEditorPage.saveAlertMessage, 35000)
-        cy.get(CQLEditorPage.saveAlertMessage).find('[class="madie-alert success"]').find('[id="content"]').find('[data-testid="library-warning"]').should('contain.text', 'MADiE does not currently support use of value set version directly in measures at this time. Your value set versions have been removed. Please use the relevant manifest for value set expansion for testing.')
-
-        //confirm that the CQL does not include the version
-        cy.get(EditMeasurePage.cqlEditorTextBox).should('include.text', ' version \'0.0.000\'using QDM version \'5.6\'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Globalinclude TJCOverallQDM version \'8.0.000\' called TJCvalueset "Antithrombotic Therapy for Ischemic Stroke": \'urn:oid:2.16.840.1.113762.1.4.1110.62\'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'valueset "Medical Reason For Not Providing Treatment": \'urn:oid:2.16.840.1.113883.3.117.1.7.1    .473\'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'valueset "Patient Refusal": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.93\'valueset "Payer Type": \'urn:oid:2.16.840.1.114222.4.11.3591\'valueset "Pharmacological Contraindications For Antithrombotic Therapy": \'urn:oid:2.16.840.1    .113762.1.4.1110.52\'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'valueset "Adolescent depression screening assessment with version": \'urn:oid:2.16.840.1.113762    .1.4.1260.162\'context Patientdefine "SDE Ethnicity":  ["Patient Characteristic Ethnicity": "Ethnicity"]define "SDE Payer":  ["Patient Characteristic Payer": "Payer Type"]define "SDE Race":  ["Patient Characteristic Race": "Race"]define "SDE Sex":  ["Patient Characteristic Sex": "ONC Administrative Sex"]define "Denominator Exclusions":  TJC."Ischemic Stroke Encounters with Discharge Disposition"    union TJC."Encounter with Comfort Measures during Hospitalization"define "Encounter with Pharmacological Contraindications for Antithrombotic Therapy at     Discharge":  TJC."Ischemic Stroke Encounter" IschemicStrokeEncounter    with ["Medication, Discharge": "Pharmacological Contraindications For Antithrombotic         Therapy"] Pharmacological      such that Pharmacological.authorDatetime during IschemicStrokeEncounter.relevantPerioddefine "Reason for Not Giving Antithrombotic at Discharge":  ["Medication, Not Discharged": "Antithrombotic Therapy for Ischemic Stroke"]       NoAntithromboticDischarge    where NoAntithromboticDischarge.negationRationale in "Medical Reason For Not Providing         Treatment"')
-
-    })
-
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -437,7 +437,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         TestCasesPage.qdmTestCaseElementAction('edit')
         //add negation
         cy.get(TestCasesPage.negationTab).click()
-        cy.get(TestCasesPage.valueSetDirectRefCode).scrollIntoView().wait(2000).click()
+        cy.get(TestCasesPage.valueSetDirectRefCode).scrollIntoView().click()
         cy.get(TestCasesPage.valueSetOptionValue).click()
         cy.get('[id="code-system-selector"]').click()
         cy.get('[data-testid="option-SNOMEDCT"]').click()
@@ -466,7 +466,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.attributesTab).click()
         cy.get(TestCasesPage.selectAttributeDropdown).click()
         cy.get('[data-testid="option-Diagnoses"]').click()
-        cy.get('[data-testid="value-set-selector"]').scrollIntoView().wait(2000).click()
+        cy.get('[data-testid="value-set-selector"]').scrollIntoView().click()
         cy.get('[data-testid="option-2.16.840.1.113883.3.117.1.7.1.247"]').click() //Select IschemicStroke from dropdown
         cy.get('[id="code-system-selector"]').click()
         cy.get('[data-testid="option-SNOMEDCT"]').click()


### PR DESCRIPTION
This PR updates some support files and creates a new test to verify that valueset versions are, now, removed from CQL if it is attempted to save a CQL value that includes or specifies a valueset version.