### PR TITLE
fix: change selectors for table

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -104,6 +104,7 @@ export class CQLEditorPage {
     public static readonly timingOption = '[data-testid="Timing-option"]'
     public static readonly preDefinedFunctionsOption = '[data-testid="Pre-Defined Functions-option"]'
     public static readonly savedDefinitionsTab = '[data-testid="saved-definitions-tab"]'
+    public static readonly savedDefinitionsTable = '[data-testid="definitions-tbl"]'
     public static readonly editCQLDefinitions = '[data-testid="edit-button-0"]'
     public static readonly deleteCQLDefinitions = '[data-testid="delete-button-0"]'
     public static readonly saveDefinitionBtn = '[data-testid="definition-save-btn"]'

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
@@ -267,7 +267,7 @@ describe('QDM CQL Definitions', () => {
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         cy.get(CQLEditorPage.deleteCQLDefinitions).click()
         cy.get(CQLLibraryPage.cqlLibraryDeleteDialogContinueBtn).click()
-        Utilities.waitForElementVisible('[class="toast success"]', 60000)
+        Utilities.waitForElementVisible(CQLEditorPage.saveSuccessMsg, 60000)
         cy.get(CQLEditorPage.saveSuccessMsg).should('contain.text', 'Definition SDE Sex has been successfully removed from the CQL.')
 
         //Navigate to Saved Definitions again and assert if the Definition is removed from Saved Definitions
@@ -277,7 +277,9 @@ describe('QDM CQL Definitions', () => {
         cy.get(CQLEditorPage.definitionsTab).click()
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         Utilities.waitForElementVisible(CQLEditorPage.deleteCQLDefinitions, 60000)
-        cy.get('.right-panel > .panel-content').should('not.contain', 'Common."Inpatient Encounter')
+        
+        // confirm entry for SDE Sex has been removed
+        cy.get(CQLEditorPage.savedDefinitionsTable).should('not.contain', 'SDE Sex')
     })
 
     it('QDM CQL Definition Comments were displayed under Saved Definitions tab', () => {

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
@@ -82,7 +82,6 @@ describe('Qi-Core CQL Definitions', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Search for Qi-Core CQL Definitions Expression Editor Name Options', () => {
@@ -301,7 +300,7 @@ describe('Qi-Core CQL Definitions', () => {
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         cy.get(CQLEditorPage.deleteCQLDefinitions).click()
         cy.get(CQLLibraryPage.cqlLibraryDeleteDialogContinueBtn).click()
-        Utilities.waitForElementVisible('[class="toast success"]', 60000)
+        Utilities.waitForElementVisible(CQLEditorPage.saveSuccessMsg, 60000)
         cy.get(CQLEditorPage.saveSuccessMsg).should('contain.text','Definition Initial Population has been successfully removed from the CQL.')
 
         //Navigate to Saved Definitions again and assert if the Definition is removed from Saved Definitions
@@ -311,7 +310,9 @@ describe('Qi-Core CQL Definitions', () => {
         cy.get(CQLEditorPage.definitionsTab).click()
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         Utilities.waitForElementVisible(CQLEditorPage.deleteCQLDefinitions, 60000)
-        cy.get('.right-panel > .panel-content').should('not.contain', 'Initial Population')
+
+        // confirm entry for IP has been removed
+        cy.get(CQLEditorPage.savedDefinitionsTable).should('not.contain', 'Initial Population')
     })
 
     it('View and Edit Qi Core CQL Definition Comments from Saved Definitions tab', () => {


### PR DESCRIPTION
This should fix both

- QiCoreCQLDefinitions.cy.ts
- QDMCQLDefinitions.cy.ts

Both tests had the same problem: they could not locate the "Saved Definitions" table & confirm that entries had been removed.