### PR TITLE
chore: remove duplicate selector

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -22,7 +22,6 @@ export class MeasuresPage {
 
     //Measure Version
     public static readonly versionMeasuresSelectionButton = '[data-testid="version-type"]'
-    public static readonly versionMeasuresConfirmInput = '[data-testid="confirm-version-input"]'
     public static readonly VersionDraftMsgs = '[data-testid="success-toast"]'
     public static readonly VersionDraftErrMsgs = '[data-testid="error-toast"]'
     public static readonly updateDraftedMeasuresTextBox = '[data-testid="measure-name-input"]'

--- a/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
@@ -190,7 +190,7 @@ describe('Measure Sharing - Multiple instances', () => {
         //Version the Measure
         MeasuresPage.actionCenter('version')
         cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
-        cy.get(MeasuresPage.versionMeasuresConfirmInput).type('1.0.000')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
         MeasuresPage.validateVersionNumber(newMeasureName, versionNumber)

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
@@ -175,7 +175,7 @@ describe('Measure Transfer - Multiple instances', () => {
         //Version the Measure
         MeasuresPage.actionCenter('version')
         cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
-        cy.get(MeasuresPage.versionMeasuresConfirmInput).type('1.0.000')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
         //MeasuresPage.validateVersionNumber(newMeasureName, versionNumber)

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseID/QDMTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseID/QDMTestCaseID.cy.ts
@@ -300,7 +300,7 @@ describe('QDM Measure - Test case number on a Draft Measure', () => {
         //Version the Measure
         MeasuresPage.actionCenter('version')
         cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
-        cy.get(MeasuresPage.versionMeasuresConfirmInput).type('1.0.000')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
         MeasuresPage.validateVersionNumber(newMeasureName, versionNumber)

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
@@ -259,7 +259,7 @@ describe('Qi Core Measure - Test case number on a Draft Measure', () => {
         //Version the Measure
         MeasuresPage.actionCenter('version')
         cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
-        cy.get(MeasuresPage.versionMeasuresConfirmInput).type('1.0.000')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
         MeasuresPage.validateVersionNumber(newMeasureName, versionNumber)


### PR DESCRIPTION
Busy work task.

I found that we had 2 different selectors for the same element (version modal's confirmation textbox) in several tests.

This removes 1 of the 2 & consolidates all usage into 1 selector.

I ran all affected tests to verify, no failures.