### PR TITLE
fix: correct expectations for feature flag scenarios

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
@@ -1,5 +1,5 @@
 import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
+import { CreateMeasurePage, SupportedModels } from "../../../../Shared/CreateMeasurePage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
@@ -8,8 +8,8 @@ import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
 import { Header } from "../../../../Shared/Header"
-import {LandingPage} from "../../../../Shared/LandingPage"
-import {CQLEditorPage} from "../../../../Shared/CQLEditorPage"
+import { LandingPage } from "../../../../Shared/LandingPage"
+import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 
 let QiCoreMeasureName0: string
 let QiCoreCqlLibraryName0: string
@@ -168,5 +168,40 @@ describe('QI Core: CQL Builder Functions tab is not present', () => {
 
 })
 
+//"qiCoreElementsTab": false
+describe('QI Core v6: UI Elements Builder tab is not shown', () => {
+
+    afterEach('Clean up', () => {
+
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
+    })
+
+    it('UI Elements Builder not shown on test cases for 6.0.0 measures', () => {
+
+        cy.clearCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookie()
+
+        CreateMeasurePage.CreateMeasureAPI(measureName, cqlLibraryName, SupportedModels.qiCore6)
+
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
+
+        OktaLogin.Login()
+
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.testCaseAction('edit')
+
+        // no options show, only default editor
+        cy.get(TestCasesPage.jsonTab).should('not.exist')
+        cy.get(TestCasesPage.elementsTab).should('not.exist')
+        cy.get('.tab-container').should('not.exist')
+
+        // assert that blank editor field is there
+        cy.get(TestCasesPage.aceEditorJsonInput).should('be.empty')
+    })
+
+})
 
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/Qi-CoreTestCaseElementsBuilder.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/Qi-CoreTestCaseElementsBuilder.cy.ts
@@ -12,7 +12,8 @@ let testCaseTitle = 'Title for Auto Test'
 let testCaseDescription = 'ElementsBuilder1'
 let testCaseSeries = 'ElementsBuilder'
 
-describe('Check for UI Elements Builder on QiCore 6.0.0 measures only', () => {
+// skipping until FF qiCoreElementsTab is released
+describe.skip('Check for UI Elements Builder on QiCore 6.0.0 measures only', () => {
 
     afterEach('Clean up', () => {
 


### PR DESCRIPTION
Skip tests in `Qi-CoreTestCaseElementsBuilder.cy.ts` until FF is ready for release.
Add scenario to `NegativeFeatureFlagTests` to account for that change.

