### PR TITLE
feat: 1st phase for elements builder and qiCore6

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -3,6 +3,26 @@ import { LandingPage } from "./LandingPage"
 import { MeasuresPage } from "./MeasuresPage"
 import { v4 as uuidv4 } from 'uuid'
 import { Utilities } from "./Utilities"
+const now = require('dayjs')
+
+export enum SupportedModels {
+    QDM = 'QDM v5.6',
+    qiCore4 = 'QI-Core v4.1.1',
+    qiCore6 = 'QI-Core v6.0.0'
+}
+
+export type CreateMeasureOptions = {
+	ecqmTitle?: string
+    measureCql?: string,
+    elmJson?: string, 
+    measureNumber?: number,
+    measureScoring?: string,
+    patientBasis?: boolean,
+    twoMeasures?: boolean,
+    altUser?: boolean,
+    mpStartDate?: string,
+    mpEndDate?: string      
+}
 
 export class CreateMeasurePage {
 
@@ -655,4 +675,139 @@ export class CreateMeasurePage {
         return user
     }
 
+    public static CreateMeasureAPI(measureName: string, cqlLibraryName: string, model: SupportedModels, optionalParams?: CreateMeasureOptions): string {
+
+        let user, 
+        mpStartDate, 
+        mpEndDate, 
+        measureNumber = 0, 
+        ecqmTitle = 'AutoTestTitle', 
+        measureCql, 
+        elmJson
+
+        if (optionalParams && optionalParams.mpStartDate) {
+            mpStartDate = optionalParams.mpStartDate
+        }
+        else {
+            mpStartDate = now().subtract('2', 'year').format('YYYY-MM-DD')
+        }
+
+        if (optionalParams && optionalParams.mpEndDate) {
+            mpEndDate = optionalParams.mpEndDate
+        }
+        else {
+            mpEndDate = now().format('YYYY-MM-DD')
+        }
+
+        if (optionalParams && optionalParams.measureCql) {
+            measureCql = optionalParams.measureCql
+        }
+        else {
+            measureCql = '' // can add a real default here, if needed
+        }
+
+        if (optionalParams && optionalParams.elmJson) {
+            elmJson =  optionalParams.elmJson
+        }
+        else {
+            elmJson =  '' // can add a real default here, if needed
+        }
+
+        if (optionalParams && optionalParams.measureNumber) {
+            measureNumber = optionalParams.measureNumber
+        }
+        if (optionalParams && optionalParams.ecqmTitle) {
+            ecqmTitle = optionalParams.ecqmTitle
+        }
+
+        sessionStorage.clear()
+        cy.clearAllCookies()
+        cy.clearLocalStorage()
+        
+        if (optionalParams && optionalParams.altUser) {
+            cy.setAccessTokenCookieALT()
+            user = Environment.credentials().harpUserALT
+        }
+        else {
+            cy.setAccessTokenCookie()
+            user = Environment.credentials().harpUser
+        }
+
+        //Create New Measure
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.request({
+                url: '/api/measure?addDefaultCQL=false',
+                headers: {
+                    authorization: 'Bearer ' + accessToken.value
+                },
+                method: 'POST',
+                body: {
+                    'measureName': measureName,
+                    'cqlLibraryName': cqlLibraryName,
+                    'model': model,
+                    'createdBy': user,
+                    "ecqmTitle": ecqmTitle,
+                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
+                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
+                    'versionId': uuidv4(),
+                    'measureSetId': uuidv4(),
+                    'cql': measureCql,
+                    'elmJson': elmJson,
+                    'measureMetaData': {
+                        "experimental": false,
+                        "description": "SemanticBits",
+                        "steward": {
+                            "name": "SemanticBits",
+                            "id": "64120f265de35122e68dac40",
+                            "oid": "02c84f54-919b-4464-bf51-a1438f2710e2",
+                            "url": "https://semanticbits.com/"
+
+                        }, "developers": [
+                            {
+                                "id": "64120f265de35122e68dabf7",
+                                "name": "Academy of Nutrition and Dietetics",
+                                "oid": "2.16.840.1.113883.3.6308",
+                                "url": "www.eatrightpro.org"
+                            }
+                        ]
+                    },
+                    "testCaseConfiguration": {
+                        "id": null,
+                        "sdeIncluded": null
+                    },
+                    'programUseContext': {
+                        "code": "mips",
+                        "display": "MIPS",
+                        "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
+                    }
+                }
+            }).then((response) => {
+                console.log(response)
+                expect(response.status).to.eql(201)
+                expect(response.body.id).to.be.exist
+
+                if (measureNumber > 0) {
+                    cy.writeFile('cypress/fixtures/measureId' + measureNumber, response.body.id)
+                    cy.writeFile('cypress/fixtures/measureSetId' + measureNumber, response.body.measureSetId)
+
+                }
+                else {
+                    cy.writeFile('cypress/fixtures/measureId', response.body.id)
+                    cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
+                }
+
+                if (optionalParams && optionalParams.twoMeasures) {
+                    cy.writeFile('cypress/fixtures/measureId2', response.body.id)
+                    cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
+                }
+                else {
+                    cy.writeFile('cypress/fixtures/measureId', response.body.id)
+                    cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
+                }
+
+            })
+        })
+        cy.log(user)
+        return user
+    }
 }

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/QI-CoreTestCaseElementsJSON.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/QI-CoreTestCaseElementsJSON.cy.ts
@@ -1,14 +1,14 @@
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { Environment } from "../../../../Shared/Environment"
+import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
+import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
+import { CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../../../Shared/OktaLogin"
+import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
+import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
+import { Utilities } from "../../../../../Shared/Utilities"
+import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
+import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+import { Environment } from "../../../../../Shared/Environment"
 
 let measureName = 'TestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
@@ -47,7 +47,6 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Create
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.Logout()
-
     })
 
     beforeEach('Set Access Token', () => {
@@ -55,13 +54,11 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Create
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-
     })
 
     after('Clean up', () => {
 
         Utilities.deleteMeasure(measureName, cqlLibraryName)
-
     })
 
     it('Enter Valid Test Case Json that contains DOB, Gender, Race, and Ethnicity data and confirm those pieces of data appears on the element tab', () => {

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/Qi-CoreTestCaseElementsBuilder.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/Qi-CoreTestCaseElementsBuilder.cy.ts
@@ -1,0 +1,80 @@
+import { CreateMeasurePage, SupportedModels } from "../../../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../../../Shared/OktaLogin"
+import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
+import { Utilities } from "../../../../../Shared/Utilities"
+import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
+import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+
+const now = Date.now()
+let measureName = 'TestMeasureElementsBuilder' + now
+let cqlLibraryName = 'TestLibraryelementsBuilder' + now
+let testCaseTitle = 'Title for Auto Test'
+let testCaseDescription = 'ElementsBuilder1'
+let testCaseSeries = 'ElementsBuilder'
+
+// this is work in progress - skipping until it is complete
+describe.skip('Proof of concept - Create qiCore 6.0.0 measure', () => {
+
+    before('Create Measure', () => {
+
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookie()
+
+        //Create New Measure
+        CreateMeasurePage.CreateMeasureAPI(measureName, cqlLibraryName, SupportedModels.qiCore6)
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.Logout()
+    })
+
+    after('Clean up', () => {
+
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
+    })
+
+    it('Creates the test case - so far', () => {
+
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        //Create test case
+        cy.get(TestCasesPage.newTestCaseButton).scrollIntoView()
+        cy.get(TestCasesPage.newTestCaseButton).should('be.visible')
+        cy.get(TestCasesPage.newTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.newTestCaseButton).click({ force: true })
+
+        cy.get(TestCasesPage.createTestCaseDialog).should('exist')
+        cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
+
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
+        Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
+        cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle)
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).focus()
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCaseDescription)
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseGroupInput).type(testCaseSeries).type('{enter}')
+
+        TestCasesPage.clickCreateTestCaseButton()
+
+        //Verify created test case Title and Series exists on Test Cases Page
+        TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
+
+      //  incomplete - stopped here as a proof of concept check
+    })
+})
+


### PR DESCRIPTION
This is still a WIP (work in progress) but this part is discrete enough to potentially add, or get feedback on.

1. Rename existing file to enforce difference between Elements using JSON document & using UI Builder. No real changes made to the existing test, just adjusted imports & some whitespace.
2. Add a new file (heavily based on the JSON version) that will contain the tests for the UI Elements Builder. For now, it contains a very basic version of adding a measure & adding a test case. I only did this much to prove out no. 3 below.
3. Add a new, generic `CreateMeasureAPI` function that will allow QiCore 6.0.0 measures, as well as potential for only maintaining 1 function with all the needed options instead of several functions that are all 90% similar.