### PR TITLE
feat: package upgrades to resolve automated security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"adm-zip": "^0.5.16",
-				"convert": "^5.1.0",
+				"convert": "^5.5.1",
 				"decompress": "^4.2.1",
 				"excel-to-json": "^1.0.0",
 				"fs-extra": "^11.2.0",
 				"node": "^18.17.0",
 				"node-stream-zip": "^1.15.0",
-				"unzipper": "^0.10.14",
+				"unzipper": "^0.12.3",
 				"uuid": "^7.0.3",
-				"xlsx": "^0.18.5"
+				"xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 			},
 			"devDependencies": {
 				"@cypress-audit/lighthouse": "^1.4.2",
@@ -2754,7 +2754,8 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"node_modules/bare-events": {
 			"version": "2.4.2",
@@ -2815,26 +2816,6 @@
 				"node": ">= 8.0.0"
 			}
 		},
-		"node_modules/big-integer": {
-			"version": "1.6.52",
-			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-			"integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/binary": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-			"integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
-			"dependencies": {
-				"buffers": "~0.1.1",
-				"chainsaw": "~0.1.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/binary-extensions": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2866,8 +2847,7 @@
 		"node_modules/bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-			"dev": true
+			"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 		},
 		"node_modules/bn.js": {
 			"version": "5.2.1",
@@ -2986,6 +2966,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -3262,27 +3243,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
 		},
-		"node_modules/buffer-indexof-polyfill": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-			"integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
 		"node_modules/buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
 			"integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
 			"dev": true
-		},
-		"node_modules/buffers": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-			"integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ==",
-			"engines": {
-				"node": ">=0.2.0"
-			}
 		},
 		"node_modules/builtin-status-codes": {
 			"version": "3.0.0",
@@ -3414,17 +3379,6 @@
 			},
 			"engines": {
 				"node": ">=0.8"
-			}
-		},
-		"node_modules/chainsaw": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-			"integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
-			"dependencies": {
-				"traverse": ">=0.3.0 <0.4"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/chalk": {
@@ -3779,7 +3733,8 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
 		},
 		"node_modules/concat-stream": {
 			"version": "1.6.2",
@@ -3840,9 +3795,9 @@
 			"dev": true
 		},
 		"node_modules/convert": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/convert/-/convert-5.4.0.tgz",
-			"integrity": "sha512-a0fKxR/9dxSDlkuHAwj/CI8cuSU9BGNVYb5flO2tvlUyw5arn/AIfOGHBTXR9QnOVHsvC8NJ5/kI4mrmh5XjVg=="
+			"version": "5.5.1",
+			"resolved": "https://registry.npmjs.org/convert/-/convert-5.5.1.tgz",
+			"integrity": "sha512-WwF2Lq0CAu28u3vQNPELlqtCqUeXAKNujgbkV4vtRDNAw+WojcjfK2gQEACI0k8HYnGQIRH4D3eNumdb9M5OlQ=="
 		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
@@ -5353,7 +5308,8 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
@@ -5367,33 +5323,6 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/fstream": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-			"deprecated": "This package is no longer supported.",
-			"dependencies": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
-			},
-			"engines": {
-				"node": ">=0.6"
-			}
-		},
-		"node_modules/fstream/node_modules/rimraf": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
 			}
 		},
 		"node_modules/fsu": {
@@ -5510,6 +5439,7 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -5911,6 +5841,7 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
 			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -6576,11 +6507,6 @@
 				"semver": "bin/semver"
 			}
 		},
-		"node_modules/listenercount": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-			"integrity": "sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ=="
-		},
 		"node_modules/listr2": {
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
@@ -7045,6 +6971,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -7789,6 +7716,11 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/node-int64": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.18",
@@ -10836,6 +10768,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -11852,11 +11785,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-		},
 		"node_modules/sha.js": {
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
@@ -12630,14 +12558,6 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
 			"dev": true
 		},
-		"node_modules/traverse": {
-			"version": "0.3.9",
-			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-			"integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/truncate-utf8-bytes": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -12874,26 +12794,16 @@
 			}
 		},
 		"node_modules/unzipper": {
-			"version": "0.10.14",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.14.tgz",
-			"integrity": "sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==",
+			"version": "0.12.3",
+			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+			"integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
 			"dependencies": {
-				"big-integer": "^1.6.17",
-				"binary": "~0.3.0",
-				"bluebird": "~3.4.1",
-				"buffer-indexof-polyfill": "~1.0.0",
+				"bluebird": "~3.7.2",
 				"duplexer2": "~0.1.4",
-				"fstream": "^1.0.12",
+				"fs-extra": "^11.2.0",
 				"graceful-fs": "^4.2.2",
-				"listenercount": "~1.0.1",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "~1.0.4"
+				"node-int64": "^0.4.0"
 			}
-		},
-		"node_modules/unzipper/node_modules/bluebird": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-			"integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.0",
@@ -13299,22 +13209,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/wmf": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-			"integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
-		"node_modules/word": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-			"integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/workerpool": {
 			"version": "6.5.1",
 			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
@@ -13437,47 +13331,12 @@
 			}
 		},
 		"node_modules/xlsx": {
-			"version": "0.18.5",
-			"resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-			"integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-			"dependencies": {
-				"adler-32": "~1.3.0",
-				"cfb": "~1.2.1",
-				"codepage": "~1.15.0",
-				"crc-32": "~1.2.1",
-				"ssf": "~0.11.2",
-				"wmf": "~1.0.1",
-				"word": "~0.3.0"
-			},
+			"version": "0.20.3",
+			"resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+			"integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
+			"license": "Apache-2.0",
 			"bin": {
 				"xlsx": "bin/xlsx.njs"
-			},
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
-		"node_modules/xlsx/node_modules/codepage": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-			"integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
-		"node_modules/xlsx/node_modules/frac": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-			"integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
-		"node_modules/xlsx/node_modules/ssf": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-			"integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-			"dependencies": {
-				"frac": "~1.1.2"
 			},
 			"engines": {
 				"node": ">=0.8"

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
 	},
 	"dependencies": {
 		"adm-zip": "^0.5.16",
-		"convert": "^5.1.0",
+		"convert": "^5.5.1",
 		"decompress": "^4.2.1",
 		"excel-to-json": "^1.0.0",
 		"fs-extra": "^11.2.0",
 		"node": "^18.17.0",
 		"node-stream-zip": "^1.15.0",
-		"unzipper": "^0.10.14",
+		"unzipper": "^0.12.3",
 		"uuid": "^7.0.3",
-		"xlsx": "^0.18.5"
+		"xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 	}
 }


### PR DESCRIPTION
These upgrades should resolve (or allow us to close automated PRs) roughly half of the current automated security issues for this repo.
This includes PRs from Snyk and dependabot, as well as the dependabot alerts in the Security tab.

I ran 5 randomly chosen Smoke tests locally after making these upgrades & they all passed with no issues.

I'm looking to resolve these slowly, a few at a time.
Assuming this is accepted, I'll plan on another PR to work further on these alerts in 2-3 weeks.