### PR TITLE
fix: switch checks to different element

### DIFF
--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/MeasureVersionValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/MeasureVersionValidations.cy.ts
@@ -141,14 +141,13 @@ describe('Measure Versioning when the measure has test case with errors', () => 
         cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
 
-        Utilities.waitForElementVisible(TestCasesPage.versionMeasureWithTCErrors, 20000)
-        cy.get(TestCasesPage.versionMeasureWithTCErrors).should('exist')
+        Utilities.waitForElementVisible(TestCasesPage.versionMeasurewithTCErrorsModalBody, 20000)
 
         cy.get(TestCasesPage.versionMeasurewithTCErrorsModalBody).should('contain.text', 'You have test cases that are invalid.')
 
         cy.get(TestCasesPage.versionMeasurewithTCErrorsCancel).click()
 
-        Utilities.waitForElementToNotExist(TestCasesPage.versionMeasureWithTCErrors, 20000)
+        Utilities.waitForElementToNotExist(TestCasesPage.versionMeasurewithTCErrorsModalBody, 20000)
 
         cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {
             cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().wait(3500).click()
@@ -164,11 +163,10 @@ describe('Measure Versioning when the measure has test case with errors', () => 
         cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
 
-        Utilities.waitForElementVisible(TestCasesPage.versionMeasureWithTCErrors, 20000)
-        cy.get(TestCasesPage.versionMeasureWithTCErrors).should('exist')
+        Utilities.waitForElementVisible(TestCasesPage.versionMeasurewithTCErrorsModalBody, 20000)
 
         cy.get(TestCasesPage.versionMeasurewithTCErrorsContinue).click()
-        Utilities.waitForElementToNotExist(TestCasesPage.versionMeasureWithTCErrors, 20000)
+        Utilities.waitForElementToNotExist(TestCasesPage.versionMeasurewithTCErrorsModalBody, 20000)
 
         MeasuresPage.validateVersionNumber(MeasuresPageOne, versionNumber)
         cy.log('Version Created Successfully')


### PR DESCRIPTION
Checking for the top level element on the modal was very problematic.
I switched several of the checks & waits to use the same modal's body element instead, which is much more stable.