### PR TITLE
fix: change name for uniqueness

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseID/QDMTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseID/QDMTestCaseID.cy.ts
@@ -353,6 +353,8 @@ describe('QDM Measure - Test case number on a Draft Measure', () => {
 
 describe('QDM Test Case - Deleting all test cases resets test case counter', () => {
 
+    const CqlLibraryName = 'TestCaseReset' + Date.now()
+
     beforeEach('Create Measure', () => {
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureQDMManifestName, CqlLibraryName, 'Proportion', false, qdmManifestTestCQL, null, false,


### PR DESCRIPTION
Add specific name to make sure "test case reset" does not use duplicates.