### PR TITLE
fix: updates after new dev

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLParameters.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLParameters.cy.ts
@@ -251,9 +251,26 @@ describe.skip('QDM CQL Parameters - Measure ownership Validations', () => {
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()
 
-        // check Parameters tab disabled
-        cy.get(CQLEditorPage.parametersTab).should('be.disabled')
+        // check tabs are all enabled
         cy.get(CQLEditorPage.includesTab).should('be.enabled')
         cy.get(CQLEditorPage.definitionsTab).should('be.enabled')
+        cy.get(CQLEditorPage.valueSetsTab).should('be.enabled')
+        cy.get(CQLEditorPage.codeSubTab).should('be.enabled')
+        cy.get(CQLEditorPage.parametersTab).should('be.enabled').click()
+
+        // name disabled
+        cy.get(CQLEditorPage.parameterNameTextBox).should('be.disabled')
+
+        // editor hidden
+        cy.get('[data-testid="ChevronRightIcon"]').should('not.have.class', 'open')
+        cy.get('[data-testid="ChevronRightIcon"]').click()
+
+        // cannot type in expanded editor
+        cy.get(CQLEditorPage.parameterExpressionEditor)
+            .find('textarea').should('have.attr', 'readonly')
+
+        // clear & appply disabled
+        cy.get(CQLEditorPage.clearParametersExpressionButton).should('be.disabled')
+        cy.get(CQLEditorPage.applyParametersExpressionButton).should('be.disabled')
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLParameters.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLParameters.cy.ts
@@ -250,9 +250,25 @@ describe.skip('Qi-Core CQL Parameters - Measure ownership Validations', () => {
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()
 
-        // check Parameters tab disabled
-        cy.get(CQLEditorPage.parametersTab).should('be.disabled')
+        // check tabs are alll enabled
         cy.get(CQLEditorPage.includesTab).should('be.enabled')
         cy.get(CQLEditorPage.definitionsTab).should('be.enabled')
+        cy.get(CQLEditorPage.parametersTab).should('be.enabled').click()
+
+        // name disabled
+        cy.get(CQLEditorPage.parameterNameTextBox).should('be.disabled')
+
+        // editor hidden
+        cy.get('[data-testid="ChevronRightIcon"]').should('not.have.class', 'open')
+        cy.get('[data-testid="ChevronRightIcon"]').click()
+
+        // cannot type in expanded editor
+        cy.get(CQLEditorPage.parameterExpressionEditor)
+            .find('textarea').should('have.attr', 'readonly')
+
+        // clear & appply disabled
+        cy.get(CQLEditorPage.clearParametersExpressionButton).should('be.disabled')
+        cy.get(CQLEditorPage.applyParametersExpressionButton).should('be.disabled')
+
     })
 })


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-7694

Corrected the previous issue of fully disabling the tab & are now treating Parameters tab in the same way as others: tab is accessible but all elements on the tab are disabled.