### PR TITLE
MAT7665 Reverting The order of how the elements are added to QDM test case

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -412,36 +412,6 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('01/01/2000 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
         //add element - code system to TC
-        //Element - Encounter:Performed: Nonelective Inpatient Encounter
-        cy.get('[data-testid="elements-tab-encounter"]').scrollIntoView().click()
-        cy.get('[data-testid="data-type-Encounter, Performed: Nonelective Inpatient Encounter"]').click()
-        QDMElements.addTimingRelevantPeriodDateTime('06/01/2025 01:00 PM', '06/02/2025 01:00 PM')
-        cy.get('[data-testid="sub-navigation-tab-codes"]').click()
-        cy.get('[id="code-system-selector"]').click()
-        cy.get('[data-testid="code-system-option-SNOMEDCT"]').click()
-        cy.get('[id="code-selector"]').click()
-        cy.get('[data-testid="code-option-183452005"]').click()
-        cy.get('[data-testid="add-code-concept-button"]').click()
-        //navigate to the attribute sub tab and enter value
-        cy.get(TestCasesPage.attributesTab).click()
-        cy.get(TestCasesPage.selectAttributeDropdown).click()
-        cy.get('[data-testid="option-Diagnoses"]').click()
-        cy.get('[data-testid="value-set-selector"]').scrollIntoView().click()
-        cy.get('[data-testid="option-2.16.840.1.113883.3.117.1.7.1.247"]').click() //Select IschemicStroke from dropdown
-        cy.get('[id="code-system-selector"]').click()
-        cy.get('[data-testid="option-SNOMEDCT"]').click()
-        cy.get('[id="code-selector"]').click()
-        cy.get('[data-value="111297002"]').click()
-        cy.get('[data-testid="integer-input-field-Rank"]').type('1')
-        cy.get(TestCasesPage.addAttribute).click()
-        cy.get(TestCasesPage.QDMTCSaveBtn).should('be.visible')
-        cy.get(TestCasesPage.QDMTCSaveBtn).should('be.enabled')
-        cy.get(TestCasesPage.QDMTCSaveBtn).click().wait(4000)
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
-        Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 50000)
-        TestCasesPage.testCaseAction('edit')
-        //add element - code system to TC
         //Element - Medication:Discharged: Antithrombotic Therapy for Ischemic Stroke
         cy.get('[data-testid="elements-tab-medication"]').click()
         cy.get('[data-testid="data-type-Medication, Discharge: Antithrombotic Therapy for Ischemic Stroke"]').click()
@@ -478,6 +448,35 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get('[data-testid="option-105480006"]').click()
         Utilities.waitForElementVisible('[data-testid="add-negation-rationale"]', 35000)
         cy.get('[data-testid="add-negation-rationale"]').click()
+        cy.get(TestCasesPage.QDMTCSaveBtn).should('be.visible')
+        cy.get(TestCasesPage.QDMTCSaveBtn).should('be.enabled')
+        cy.get(TestCasesPage.QDMTCSaveBtn).click().wait(4000)
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+        Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 50000)
+        TestCasesPage.testCaseAction('edit')
+        //Element - Encounter:Performed: Nonelective Inpatient Encounter
+        cy.get('[data-testid="elements-tab-encounter"]').scrollIntoView().click()
+        cy.get('[data-testid="data-type-Encounter, Performed: Nonelective Inpatient Encounter"]').click()
+        QDMElements.addTimingRelevantPeriodDateTime('06/01/2025 01:00 PM', '06/02/2025 01:00 PM')
+        cy.get('[data-testid="sub-navigation-tab-codes"]').click()
+        cy.get('[id="code-system-selector"]').click()
+        cy.get('[data-testid="code-system-option-SNOMEDCT"]').click()
+        cy.get('[id="code-selector"]').click()
+        cy.get('[data-testid="code-option-183452005"]').click()
+        cy.get('[data-testid="add-code-concept-button"]').click()
+        //navigate to the attribute sub tab and enter value
+        cy.get(TestCasesPage.attributesTab).click()
+        cy.get(TestCasesPage.selectAttributeDropdown).click()
+        cy.get('[data-testid="option-Diagnoses"]').click()
+        cy.get('[data-testid="value-set-selector"]').scrollIntoView().click()
+        cy.get('[data-testid="option-2.16.840.1.113883.3.117.1.7.1.247"]').click() //Select IschemicStroke from dropdown
+        cy.get('[id="code-system-selector"]').click()
+        cy.get('[data-testid="option-SNOMEDCT"]').click()
+        cy.get('[id="code-selector"]').click()
+        cy.get('[data-value="111297002"]').click()
+        cy.get('[data-testid="integer-input-field-Rank"]').type('1')
+        cy.get(TestCasesPage.addAttribute).click()
         //Close the Element
         cy.get('[data-testid="CloseIcon"]').scrollIntoView()
         cy.scrollTo(100, 0)
@@ -487,8 +486,6 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.QDMTCSaveBtn).should('be.visible')
         cy.get(TestCasesPage.QDMTCSaveBtn).should('be.enabled')
         cy.get(TestCasesPage.QDMTCSaveBtn).click()
-
-
         //Add Expected value for Test case
         //navigate to the Expected / Actual tab
         cy.get(TestCasesPage.tctExpectedActualSubTab).scrollIntoView().click()
@@ -541,7 +538,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.executeTestCaseButton).click()
 
         //verify the results row
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' +todaysDate+ 'Select')
+        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate + 'Select')
 
         //navigate to the test case list Expansion page
         cy.get(TestCasesPage.qdmExpansionSubTab).click()
@@ -574,7 +571,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.executeTestCaseButton).click()
 
         //verify the results row
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'FailQDMManifestTCGroupQDMManifestTCQDMManifestTC' +todaysDate+ 'Select')
+        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'FailQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate + 'Select')
 
     })
 


### PR DESCRIPTION
This PR reverts the order in which elements are added to the QDM test case. Previously, the order was adjusted to account for the bug in MAT-7665.
The bug has been fixed, now, and there is no reason to have the opposite order.