### PR TITLE
Updated existing test to validate the fix for MAT-7448

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -99,7 +99,7 @@ export class MeasuresPage {
             cy.get('[data-testid="measure-action-' + fileContents + '"]').should('be.enabled')
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
-                    cy.wait(3700)
+                    cy.wait(7000)
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     Utilities.waitForElementVisible('[data-testid="view-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="view-measure-' + fileContents + '"]').should('be.visible')
@@ -110,7 +110,7 @@ export class MeasuresPage {
                     break
                 }
                 case 'export': {
-
+                    cy.wait(7000)
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-measure-' + fileContents + '"]', 105000)
@@ -127,7 +127,7 @@ export class MeasuresPage {
                     break
                 }
                 case 'qdmexport': {
-                    cy.wait(3750)
+                    cy.wait(7000)
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').scrollIntoView()
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
@@ -145,7 +145,7 @@ export class MeasuresPage {
                     break
                 }
                 case 'version': {
-
+                    cy.wait(7000)
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     Utilities.waitForElementVisible('[data-testid="create-version-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="create-version-measure-' + fileContents + '"]').should('be.visible')
@@ -155,7 +155,7 @@ export class MeasuresPage {
                     break
                 }
                 case 'draft': {
-
+                    cy.wait(7000)
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     Utilities.waitForElementVisible('[data-testid="draft-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="draft-measure-' + fileContents + '"]').should('be.visible')

--- a/cypress/Shared/OktaLogin.ts
+++ b/cypress/Shared/OktaLogin.ts
@@ -121,7 +121,7 @@ export class OktaLogin {
     public static UILogout(): void {
 
 
-
+        cy.wait(7000)
         Utilities.waitForElementVisible(Header.userProfileSelect, 500000)
         cy.get(Header.userProfileSelect).scrollIntoView()
         cy.get(Header.userProfileSelect).click()

--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
@@ -60,7 +60,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         MeasuresPage.measureAction('version')
 
         cy.get(MeasuresPage.measureVersionTypeDropdown).click()
-        cy.get(MeasuresPage.measureVersionMajor).click()
+        cy.get(MeasuresPage.measureVersionMajor).click().wait(5000)
         cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
@@ -80,8 +80,10 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(Header.mainMadiePageButton).click().wait(2500)
         cy.reload()
 
+
         cy.readFile(filePath).should('exist').then((fileContents) => {
             Utilities.waitForElementVisible('[data-testid="measure-action-' + fileContents + '"]', 100000)
+            cy.wait(7000)
             cy.get('[data-testid="measure-action-' + fileContents + '"]').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid="measure-action-' + fileContents + '"]', 100000)
             cy.get('[data-testid="measure-action-' + fileContents + '"]').should('be.enabled')
@@ -113,8 +115,8 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
     })
 
-    //skipping until https://jira.cms.gov/browse/MAT-7448 is fixed
-    it.skip('User cannot create a draft for a measure / version, whom already has been drafted', () => {
+
+    it('User cannot create a draft for a measure / version, whom already has been drafted', () => {
 
         let versionNumber = '1.0.000'
         updatedMeasuresPageName = 'UpdatedMeasuresPageOne' + Date.now()
@@ -122,7 +124,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         MeasuresPage.measureAction('version')
 
         cy.get(MeasuresPage.measureVersionTypeDropdown).click()
-        cy.get(MeasuresPage.measureVersionMajor).click()
+        cy.get(MeasuresPage.measureVersionMajor).click().wait(5000)
         cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
@@ -136,9 +138,8 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.reload()
 
         cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {
-            cy.reload(true)
-            cy.scrollTo('top').wait(37500)
             Utilities.waitForElementVisible('[data-testid=measure-action-' + fileContents + ']', 30000)
+            cy.wait(7000)
             cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid=measure-action-' + fileContents + ']', 30000)
             cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.enabled')
@@ -193,15 +194,15 @@ describe('Draft and Version Validations -- CQL and Group are correct', () => {
         OktaLogin.UILogout()
 
     })
-    //skipping until https://jira.cms.gov/browse/MAT-7448 is fixed
-    it.skip('Verify Draft measure CQL, Group and Test case', () => {
+
+    it('Verify Draft measure CQL, Group and Test case', () => {
         let versionNumber = '1.0.000'
         updatedMeasuresPageName = 'UpdatedTestMeasures1' + Date.now()
 
         //version and draft measure
         MeasuresPage.measureAction('version')
         cy.get(MeasuresPage.measureVersionTypeDropdown).click()
-        cy.get(MeasuresPage.measureVersionMajor).click()
+        cy.get(MeasuresPage.measureVersionMajor).click().wait(5000)
         cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
 
         cy.get(MeasuresPage.measureVersionContinueBtn).should('exist')
@@ -251,7 +252,7 @@ describe('Draft and Version Validations -- CQL and Group are correct', () => {
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click().wait(7000)
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
         cy.get(EditMeasurePage.cqlEditorTextBox).should('contain.text', 'library ' + newCqlLibraryName)
 


### PR DESCRIPTION
This PR removes some skips that were originally placed because of the issue reported in MAT-7448. This PR also adds some delays to account for some timing issues that were noticed while interacting with action buttons and the version modal text box.