### PR TITLE
feat: remove git tracking on several files for local results processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,23 @@ cypress/results/
 .vscode/
 .idea/*
 
-
+# files for local processing
+cypress/fixtures/cqlLibraryId
+cypress/fixtures/cqlLibraryId2
+cypress/fixtures/groupId
+cypress/fixtures/groupId2
+cypress/fixtures/measureId
+cypress/fixtures/measureId2
+cypress/fixtures/measureId3
+cypress/fixtures/measureId4
+cypress/fixtures/measureSetId
+cypress/fixtures/measureSetId2
+cypress/fixtures/measureSetId3
+cypress/fixtures/measureSetId4
+cypress/fixtures/testCaseId
+cypress/fixtures/testCaseId2
+cypress/fixtures/versionId
+cypress/fixtures/versionId2
 
 
 # Created by https://www.toptal.com/developers/gitignore/api/node


### PR DESCRIPTION
My understanding is that all these fixture files: 

- are used for processing local test results
- are specific to just the most recent test or test suite run
- need to exist within the repo
- would never need to be updated with new values

That makes them prime candidates for the .gitignore file.

After this is merged, these files will still exist but will be ignored in any commands like `git diff` or `git status`.
They would also not appear when using git integrations in IntelliJ, VS Code, etc