### PR TITLE
feat: restore debugging snapshot capability

### DIFF
--- a/cypress/config/dev.json
+++ b/cypress/config/dev.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "https://dev-madie.hcqis.org",
   "screenshotsFolder": "mochawesome-report/assets",
-  "numTestsKeptInMemory": 0,
+  "numTestsKeptInMemory": 1,
   "env": {
     "environment": "dev",
     "type": "base"

--- a/cypress/config/impl.json
+++ b/cypress/config/impl.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "https://impl-madie.hcqis.org",
   "screenshotsFolder": "mochawesome-report/assets",
-  "numTestsKeptInMemory": 0,
+  "numTestsKeptInMemory": 1,
   "env": {
     "environment": "impl",
     "type": "base"

--- a/cypress/config/test.json
+++ b/cypress/config/test.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "https://test-madie.hcqis.org",
   "screenshotsFolder": "mochawesome-report/assets",
-  "numTestsKeptInMemory": 0,
+  "numTestsKeptInMemory": 1,
   "env": {
     "environment": "test",
     "type": "base"


### PR DESCRIPTION
Per this [Cypress issue](https://github.com/cypress-io/cypress/issues/7964)

These changes to the <env>.json files should restore the "snapshot" and local debugging features inside the Cypress runner, i.e. while using the general `cypress open` command.

A value of 1 means that only the current test you run will have these features active.