### PR TITLE
feat: round 2 of changes for acl sharing

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
@@ -3,6 +3,7 @@ import { OktaLogin } from "../../../../Shared/OktaLogin"
 import { Header } from "../../../../Shared/Header"
 import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
+import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
 
 let CQLLibraryName = 'TestLibrary' + Date.now()
 let newCQLLibraryName = ''
@@ -10,7 +11,6 @@ let randValue = (Math.floor((Math.random() * 1000) + 1))
 let updatedCQLLibraryName = CQLLibraryName + randValue + 'SomeUpdate' + 9
 let randomCQLLibraryName = 'TransferTestCQLLibrary' + randValue + 5
 let CQLLibraryPublisher = 'SemanticBits'
-let measureSharingAPIKey = Environment.credentials().deleteMeasureAdmin_API_Key
 let harpUserALT = Environment.credentials().harpUserALT
 let versionNumber = '1.0.000'
 
@@ -42,32 +42,7 @@ describe('CQL Library Sharing', () => {
         cy.wait(1000)
 
         //Share Library with ALT User
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/acls',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': measureSharingAPIKey
-                    },
-                    method: 'PUT',
-                    body: {
-                        "acls": [
-                            {
-                                "userId": harpUserALT,
-                                "roles": [
-                                    "SHARED_WITH"
-                                ]
-                            }
-                        ],
-                        "action": "GRANT"
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
-        })
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
         OktaLogin.AltLogin()
@@ -81,38 +56,13 @@ describe('CQL Library Sharing', () => {
 
     it('Verify CQL Library can be edited by the shared user', () => {
 
-        //Share Library with ALT User
         cy.clearCookies()
         cy.clearLocalStorage()
         //set local user that does not own the Library
         cy.setAccessTokenCookie()
         cy.wait(1000)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/acls',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': measureSharingAPIKey
-                    },
-                    method: 'PUT',
-                    body: {
-                        "acls": [
-                            {
-                                "userId": harpUserALT,
-                                "roles": [
-                                    "SHARED_WITH"
-                                ]
-                            }
-                        ],
-                        "action": "GRANT"
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
-        })
+        //Share Library with ALT User
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
         OktaLogin.AltLogin()
@@ -188,32 +138,7 @@ describe('CQL Library Sharing - Multiple instances', () => {
         //set local user that does not own the Library
         cy.setAccessTokenCookie()
         cy.wait(1000)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/acls',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': measureSharingAPIKey
-                    },
-                    method: 'PUT',
-                    body: {
-                        "acls": [
-                            {
-                                "userId": harpUserALT,
-                                "roles": [
-                                    "SHARED_WITH"
-                                ]
-                            }
-                        ],
-                        "action": "GRANT"
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
-        })
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
         OktaLogin.AltLogin()

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
@@ -3,6 +3,7 @@ import { OktaLogin } from "../../../../Shared/OktaLogin"
 import { Header } from "../../../../Shared/Header"
 import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
+import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
 
 let CQLLibraryName = 'TestLibrary' + Date.now()
 let newCQLLibraryName = ''
@@ -10,7 +11,6 @@ let randValue = (Math.floor((Math.random() * 1000) + 1))
 let updatedCQLLibraryName = CQLLibraryName + randValue + 'SomeUpdate' + 9
 let randomCQLLibraryName = 'TransferTestCQLLibrary' + randValue + 5
 let CQLLibraryPublisher = 'SemanticBits'
-let measureSharingAPIKey = Environment.credentials().deleteMeasureAdmin_API_Key
 let harpUserALT = Environment.credentials().harpUserALT
 let versionNumber = '1.0.000'
 
@@ -24,7 +24,6 @@ describe('CQL Library Transfer', () => {
         CQLLibraryPage.createCQLLibraryAPI(newCQLLibraryName, CQLLibraryPublisher)
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
     })
 
@@ -37,27 +36,11 @@ describe('CQL Library Transfer', () => {
     it('Verify transferred CQL Library is viewable under My Libraries tab', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         cy.wait(1000)
 
-        //Share Measure with ALT User
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/ownership?userid=' + harpUserALT,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': measureSharingAPIKey
-                    },
-                    method: 'PUT'
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(harpUserALT + ' granted ownership to Library successfully.')
-                })
-            })
-        })
+        //Share Library with ALT User
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
         OktaLogin.AltLogin()
@@ -66,33 +49,16 @@ describe('CQL Library Transfer', () => {
         cy.get(CQLLibraryPage.myLibrariesBtn).should('be.visible')
         cy.get(CQLLibraryPage.myLibrariesBtn).click().wait(1000)
         CQLLibrariesPage.validateCQLLibraryName(CQLLibraryName)
-
     })
 
     it('Verify CQL Library can be edited by the transferred user', () => {
 
-        //Share Measure with ALT User
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         cy.wait(1000)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/ownership?userid=' + harpUserALT,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': measureSharingAPIKey
-                    },
-                    method: 'PUT'
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(harpUserALT + ' granted ownership to Library successfully.')
-                })
-            })
-        })
+        //Share Library with ALT User
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
         OktaLogin.AltLogin()
@@ -119,7 +85,6 @@ describe('CQL Library Transfer - Multiple instances', () => {
         CQLLibraryPage.createAPICQLLibraryWithValidCQL(newCQLLibraryName, CQLLibraryPublisher)
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         OktaLogin.Login()
     })
@@ -161,28 +126,13 @@ describe('CQL Library Transfer - Multiple instances', () => {
         cy.get(CQLLibrariesPage.cqlLibraryVersionList).should('contain', 'Draft 1.0.000')
         cy.log('Draft Created Successfully')
 
-        //Share Measure with ALT User
+
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         cy.wait(1000)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/ownership?userid=' + harpUserALT,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': measureSharingAPIKey
-                    },
-                    method: 'PUT'
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(harpUserALT + ' granted ownership to Library successfully.')
-                })
-            })
-        })
+       //Share Library with ALT User
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
         OktaLogin.AltLogin()

--- a/cypress/e2e/WebInterface/CQL Library/CQLLibraryDelete.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQLLibraryDelete.cy.ts
@@ -3,14 +3,13 @@ import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 import { Environment } from "../../../Shared/Environment"
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { Header } from "../../../Shared/Header"
-import { Utilities } from "../../../Shared/Utilities"
+import { MadieObject, PermissionActions, Utilities } from "../../../Shared/Utilities"
 import { OktaLogin } from "../../../Shared/OktaLogin"
 
 let filePath = 'cypress/fixtures/cqlLibraryId'
 let CQLLibraryName = ''
 let CQLLibraryPublisher = 'SemanticBits'
 let harpUserALT = Environment.credentials().harpUserALT
-let adminApiKey : string = Environment.credentials().deleteMeasureAdmin_API_Key
 let measureCQLAlt = MeasureCQL.ICFCleanTestQICore
 
 describe('Delete CQL Library: Tests covering Libraries that are in draft and versioned states as well as when user is the owner, when user has had Library transferred to them, and when the user is neither the owner nor has had the Library transferred to them', () => {
@@ -56,6 +55,7 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
         })
 
     })
+
     it('Delete test Case - Draft Library - user is the owner of the Library', () => {
 
         cy.get(Header.cqlLibraryTab).click()
@@ -82,29 +82,16 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
             Utilities.waitForElementToNotExist('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]', 50000)
         })
     })
-    it('Delete test Case - Draft Library - user has had the Library transferred to them', () => {
+
+    // ToDo: title seems wrong. It says delete test case but tries to delete the whole library?
+    it.skip('Delete test Case - Draft Library - user has had the Library transferred to them', () => {
         OktaLogin.Logout()
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         cy.wait(1000)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/ownership?userid=' + harpUserALT,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': adminApiKey
-                    },
-                    method: 'PUT'
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(harpUserALT + ' granted ownership to Library successfully.')
-                })
-            })
-        })
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
+        
         cy.clearAllCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookieALT()
@@ -134,10 +121,10 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
             Utilities.waitForElementToNotExist('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]', 50000)
         })
     })
+
     it('Delete CQL Library - Versioned Library - user does not own nor has Library been shared with user', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {
@@ -209,34 +196,18 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
             cy.get('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]').click()
             Utilities.waitForElementToNotExist('[data-testid="delete-existing-draft-' + fileContents + '-button"]', 55000)
         })
-
     })
+
     it('Delete test Case - Versioned Library - user has had the Library transferred to them', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
-        //set local user that does not own the measure
         cy.setAccessTokenCookie()
         cy.wait(1000)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id + '/ownership?userid=' + harpUserALT,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value,
-                        'api-key': adminApiKey
-                    },
-                    method: 'PUT'
+        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(harpUserALT + ' granted ownership to Library successfully.')
-                })
-            })
-        })
         cy.clearCookies()
         cy.clearLocalStorage()
         OktaLogin.AltLogin()
-        //set local user that does not own the measure
         cy.setAccessTokenCookieALT()
         cy.wait(1000)
         cy.getCookie('accessToken').then((accessToken) => {


### PR DESCRIPTION
Continuing from https://github.com/MeasureAuthoringTool/madie-cypress/pull/1559

This PR updates several tests to use the simple interface of the Utility function, as well as cleaning up a few small process issues, whitespace, and comments.

Some of these tests were just updated for the new /acls endpoint, and some were still using the older /ownership and /grant endpoints.