### PR TITLE
Refactor to remove CreateQDMMeasureWithBaseConfigurationFieldsWithoutDescriptionStewardsandDevelopersAPI 

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -17,11 +17,11 @@ export type CreateMeasureOptions = {
     elmJson?: string,
     measureNumber?: number,
     measureScoring?: string,
-    patientBasis?: boolean,
-    twoMeasures?: boolean,
+    patientBasis?: string,
     altUser?: boolean,
     mpStartDate?: string,
-    mpEndDate?: string
+    mpEndDate?: string,
+    blankMetadata?: boolean
 }
 
 export class CreateMeasurePage {
@@ -465,135 +465,25 @@ export class CreateMeasurePage {
         return user
     }
 
-    public static CreateQDMMeasureWithBaseConfigurationFieldsWithoutDescriptionStewardsandDevelopersAPI(measureName: string, CqlLibraryName: string, measureScoring: string, patientBasis?: boolean, measureCQL?: string, twoMeasures?: boolean, altUser?: boolean, mpStartDate?: string, mpEndDate?: string, measureNumber?: number): string {
-
-        let user = ''
-        const now = require('dayjs')
-        let ecqmTitle = 'eCQMTitle'
-        let elmJson = "{\"library\":{\"identifier\":{\"id\":\"CQLLibraryName1662121072763538\",\"version\":\"0.0.000\"},\"schemaIdentifier\":{\"id\":\"urn:hl7-org:elm\",\"version\":\"r1\"},\"usings\":{\"def\":[{\"localIdentifier\":\"System\",\"uri\":\"urn:hl7-org:elm-types:r1\"},{\"localId\":\"1\",\"locator\":\"3:1-3:26\",\"localIdentifier\":\"FHIR\",\"uri\":\"http://hl7.org/fhir\",\"version\":\"4.0.1\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"1\",\"s\":[{\"value\":[\"\",\"using \"]},{\"s\":[{\"value\":[\"FHIR\"]}]},{\"value\":[\" version \",\"'4.0.1'\"]}]}}]}]},\"includes\":{\"def\":[{\"localId\":\"2\",\"locator\":\"5:1-5:56\",\"localIdentifier\":\"FHIRHelpers\",\"path\":\"FHIRHelpers\",\"version\":\"4.1.000\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"2\",\"s\":[{\"value\":[\"\",\"include \"]},{\"s\":[{\"value\":[\"FHIRHelpers\"]}]},{\"value\":[\" version \",\"'4.1.000'\",\" called \",\"FHIRHelpers\"]}]}}]}]},\"parameters\":{\"def\":[{\"localId\":\"5\",\"locator\":\"7:1-7:49\",\"name\":\"Measurement Period\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"5\",\"s\":[{\"value\":[\"\",\"parameter \",\"\\\"Measurement Period\\\"\",\" \"]},{\"r\":\"4\",\"s\":[{\"value\":[\"Interval<\"]},{\"r\":\"3\",\"s\":[{\"value\":[\"DateTime\"]}]},{\"value\":[\">\"]}]}]}}],\"resultTypeSpecifier\":{\"type\":\"IntervalTypeSpecifier\",\"pointType\":{\"name\":\"{urn:hl7-org:elm-types:r1}DateTime\",\"type\":\"NamedTypeSpecifier\"}},\"parameterTypeSpecifier\":{\"localId\":\"4\",\"locator\":\"7:32-7:49\",\"type\":\"IntervalTypeSpecifier\",\"resultTypeSpecifier\":{\"type\":\"IntervalTypeSpecifier\",\"pointType\":{\"name\":\"{urn:hl7-org:elm-types:r1}DateTime\",\"type\":\"NamedTypeSpecifier\"}},\"pointType\":{\"localId\":\"3\",\"locator\":\"7:41-7:48\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}DateTime\",\"name\":\"{urn:hl7-org:elm-types:r1}DateTime\",\"type\":\"NamedTypeSpecifier\"}}}]},\"contexts\":{\"def\":[{\"locator\":\"9:1-9:15\",\"name\":\"Patient\"}]},\"statements\":{\"def\":[{\"locator\":\"9:1-9:15\",\"name\":\"Patient\",\"context\":\"Patient\",\"expression\":{\"type\":\"SingletonFrom\",\"operand\":{\"locator\":\"9:1-9:15\",\"dataType\":\"{http://hl7.org/fhir}Patient\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Patient\",\"type\":\"Retrieve\"}}},{\"localId\":\"7\",\"locator\":\"11:1-12:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"ipp\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"7\",\"s\":[{\"r\":\"6\",\"value\":[\"\",\"define \",\"\\\"ipp\\\"\",\":\\n  \",\"true\"]}]}}],\"expression\":{\"localId\":\"6\",\"locator\":\"12:3-12:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"valueType\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"value\":\"true\",\"type\":\"Literal\"}},{\"localId\":\"9\",\"locator\":\"14:1-15:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"denom\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"9\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"denom\\\"\",\":\\n \"]},{\"r\":\"8\",\"s\":[{\"value\":[\"\\\"ipp\\\"\"]}]}]}}],\"expression\":{\"localId\":\"8\",\"locator\":\"15:2-15:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"ipp\",\"type\":\"ExpressionRef\"}},{\"localId\":\"18\",\"locator\":\"17:1-18:52\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"num\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"18\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"num\\\"\",\":\\n  \"]},{\"r\":\"17\",\"s\":[{\"value\":[\"exists \"]},{\"r\":\"16\",\"s\":[{\"s\":[{\"r\":\"11\",\"s\":[{\"r\":\"10\",\"s\":[{\"r\":\"10\",\"s\":[{\"value\":[\"[\",\"\\\"Encounter\\\"\",\"]\"]}]}]},{\"value\":[\" \",\"E\"]}]}]},{\"value\":[\" \"]},{\"r\":\"15\",\"s\":[{\"value\":[\"where \"]},{\"r\":\"15\",\"s\":[{\"r\":\"13\",\"s\":[{\"r\":\"12\",\"s\":[{\"value\":[\"E\"]}]},{\"value\":[\".\"]},{\"r\":\"13\",\"s\":[{\"value\":[\"status\"]}]}]},{\"value\":[\" \",\"~\",\" \"]},{\"r\":\"14\",\"s\":[{\"value\":[\"'finished'\"]}]}]}]}]}]}]}}],\"expression\":{\"localId\":\"17\",\"locator\":\"18:3-18:52\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"type\":\"Exists\",\"operand\":{\"localId\":\"16\",\"locator\":\"18:10-18:52\",\"type\":\"Query\",\"resultTypeSpecifier\":{\"type\":\"ListTypeSpecifier\",\"elementType\":{\"name\":\"{http://hl7.org/fhir}Encounter\",\"type\":\"NamedTypeSpecifier\"}},\"source\":[{\"localId\":\"11\",\"locator\":\"18:10-18:24\",\"alias\":\"E\",\"resultTypeSpecifier\":{\"type\":\"ListTypeSpecifier\",\"elementType\":{\"name\":\"{http://hl7.org/fhir}Encounter\",\"type\":\"NamedTypeSpecifier\"}},\"expression\":{\"localId\":\"10\",\"locator\":\"18:10-18:22\",\"dataType\":\"{http://hl7.org/fhir}Encounter\",\"templateId\":\"http://hl7.org/fhir/StructureDefinition/Encounter\",\"type\":\"Retrieve\",\"resultTypeSpecifier\":{\"type\":\"ListTypeSpecifier\",\"elementType\":{\"name\":\"{http://hl7.org/fhir}Encounter\",\"type\":\"NamedTypeSpecifier\"}}}}],\"relationship\":[],\"where\":{\"localId\":\"15\",\"locator\":\"18:26-18:52\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"type\":\"Equivalent\",\"operand\":[{\"name\":\"ToString\",\"libraryName\":\"FHIRHelpers\",\"type\":\"FunctionRef\",\"operand\":[{\"localId\":\"13\",\"locator\":\"18:32-18:39\",\"resultTypeName\":\"{http://hl7.org/fhir}EncounterStatus\",\"path\":\"status\",\"scope\":\"E\",\"type\":\"Property\"}]},{\"localId\":\"14\",\"locator\":\"18:43-18:52\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}String\",\"valueType\":\"{urn:hl7-org:elm-types:r1}String\",\"value\":\"finished\",\"type\":\"Literal\"}]}}}},{\"localId\":\"20\",\"locator\":\"20:1-21:9\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"numeratorExclusion\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"20\",\"s\":[{\"value\":[\"\",\"define \",\"\\\"numeratorExclusion\\\"\",\":\\n    \"]},{\"r\":\"19\",\"s\":[{\"value\":[\"\\\"num\\\"\"]}]}]}}],\"expression\":{\"localId\":\"19\",\"locator\":\"21:5-21:9\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"num\",\"type\":\"ExpressionRef\"}},{\"localId\":\"39\",\"locator\":\"23:1-32:12\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Code\",\"name\":\"ToCode\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"type\":\"FunctionDef\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"39\",\"s\":[{\"value\":[\"\",\"define function \",\"ToCode\",\"(\",\"coding\",\" \"]},{\"r\":\"21\",\"s\":[{\"value\":[\"FHIR\",\".\",\"Coding\"]}]},{\"value\":[\"):\\n \"]},{\"r\":\"38\",\"s\":[{\"r\":\"38\",\"s\":[{\"value\":[\"if \"]},{\"r\":\"23\",\"s\":[{\"r\":\"22\",\"s\":[{\"value\":[\"coding\"]}]},{\"value\":[\" is null\"]}]},{\"r\":\"24\",\"value\":[\" then\\n   \",\"null\",\"\\n      else\\n        \"]},{\"r\":\"37\",\"s\":[{\"value\":[\"System\",\".\",\"Code\",\" {\\n           \"]},{\"s\":[{\"value\":[\"code\",\": \"]},{\"r\":\"27\",\"s\":[{\"r\":\"26\",\"s\":[{\"r\":\"25\",\"s\":[{\"value\":[\"coding\"]}]},{\"value\":[\".\"]},{\"r\":\"26\",\"s\":[{\"value\":[\"code\"]}]}]},{\"value\":[\".\"]},{\"r\":\"27\",\"s\":[{\"value\":[\"value\"]}]}]}]},{\"value\":[\",\\n           \"]},{\"s\":[{\"value\":[\"system\",\": \"]},{\"r\":\"30\",\"s\":[{\"r\":\"29\",\"s\":[{\"r\":\"28\",\"s\":[{\"value\":[\"coding\"]}]},{\"value\":[\".\"]},{\"r\":\"29\",\"s\":[{\"value\":[\"system\"]}]}]},{\"value\":[\".\"]},{\"r\":\"30\",\"s\":[{\"value\":[\"value\"]}]}]}]},{\"value\":[\",\\n          \"]},{\"s\":[{\"value\":[\"version\",\": \"]},{\"r\":\"33\",\"s\":[{\"r\":\"32\",\"s\":[{\"r\":\"31\",\"s\":[{\"value\":[\"coding\"]}]},{\"value\":[\".\"]},{\"r\":\"32\",\"s\":[{\"value\":[\"version\"]}]}]},{\"value\":[\".\"]},{\"r\":\"33\",\"s\":[{\"value\":[\"value\"]}]}]}]},{\"value\":[\",\\n           \"]},{\"s\":[{\"value\":[\"display\",\": \"]},{\"r\":\"36\",\"s\":[{\"r\":\"35\",\"s\":[{\"r\":\"34\",\"s\":[{\"value\":[\"coding\"]}]},{\"value\":[\".\"]},{\"r\":\"35\",\"s\":[{\"value\":[\"display\"]}]}]},{\"value\":[\".\"]},{\"r\":\"36\",\"s\":[{\"value\":[\"value\"]}]}]}]},{\"value\":[\"\\n           }\"]}]}]}]}]}}],\"expression\":{\"localId\":\"38\",\"locator\":\"24:2-32:12\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Code\",\"type\":\"If\",\"condition\":{\"localId\":\"23\",\"locator\":\"24:5-24:18\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"type\":\"IsNull\",\"operand\":{\"localId\":\"22\",\"locator\":\"24:5-24:10\",\"resultTypeName\":\"{http://hl7.org/fhir}Coding\",\"name\":\"coding\",\"type\":\"OperandRef\"}},\"then\":{\"asType\":\"{urn:hl7-org:elm-types:r1}Code\",\"type\":\"As\",\"operand\":{\"localId\":\"24\",\"locator\":\"25:4-25:7\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Any\",\"type\":\"Null\"}},\"else\":{\"localId\":\"37\",\"locator\":\"27:9-32:12\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Code\",\"classType\":\"{urn:hl7-org:elm-types:r1}Code\",\"type\":\"Instance\",\"element\":[{\"name\":\"code\",\"value\":{\"localId\":\"27\",\"locator\":\"28:18-28:34\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}String\",\"path\":\"value\",\"type\":\"Property\",\"source\":{\"localId\":\"26\",\"locator\":\"28:18-28:28\",\"resultTypeName\":\"{http://hl7.org/fhir}code\",\"path\":\"code\",\"type\":\"Property\",\"source\":{\"localId\":\"25\",\"locator\":\"28:18-28:23\",\"resultTypeName\":\"{http://hl7.org/fhir}Coding\",\"name\":\"coding\",\"type\":\"OperandRef\"}}}},{\"name\":\"system\",\"value\":{\"localId\":\"30\",\"locator\":\"29:20-29:38\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}String\",\"path\":\"value\",\"type\":\"Property\",\"source\":{\"localId\":\"29\",\"locator\":\"29:20-29:32\",\"resultTypeName\":\"{http://hl7.org/fhir}uri\",\"path\":\"system\",\"type\":\"Property\",\"source\":{\"localId\":\"28\",\"locator\":\"29:20-29:25\",\"resultTypeName\":\"{http://hl7.org/fhir}Coding\",\"name\":\"coding\",\"type\":\"OperandRef\"}}}},{\"name\":\"version\",\"value\":{\"localId\":\"33\",\"locator\":\"30:20-30:39\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}String\",\"path\":\"value\",\"type\":\"Property\",\"source\":{\"localId\":\"32\",\"locator\":\"30:20-30:33\",\"resultTypeName\":\"{http://hl7.org/fhir}string\",\"path\":\"version\",\"type\":\"Property\",\"source\":{\"localId\":\"31\",\"locator\":\"30:20-30:25\",\"resultTypeName\":\"{http://hl7.org/fhir}Coding\",\"name\":\"coding\",\"type\":\"OperandRef\"}}}},{\"name\":\"display\",\"value\":{\"localId\":\"36\",\"locator\":\"31:21-31:40\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}String\",\"path\":\"value\",\"type\":\"Property\",\"source\":{\"localId\":\"35\",\"locator\":\"31:21-31:34\",\"resultTypeName\":\"{http://hl7.org/fhir}string\",\"path\":\"display\",\"type\":\"Property\",\"source\":{\"localId\":\"34\",\"locator\":\"31:21-31:26\",\"resultTypeName\":\"{http://hl7.org/fhir}Coding\",\"name\":\"coding\",\"type\":\"OperandRef\"}}}}]}},\"operand\":[{\"name\":\"coding\",\"operandTypeSpecifier\":{\"localId\":\"21\",\"locator\":\"23:31-23:41\",\"resultTypeName\":\"{http://hl7.org/fhir}Coding\",\"name\":\"{http://hl7.org/fhir}Coding\",\"type\":\"NamedTypeSpecifier\"}}]},{\"localId\":\"42\",\"locator\":\"34:1-35:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"fun\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"type\":\"FunctionDef\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"42\",\"s\":[{\"value\":[\"\",\"define function \",\"fun\",\"(\",\"notPascalCase\",\" \"]},{\"r\":\"40\",\"s\":[{\"value\":[\"Integer\"]}]},{\"value\":[\" ):\\n  \"]},{\"r\":\"41\",\"s\":[{\"r\":\"41\",\"value\":[\"true\"]}]}]}}],\"expression\":{\"localId\":\"41\",\"locator\":\"35:3-35:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"valueType\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"value\":\"true\",\"type\":\"Literal\"},\"operand\":[{\"name\":\"notPascalCase\",\"operandTypeSpecifier\":{\"localId\":\"40\",\"locator\":\"34:35-34:41\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Integer\",\"name\":\"{urn:hl7-org:elm-types:r1}Integer\",\"type\":\"NamedTypeSpecifier\"}}]},{\"localId\":\"45\",\"locator\":\"37:1-38:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"name\":\"isFinishedEncounter\",\"context\":\"Patient\",\"accessLevel\":\"Public\",\"type\":\"FunctionDef\",\"annotation\":[{\"type\":\"Annotation\",\"s\":{\"r\":\"45\",\"s\":[{\"value\":[\"\",\"define function \",\"\\\"isFinishedEncounter\\\"\",\"(\",\"Enc\",\" \"]},{\"r\":\"43\",\"s\":[{\"value\":[\"Encounter\"]}]},{\"value\":[\"):\\n  \"]},{\"r\":\"44\",\"s\":[{\"r\":\"44\",\"value\":[\"true\"]}]}]}}],\"expression\":{\"localId\":\"44\",\"locator\":\"38:3-38:6\",\"resultTypeName\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"valueType\":\"{urn:hl7-org:elm-types:r1}Boolean\",\"value\":\"true\",\"type\":\"Literal\"},\"operand\":[]}]}},\"externalErrors\":[]}"
-
-        if (mpStartDate === undefined) {
-            mpStartDate = now().subtract('2', 'year').format('YYYY-MM-DD')
-        }
-
-        if (mpEndDate === undefined) {
-            mpEndDate = now().format('YYYY-MM-DD')
-        }
-        if ((measureNumber === undefined) || (measureNumber === null)) {
-            measureNumber = 0
-        }
-
-        if (altUser) {
-            cy.setAccessTokenCookieALT()
-            user = Environment.credentials().harpUserALT
-        }
-        else {
-            cy.setAccessTokenCookie()
-            user = Environment.credentials().harpUser
-        }
-
-        //Create New Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/measure?addDefaultCQL=false',
-                headers: {
-                    authorization: 'Bearer ' + accessToken.value
-                },
-                method: 'POST',
-                body: {
-                    'measureName': measureName,
-                    'cqlLibraryName': CqlLibraryName,
-                    'model': 'QDM v5.6',
-                    'createdBy': user,
-                    "ecqmTitle": ecqmTitle,
-                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
-                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
-                    'versionId': uuidv4(),
-                    'measureSetId': uuidv4(),
-                    'cql': measureCQL,
-                    'elmJson': elmJson,
-                    "scoring": measureScoring,
-                    //"baseConfigurationTypes": ["Process"],
-                    "patientBasis": patientBasis,
-                    'measureMetaData': {
-                        "experimental": false,
-                        //"description": "SemanticBits",
-                        /*"steward": {
-                                                         "name": "SemanticBits",
-                                                        "id": "64120f265de35122e68dac40",
-                                                        "oid": "02c84f54-919b-4464-bf51-a1438f2710e2",
-                                                        "url": "https://semanticbits.com/" 
-
-                        },*/ "developers": [
-                            /*                             {
-                                                            "id": "64120f265de35122e68dabf7",
-                                                            "name": "Academy of Nutrition and Dietetics",
-                                                            "oid": "2.16.840.1.113883.3.6308",
-                                                            "url": "www.eatrightpro.org"
-                                                        } */
-                        ]
-                    },
-                    'programUseContext': {
-                        "code": "mips",
-                        "display": "MIPS",
-                        "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
-                    }
-                }
-            }).then((response) => {
-                console.log(response)
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
-                if (measureNumber > 0) {
-                    cy.writeFile('cypress/fixtures/measureId' + measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/measureSetId' + measureNumber, response.body.measureSetId)
-
-                }
-                else {
-                    cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
-                }
-
-                if (twoMeasures === true) {
-                    cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-                    //cy.writeFile('cypress/fixtures/versionId2', response.body.versionId)
-                    cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
-                }
-                else {
-                    cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    //cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
-                    cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
-                }
-
-            })
-        })
-        return user
-    }
-
     public static CreateMeasureAPI(measureName: string, cqlLibraryName: string, model: SupportedModels, optionalParams?: CreateMeasureOptions): string {
 
         let user,
-            mpStartDate,
-            mpEndDate,
+            mpStartDate = now().subtract('2', 'year').format('YYYY-MM-DD'),
+            mpEndDate = now().format('YYYY-MM-DD'),
             measureNumber = 0,
             ecqmTitle = 'AutoTestTitle',
             measureCql,
-            elmJson
+            elmJson,
+            patientBasis: string,
+            measureScoring,
+            measureMetadata
 
         if (optionalParams && optionalParams.mpStartDate) {
             mpStartDate = optionalParams.mpStartDate
         }
-        else {
-            mpStartDate = now().subtract('2', 'year').format('YYYY-MM-DD')
-        }
-
         if (optionalParams && optionalParams.mpEndDate) {
             mpEndDate = optionalParams.mpEndDate
         }
-        else {
-            mpEndDate = now().format('YYYY-MM-DD')
-        }
-
         if (optionalParams && optionalParams.measureCql) {
             measureCql = optionalParams.measureCql
         }
@@ -613,6 +503,38 @@ export class CreateMeasurePage {
         }
         if (optionalParams && optionalParams.ecqmTitle) {
             ecqmTitle = optionalParams.ecqmTitle
+        }
+        if (optionalParams && optionalParams.patientBasis) {
+            patientBasis = optionalParams.patientBasis
+        }
+        if (optionalParams && optionalParams.measureScoring) {
+            measureScoring = optionalParams.measureScoring
+        }
+        if (optionalParams && optionalParams.blankMetadata) {
+            measureMetadata = {
+                "experimental": false,
+                "steward": undefined, 
+                "developers": []
+            }
+        } else {
+            measureMetadata = {
+                "experimental": false,
+                "description": "SemanticBits",
+                "steward": {
+                    "name": "SemanticBits",
+                    "id": "64120f265de35122e68dac40",
+                    "oid": "02c84f54-919b-4464-bf51-a1438f2710e2",
+                    "url": "https://semanticbits.com/"
+                }, 
+                "developers": [
+                    {
+                        "id": "64120f265de35122e68dabf7",
+                        "name": "Academy of Nutrition and Dietetics",
+                        "oid": "2.16.840.1.113883.3.6308",
+                        "url": "www.eatrightpro.org"
+                    }
+                ]
+            }
         }
 
         sessionStorage.clear()
@@ -648,24 +570,9 @@ export class CreateMeasurePage {
                     'measureSetId': uuidv4(),
                     'cql': measureCql,
                     'elmJson': elmJson,
-                    'measureMetaData': {
-                        "experimental": false,
-                        "description": "SemanticBits",
-                        "steward": {
-                            "name": "SemanticBits",
-                            "id": "64120f265de35122e68dac40",
-                            "oid": "02c84f54-919b-4464-bf51-a1438f2710e2",
-                            "url": "https://semanticbits.com/"
-
-                        }, "developers": [
-                            {
-                                "id": "64120f265de35122e68dabf7",
-                                "name": "Academy of Nutrition and Dietetics",
-                                "oid": "2.16.840.1.113883.3.6308",
-                                "url": "www.eatrightpro.org"
-                            }
-                        ]
-                    },
+                    "scoring": measureScoring,
+                    "patientBasis": patientBasis,
+                    'measureMetaData': measureMetadata,
                     "testCaseConfiguration": {
                         "id": null,
                         "sdeIncluded": null
@@ -684,22 +591,11 @@ export class CreateMeasurePage {
                 if (measureNumber > 0) {
                     cy.writeFile('cypress/fixtures/measureId' + measureNumber, response.body.id)
                     cy.writeFile('cypress/fixtures/measureSetId' + measureNumber, response.body.measureSetId)
-
                 }
                 else {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
                     cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
                 }
-
-                if (optionalParams && optionalParams.twoMeasures) {
-                    cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-                    cy.writeFile('cypress/fixtures/measureSetId2', response.body.measureSetId)
-                }
-                else {
-                    cy.writeFile('cypress/fixtures/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
-                }
-
             })
         })
         cy.log(user)

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
@@ -1,4 +1,4 @@
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
+import { CreateMeasurePage, SupportedModels, CreateMeasureOptions} from "../../../../Shared/CreateMeasurePage"
 import { OktaLogin } from "../../../../Shared/OktaLogin"
 import { Utilities } from "../../../../Shared/Utilities"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
@@ -13,7 +13,6 @@ let CqlLibraryName = 'TestLibrary' + Date.now()
 let randValue = (Math.floor((Math.random() * 1000) + 1))
 let newMeasureName = ''
 let newCqlLibraryName = ''
-const now = require('dayjs')
 let qdmMeasureCQL = MeasureCQL.CQLQDMObservationRun
 let updatedMeasureCQL = 'library TestLibrary1685544523170534 version \'0.0.000\'\n' +
     'using QDM version \'5.6\'\n' +
@@ -48,7 +47,15 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
         newCqlLibraryName = CqlLibraryName + randValue
 
         cy.setAccessTokenCookie()
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsWithoutDescriptionStewardsandDevelopersAPI(newMeasureName, newCqlLibraryName, 'Cohort', false, qdmMeasureCQL)
+
+        const measureOptions: CreateMeasureOptions = {
+            measureCql: qdmMeasureCQL,
+            measureScoring: 'Cohort', 
+            patientBasis: 'false',
+            blankMetadata: true
+        }
+        CreateMeasurePage.CreateMeasureAPI(newMeasureName, newCqlLibraryName, SupportedModels.QDM, measureOptions)
+
         MeasureGroupPage.CreateCohortMeasureGroupWithoutTypeAPI(false, false, 'Initial Population')
         OktaLogin.Login()
     })
@@ -71,7 +78,6 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
             cy.get('[class="error-message"] > ul > :nth-child(2)').should('contain.text', 'Missing Steward')
             cy.get('[class="error-message"] > ul > :nth-child(3)').should('contain.text', 'Missing Description')
             cy.get('[class="error-message"] > ul > :nth-child(4)').should('contain.text', 'Measure Type is required')
-
         })
     })
 })
@@ -111,7 +117,6 @@ describe('Error Message on Measure Export when the Measure has missing/invalid C
             cy.get('[data-testid="export-action-btn"]').click()
 
             cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
-
         })
     })
 
@@ -135,7 +140,6 @@ describe('Error Message on Measure Export when the Measure has missing/invalid C
             cy.get('[data-testid="export-action-btn"]').click()
 
             cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
-
         })
     })
 })
@@ -177,7 +181,6 @@ describe('Error Message on Measure Export when the Measure does not have Populat
 
             cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
             cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'Missing Population Criteria')
-
         })
     })
 })
@@ -223,7 +226,6 @@ describe('Error Message on Measure Export when the Population Criteria does not 
 
             cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
             cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'CQL Populations Return Types are invalid')
-
         })
     })
 })


### PR DESCRIPTION
feat: remove extra function & replace it with config

This was only being used in 1 test.
I added config options to CreateMeasureAPI to allow for all the same options.