### PR TITLE
MAT-7254 Display Translator Version Being Used in UI and other updates

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -37,6 +37,9 @@ export class MeasuresPage {
     public static readonly measureVersioningErrorMsg = '[data-testid="error-toast"]'
     public static readonly measureVersionHelperText = '[data-testid="version-helper-text"]'
 
+    //CQL to ELM version field
+    public static readonly measureCQLToElmVersionTxtBox = '[data-testid="translator-version-text-field"]'
+
 
     public static validateMeasureName(expectedValue: string): void {
         cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {

--- a/cypress/e2e/WebInterface/CQL Library/CQL Editor/ValidateCQLLibraryEditor.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Editor/ValidateCQLLibraryEditor.cy.ts
@@ -47,8 +47,8 @@ describe('Validate CQL on CQL Library page', () => {
 
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully! Library Statement or Using ' +
-            'Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).contains(apiCQLLibraryName)
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).contains('version \'0.0.000\'')
@@ -82,8 +82,8 @@ describe('Validate CQL on CQL Library page', () => {
         //save the value in the CQL Editor
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'CQL updated successfully! Library Statement or Using ' +
-            'Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
         //Validate error(s) in CQL Editor window
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
@@ -140,8 +140,8 @@ describe('Validate CQL on CQL Library page', () => {
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.enabled')
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'CQL updated successfully! Library Statement or Using ' +
-            'Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
         //Validate error(s) in CQL Editor after saving
         cy.scrollTo('top')
@@ -220,8 +220,8 @@ describe('CQL Library: CQL Editor: valueSet', () => {
 
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully! Library Statement or Using ' +
-            'Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
     })
 
@@ -246,8 +246,8 @@ describe('CQL Library: CQL Editor: valueSet', () => {
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'CQL updated successfully! Library Statement or Using ' +
-            'Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
         cy.get(CQLLibraryPage.umlsErrorMessage).should('not.be.visible')
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
@@ -155,7 +155,8 @@ describe('CQL Library Sharing - Multiple instances', () => {
         cy.get(CQLLibrariesPage.createDraftContinueBtn).should('exist')
         cy.get(CQLLibrariesPage.createDraftContinueBtn).should('be.visible')
         cy.get(CQLLibrariesPage.createDraftContinueBtn).should('be.enabled')
-        cy.get(CQLLibrariesPage.createDraftContinueBtn).click().wait(1000)
+
+        cy.get(CQLLibrariesPage.createDraftContinueBtn).wait(1000).click()
 
         cy.get(CQLLibrariesPage.VersionDraftMsgs).should('contain.text', 'New Draft of CQL Library is Successfully created')
         cy.get(CQLLibrariesPage.cqlLibraryVersionList).should('contain', 'Draft 1.0.000')

--- a/cypress/e2e/WebInterface/CQL Library/CreateCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CreateCQLLibraryValidations.cy.ts
@@ -306,8 +306,8 @@ describe('CQL Library Validations', () => {
         Utilities.typeFileContents('cypress/fixtures/AdultOutpatientEncountersQICore4Entry.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
 
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully! Library Statement or Using Statement were incorrect.' +
-            ' MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
         cy.get(Header.cqlLibraryTab).should('be.visible')
         cy.get(Header.cqlLibraryTab).click()

--- a/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
@@ -117,7 +117,8 @@ describe('Edit CQL Library validations', () => {
 
         cy.get(CQLLibraryPage.genericSuccessMessage).should('exist')
         cy.get(CQLLibraryPage.genericSuccessMessage).should('be.visible')
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL Library saved successfully')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Missing a using statement. Please add in a valid model and version.')
 
         //navigate back to the CQL Library page and navigate to the edit CQL Library page
         cy.get(Header.cqlLibraryTab).should('exist')

--- a/cypress/e2e/WebInterface/CQL Library/QDMCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/QDMCQLLibraryValidations.cy.ts
@@ -1,7 +1,7 @@
-import {Header} from "../../../Shared/Header"
-import {Utilities} from "../../../Shared/Utilities"
-import {CQLLibraryPage} from "../../../Shared/CQLLibraryPage"
-import {OktaLogin} from "../../../Shared/OktaLogin"
+import { Header } from "../../../Shared/Header"
+import { Utilities } from "../../../Shared/Utilities"
+import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
+import { OktaLogin } from "../../../Shared/OktaLogin"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 
 let CQLLibraryName = 'TestLibrary' + Date.now()
@@ -69,7 +69,8 @@ describe('QDM CQL Library Validations', () => {
 
         cy.get(CQLLibraryPage.currentCQLLibName).clear().type(updatedCQLLibraryName)
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL Library saved successfully')
+        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Missing a using statement. Please add in a valid model and version.')
 
     })
 

--- a/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
@@ -961,12 +961,16 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         //Click on Edit Button
         MeasuresPage.measureAction("edit")
 
+        //verify that the CQL to ELM version is not empty
+        cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
+
         //Save CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully but the following issues were found')
+        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
         //Group Creation
 

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
@@ -122,6 +122,9 @@ describe('Edit Measure: Add Meta Data', () => {
         //Click on Edit Measure
         MeasuresPage.measureAction("edit")
 
+        //verify that the CQL to ELM version is not empty
+        cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
+
         //Endorsing Organization and number on Name, Version & ID page
         cy.get(EditMeasurePage.endorsingOrganizationTextBox).invoke('val').then(endorsingOrg => {
             cy.get(EditMeasurePage.endorsementNumber).invoke('val').then(endorsementNumber => {
@@ -178,6 +181,7 @@ describe('Edit Measure: Add Meta Data', () => {
             expect(val).to.eql(clinicalRecommendation)
         })
         cy.log('Measure Clinical Recommendation added successfully')
+
 
     })
 })
@@ -274,6 +278,9 @@ describe('Generate CMS ID for QDM Measure', () => {
 
         //Click on Edit Measure
         MeasuresPage.measureAction("edit")
+
+        //verify that the CQL to ELM version is not empty
+        cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
 
         cy.get(EditMeasurePage.generateCmsIdButton).should('exist')
         cy.get(EditMeasurePage.generateCmsIdButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLEditorValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLEditorValidations.cy.ts
@@ -91,7 +91,7 @@ describe('Validate errors/warnings/success messages on CQL editor component on s
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL saved successfully')
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully')
 
     })
     it('Verify error message when there is no using statement in the CQL', () => {
@@ -107,7 +107,7 @@ describe('Validate errors/warnings/success messages on CQL editor component on s
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'CQL updated successfully but was missing a Using statement. Please add in a valid model and version.')
+        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'Missing a using statement. Please add in a valid model and version.Library statement was incorrect. MADiE has overwritten it.')
 
     })
     it('Verify error message when there is an using statement in the CQL, but it is not accurate', () => {
@@ -123,7 +123,7 @@ describe('Validate errors/warnings/success messages on CQL editor component on s
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.Using statement was incorrect. MADiE has overwritten it.')
 
     })
     it('Verify error message when there is an using statement in the CQL, but it is not accurate, and the library name used is not correct', () => {
@@ -139,7 +139,7 @@ describe('Validate errors/warnings/success messages on CQL editor component on s
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully! Library Statement or Using Statement were incorrect. MADiE has overwritten them to ensure proper CQL.')
+        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
 
     })
 


### PR DESCRIPTION
This PR adds additional validations to some existing tests to make sure the translator version is, now, listed on the Measure detail page. Additionally, other updates were made to several regression tests around CQL Editor messaging, per MAT-7246.