### PR TITLE
Additional Feature Flag regression test file fix

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
@@ -168,6 +168,18 @@ describe('QDM: Generate CMS ID', () => {
 
         MeasuresPage.measureAction('edit')
         cy.get(EditMeasurePage.generateCmsIdButton).click()
+        //
+
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
+        cy.get(EditMeasurePage.cmsIDDialogCancel).click()
+        cy.get(EditMeasurePage.cmsIdInput).should('not.exist')
+        cy.get(EditMeasurePage.generateCmsIdButton).click()
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
+        cy.get(EditMeasurePage.cmsIDDialogContinue).click()
+
+        //
         cy.get(EditMeasurePage.cmsIdInput).should('exist')
 
     })


### PR DESCRIPTION
This PR adds steps to the test around the flag for generating CMS IDs, on QDM measures, to account for the new modal window.