### PR TITLE
Regression failure fix for the MeasureVersion smoke test

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -164,6 +164,7 @@ export class MeasuresPage {
         }
 
         cy.readFile(filePath).should('exist').then((fileContents) => {
+            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 10000)
             cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().wait(3500).click()
         })
 

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -889,7 +889,6 @@ export class TestCasesPage {
     public static CreateTestCaseAPI(title: string, series: string, description: string, jsonValue?: string, secondMeasure?: boolean, twoTestCases?: boolean, altUser?: boolean, measureNumber?: number): string {
         let user = ''
         let measurePath = 'cypress/fixtures/measureId'
-        let measureGroupPath = 'cypress/fixtures/groupId'
         let testCasePath = ''
         let testCasePIdPath = ''
         if (altUser) {
@@ -926,35 +925,34 @@ export class TestCasesPage {
         //Add Test Case to the Measure
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile(measurePath).should('exist').then((id) => {
-                cy.readFile(measureGroupPath).should('exist').then((groupIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'POST',
-                        body: {
-                            'name': "TEST",
-                            'series': series,
-                            'title': title,
-                            'description': description,
-                            'json': jsonValue,
-                            "hapiOperationOutcome": {
-                                "code": 201,
-                                "message": null,
-                                "outcomeResponse": null
-                            }
+                cy.request({
+                    url: '/api/measures/' + id + '/test-cases',
+                    headers: {
+                        authorization: 'Bearer ' + accessToken.value
+                    },
+                    method: 'POST',
+                    body: {
+                        'name': "TEST",
+                        'series': series,
+                        'title': title,
+                        'description': description,
+                        'json': jsonValue,
+                        'hapiOperationOutcome': {
+                            "code": 201,
+                            "message": null,
+                            "outcomeResponse": null
                         }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        expect(response.body.series).to.eql(series)
-                        expect(response.body.title).to.eql(title)
-                        expect(response.body.description).to.eql(description)
-                        cy.writeFile(testCasePath, response.body.id)
-                        cy.writeFile(testCasePIdPath, response.body.patientId)
-                    })
+                    }
+                }).then((response) => {
+                    expect(response.status).to.eql(201)
+                    expect(response.body.id).to.be.exist
+                    expect(response.body.series).to.eql(series)
+                    expect(response.body.title).to.eql(title)
+                    expect(response.body.description).to.eql(description)
+                    cy.writeFile(testCasePath, response.body.id)
+                    cy.writeFile(testCasePIdPath, response.body.patientId)
                 })
+
             })
         })
         return user


### PR DESCRIPTION
This PR is to resolve a timing related issue that was causing the MeasureVersion regression smoke test to fail, intermittently.