### PR TITLE
Updating import tests to verify test case list table

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -21,6 +21,8 @@ let prodBonneTestCasesFile = 'patients_39E0424A-1727-4629-89E2-C46C2FBB3F5F_QDM_
 let measureNamePropListQDM = 'QDMTestMeasure' + Date.now()
 let CqlLibraryNamePropListQDM = 'QDMTestLibrary' + Date.now()
 let measureCQLPRODCat = MeasureCQL.qdmMeasureCQLPRODCataracts2040BCVAwithin90Days
+const now = require('dayjs')
+let todaysDate = now().format('MM/DD/YYYY')
 
 describe('Test case Coverage tab', () => {
 
@@ -112,6 +114,8 @@ describe('Test case Coverage tab', () => {
 
         //click on the 'Import' button on the modal window
         cy.get(TestCasesPage.importTestCaseModalBtn).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction82N/ADENEXPassCertTypeIridOverlapsCatSurgPatient with certain types of iridocyclitis overlapping cataract surgery. ' + todaysDate + 'Select81N/ADENEXPassChorioretinitis and RetinochoroiditisOverlapsCatSurgPatient with moderate or severe impairment better eye overlapping cataract surgery. ' + todaysDate + 'Select80N/ADENEXPassChoroidDegenOverlapsCatSurgPatient with choroidal degenerations overlapping cataract surgery. ' + todaysDate + 'Select79N/ADENEXPassCloudyCorneaOverlapsCatSurgPatient with cloudy cornea overlapping cataract surgery. ' + todaysDate + 'Select78N/ADENEXPassDegenDisGlobeOverlapsCatSurgPatient with degenerative disorders of globe overlapping cataract surgery. ' + todaysDate + 'Select77N/ADENEXPassDisVisualCortexOverlapsCatSurgPatient with disorders of visual cortex overlapping cataract surgery. ' + todaysDate + 'Select76N/ADENEXPassDissChorioretOverlapsCatSurgPatient with disseminated chorioretinitis overlapping cataract surgery. ' + todaysDate + 'Select75N/ADENEXPassHeredCornDysOverlapsCatSurgPatient with hereditary corneal dystrophies overlapping cataract surgery. ' + todaysDate + 'Select74N/ADENEXPassHypotonyOverlapsCatSurgPatient with hypotony of eye overlapping cataract surgery. ' + todaysDate + 'Select73N/ADENEXPassInjOptNrvOverlapsCatSurgPatient with injury to optic nerve overlapping cataract surgery. ' + todaysDate + 'Select')
 
         //success message that appears after import
         cy.get(TestCasesPage.tcSaveSuccessMsg).should('contain.text', '(82) Test cases imported successfully')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
@@ -26,6 +26,8 @@ let validTestCaseJsonBobby = TestCaseJson.TestCaseJson_Valid_not_Lizzy_Health
 let measureCQLPFTests = MeasureCQL.CQL_Populations
 let validFileToUpload = downloadsFolder.toString()
 let zipFileToUpload = 'cypress/fixtures'
+const now = require('dayjs')
+let todaysDate = now().format('MM/DD/YYYY')
 
 describe('MADIE Zip Test Case Import', () => {
 
@@ -149,6 +151,8 @@ describe('MADIE Zip Test Case Import', () => {
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ATest Series 2Test Case 2Description 2' + todaysDate + 'Select1N/ATest Series 1Test Case 1Description 1' + todaysDate + 'Select')
 
         //verify confirmation message
         Utilities.waitForElementVisible(TestCasesPage.tcSaveSuccessMsg, 35000)
@@ -284,6 +288,8 @@ describe('MADIE Zip Test Case Import', () => {
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction138N/ADENEXFailICULT1DayICU LOS < 1 day\n' + todaysDate + 'Select137N/ADENEXPassSCIPKneeRank1Patient had SCIP -KneeSurg during Encounter and Rank =1\n' + todaysDate + 'Select136N/ADENEXPassSCIPHipFxRank1SMDCTDuplicate case by using SNOMDCT ' + todaysDate + 'Select135N/ANUMERPassMAOralXaKneeOnEncStartTimeoral factor Xa administered concurrent with start of IP encounter, Hip replacement concurrent with Start of IP encounter...more' + todaysDate + 'Select134N/ANUMERFailWarfarinAFDisch2Encounters2 encounters. warfarin administered after 2nd encounter discharge time\n' + todaysDate + 'Select133N/ADENEXPassCMODrgED2HrsBFAdmSameDateAdmDateDoNotPerformFalseCMO occurs in ED that ED ends > 1 hour before Adm. But this case pass because it is on the same day as adm date\n' + todaysDate + 'Select132N/ANUMERPassMedReasonMALDUHepDAGCSDuringEDmedical reasons to not receive no GCS and no low dose heparin during ED\n' + todaysDate + 'Select131N/ANUMERFailINRInvalidValue>18, dx VTE, LOS<120 day,   LabResult INR is a invalid value as coded value,  < 0 day after surgery end datetime\n' + todaysDate + 'Select130N/ADENEXFailCMO2DayAfterAnesthesiacomfort measures order 2 day after end of  anesthesia\n' + todaysDate + 'Select129N/ANUMERPassMAOralXaOnDayAFAnesMedAdmDToral factor Xa administered =0 day after end of anesthesia with MedicationAdm. effectiveDateTime\n' + todaysDate + 'Select')
 
         //Click on the Copy button and verify success msg
         Utilities.waitForElementVisible(EditMeasurePage.testCasesTab, 65000)

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
@@ -8,8 +8,9 @@ import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
 import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 import { Header } from "../../../../../Shared/Header"
-import { util } from "chai"
 
+const now = require('dayjs')
+let todaysDate = now().format('MM/DD/YYYY')
 let measureName = 'TestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
 let randValue = (Math.floor((Math.random() * 1000) + 1))
@@ -205,6 +206,8 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
 
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate + 'Select')
+
         //navigate to test case edit / detail page
         TestCasesPage.testCaseAction('edit')
 
@@ -292,6 +295,8 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/A' + testCaseSeries + 'b' + 'Title for Auto Testb' + testCaseDescription + 'b' + todaysDate + 'Select1N/A' + testCaseSeries + 'a' + 'Title for Auto Testa' + testCaseDescription + 'a' + todaysDate + 'Select')
 
         //navigate to test case edit / detail page for the first test case
         TestCasesPage.testCaseAction('edit')
@@ -387,6 +392,8 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
 
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate + 'Select')
+
         //navigate to test case edit / detail page
         TestCasesPage.testCaseAction('edit')
 
@@ -474,6 +481,8 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesbTitle for Auto Testb' + testCaseDescription + 'b' + todaysDate + 'Select1N/ASBTestSeriesaTitle for Auto Testa' + testCaseDescription + 'a' + todaysDate + 'Select')
 
         //navigate to test case edit / detail page for the first test case
         TestCasesPage.testCaseAction('edit')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -11,6 +11,8 @@ import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 import { Header } from "../../../../../Shared/Header"
 import { Environment } from "../../../../../Shared/Environment"
 
+const now = require('dayjs')
+let todaysDate = now().format('MM/DD/YYYY')
 let measureSharingAPIKey = Environment.credentials().measureSharing_API_Key
 let harpUserALT = Environment.credentials().harpUserALT
 let versionNumber = '1.0.000'
@@ -184,6 +186,8 @@ describe('Test Case Import: functionality tests', () => {
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesFFailing Test Case' + secondTestCaseDescription + todaysDate + 'Select1N/ASBTestSeriesPPassing Test Case' + testCaseDescription + todaysDate + 'Select')
 
         //verify confirmation message
         Utilities.waitForElementVisible(TestCasesPage.tcSaveSuccessMsg, 35000)
@@ -485,6 +489,7 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         cy.setAccessTokenCookie()
         CqlLibraryName = 'TestLibrary6' + Date.now()
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName + 'b', CqlLibraryName, measureCQLPFTests, 2)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean', 2)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit', 2)
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -558,6 +563,8 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesPb1Passing Test Caseb1' + testCaseDescription + 'b1' + todaysDate + 'Select1N/ASBTestSeriesFb2Failing Test Caseb2' + secondTestCaseDescription + 'b2' + todaysDate + 'Select')
 
         //verify confirmation message
         Utilities.waitForElementVisible(TestCasesPage.importTestCaseSuccessInfo, 35000)
@@ -670,6 +677,8 @@ describe('Test case uniqueness error validation', () => {
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
 
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1InvalidSBTestSeriesPb1Passing Test Caseb1' + testCaseDescription + 'b1' + todaysDate + 'Select')
+
         //verifies alert message at top of page informing user that no test case was imported
         Utilities.waitForElementVisible(TestCasesPage.importTestCaseAlertMessage, 35000)
         cy.get(TestCasesPage.importTestCaseAlertMessage).find('[id="content"]').should('contain.text', '(0) test case(s) were imported. The following (1) test case(s) could not be imported. Please ensure that your formatting is correct and try again.')
@@ -754,6 +763,8 @@ describe('Test Case Import: New Test cases on measure validations: PC does not m
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesPb1Passing Test Caseb1' + testCaseDescription + 'b1' + todaysDate + 'Select1N/ASBTestSeriesFb2Failing Test Caseb2' + secondTestCaseDescription + 'b2' + todaysDate + 'Select')
 
         //verifies alert message at tope of page informing user that no test case was imported
         Utilities.waitForElementVisible(TestCasesPage.importTestCaseAlertMessage, 35000)


### PR DESCRIPTION
This PR contains updates to regression tests where test cases are being imported onto Qi CORE and QDM measures. The updates includes adding validation on the test case list table to ensure that the test cases actually appear on the page after the import has completed.