### PR TITLE
Remove additional wait lines on regression tests

### DIFF
--- a/cypress/Shared/CQLLibrariesPage.ts
+++ b/cypress/Shared/CQLLibrariesPage.ts
@@ -29,8 +29,7 @@ export class CQLLibrariesPage {
         //Navigate to CQL Library Page
         cy.get(Header.cqlLibraryTab).should('exist')
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.get(Header.cqlLibraryTab).wait(2000).click()
-        cy.wait(2000)
+        cy.get(Header.cqlLibraryTab).click()
         Utilities.waitForElementVisible(CQLLibraryPage.LibFilterTextField, 60000)
         cy.readFile(filePath).should('exist').then((fileContents) => {
 
@@ -39,7 +38,7 @@ export class CQLLibrariesPage {
             cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').should('exist')
             cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid=cqlLibrary-button-' + fileContents + ']', 3500)
-            cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').wait(1000).click()
+            cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').click()
 
             cy.wait('@cqlLibrary').then(({ response }) => {
                 expect(response.statusCode).to.eq(200)
@@ -103,7 +102,7 @@ export class CQLLibrariesPage {
             Utilities.waitForElementVisible('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]', 50000)
             cy.get('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]', 50000)
-            cy.get('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]').should('be.enabled').wait(1000)
+            cy.get('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]').should('be.enabled')
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
                     cy.get('[data-testid="view/edit-cqlLibrary-button-' + fileContents + '"]').click()

--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -79,7 +79,7 @@ export class CQLLibraryPage {
         Utilities.waitForElementEnabled(CQLLibraryPage.createCQLLibraryBtn, 60000)
 
         cy.get(this.createCQLLibraryBtn).should('be.visible')
-        cy.get(this.createCQLLibraryBtn).should('be.enabled').wait(1500)
+        cy.get(this.createCQLLibraryBtn).should('be.enabled')
         cy.get(this.createCQLLibraryBtn).click()
 
         cy.get(this.newCQLLibName).should('be.visible')
@@ -92,7 +92,7 @@ export class CQLLibraryPage {
 
         this.clickCreateLibraryButton()
         cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.get(Header.cqlLibraryTab).wait(1000).click()
+        cy.get(Header.cqlLibraryTab).click()
 
         this.validateCQlLibraryName(CQLLibraryName)
         this.validateCQlLibraryModel('QI-Core')
@@ -169,7 +169,7 @@ export class CQLLibraryPage {
         //setup for grabbing the measure create call
         cy.intercept('POST', '/api/cql-libraries').as(alias)
 
-        cy.get(this.saveCQLLibraryBtn).wait(1000).click()
+        cy.get(this.saveCQLLibraryBtn).click()
         //saving measureID to file to use later
         cy.wait('@' + alias).then(({ response }) => {
             expect(response.statusCode).to.eq(201)

--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -98,7 +98,6 @@ export class CreateMeasurePage {
         }
         Utilities.waitForElementVisible(LandingPage.newMeasureButton, 30000)
         Utilities.waitForElementEnabled(LandingPage.newMeasureButton, 30000)
-        cy.wait(2000)
         cy.get(LandingPage.newMeasureButton).click({ force: true })
         cy.get(this.measureNameTextbox).type(measureName)
         cy.get(this.measureModelDropdown).click()
@@ -482,7 +481,7 @@ export class CreateMeasurePage {
         if (optionalParams && optionalParams.blankMetadata) {
             measureMetadata = {
                 "experimental": false,
-                "steward": undefined, 
+                "steward": undefined,
                 "developers": []
             }
         } else {
@@ -494,7 +493,7 @@ export class CreateMeasurePage {
                     "id": "64120f265de35122e68dac40",
                     "oid": "02c84f54-919b-4464-bf51-a1438f2710e2",
                     "url": "https://semanticbits.com/"
-                }, 
+                },
                 "developers": [
                     {
                         "id": "64120f265de35122e68dabf7",

--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -185,7 +185,6 @@ export class EditMeasurePage {
     public static actionCenter(action: EditMeasureActions): void {
 
         cy.get(this.editMeasureButtonActionBtn).click()
-        cy.wait(500)
 
         switch (action) {
 
@@ -215,7 +214,6 @@ export class EditMeasurePage {
                 cy.get(MeasuresPage.versionMeasuresSelectionButton).click()
                 cy.get(MeasuresPage.measureVersionMajor).click()
                 // need a short pause here for the modal to present new fields
-                cy.wait(1500)
 
                 cy.get('#new-version').invoke('val').then(value => {
                     cy.get(MeasuresPage.confirmMeasureVersionNumber).type(value.toString())
@@ -246,7 +244,6 @@ export class EditMeasurePage {
             }
             default: { }
 
-            cy.wait(1500)
         }
     }
 }

--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -57,7 +57,6 @@ export class MeasuresPage {
         cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {
             Utilities.waitForElementVisible('[data-testid=measure-action-' + fileContents + ']', 100000)
             cy.get('[data-testid=measure-action-' + fileContents + ']').parent()
-            cy.wait(4270)
             cy.reload()
             cy.get('[data-testid="measure-name-' + fileContents + '_version"]').should('contain', versionNumber)
         })
@@ -79,7 +78,7 @@ export class MeasuresPage {
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
 
-                    cy.get('[data-testid="measure-action-' + fileContents + '"]').wait(1500).click()
+                    cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     Utilities.waitForElementVisible('[data-testid="view-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="view-measure-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="view-measure-' + fileContents + '"]', 105000)
@@ -90,7 +89,7 @@ export class MeasuresPage {
                 }
                 case 'export': {
 
-                    cy.get('[data-testid="measure-action-' + fileContents + '"]').wait(1500).click()
+                    cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="view-measure-' + fileContents + '"]').should('be.visible')
@@ -107,7 +106,7 @@ export class MeasuresPage {
                 }
                 case 'qdmexport': {
 
-                    cy.get('[data-testid="measure-action-' + fileContents + '"]').wait(1500).scrollIntoView()
+                    cy.get('[data-testid="measure-action-' + fileContents + '"]').scrollIntoView()
                     cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
                     Utilities.waitForElementVisible('[data-testid="export-measure-' + fileContents + '"]', 105000)
@@ -125,7 +124,7 @@ export class MeasuresPage {
                 }
                 case 'version': {
 
-                    cy.get('[data-testid="measure-action-' + fileContents + '"]').wait(1500).click()
+                    cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     Utilities.waitForElementVisible('[data-testid="create-version-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="create-version-measure-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="create-version-measure-' + fileContents + '"]', 105000)
@@ -135,7 +134,7 @@ export class MeasuresPage {
                 }
                 case 'draft': {
 
-                    cy.get('[data-testid="measure-action-' + fileContents + '"]').wait(1500).click()
+                    cy.get('[data-testid="measure-action-' + fileContents + '"]').click()
                     Utilities.waitForElementVisible('[data-testid="draft-measure-' + fileContents + '"]', 105000)
                     cy.get('[data-testid="draft-measure-' + fileContents + '"]').should('be.visible')
                     Utilities.waitForElementEnabled('[data-testid="draft-measure-' + fileContents + '"]', 105000)
@@ -211,7 +210,7 @@ export class MeasuresPage {
                 })
 
                 cy.get('[data-testid="version-action-btn"]').should('be.visible')
-                cy.get('[data-testid="version-action-btn"]').wait(2000).click()
+                cy.get('[data-testid="version-action-btn"]').click()
 
                 break
             }
@@ -238,12 +237,12 @@ export class MeasuresPage {
                 //there is a prerequisite that you have a measure created and measure ID stored for 'measureId' and 'measureId2'
                 cy.readFile('cypress/fixtures/measureId2').should('exist').then((fileContents) => {
                     Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 500000)
-                    cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().wait(3500).click()
+                    cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
                 })
 
                 cy.get('[data-testid="associate-cms-id-action-btn"]').should('be.visible')
                 cy.get('[data-testid="associate-cms-id-action-btn"]').should('be.enabled')
-                cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView().wait(2000).click()
+                cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView().click()
 
                 cy.get('[data-testid="associate-cms-id-button"]').should('be.visible')
                 cy.get('[data-testid="associate-cms-id-button"]').should('be.enabled')

--- a/cypress/Shared/OktaLogin.ts
+++ b/cypress/Shared/OktaLogin.ts
@@ -25,7 +25,6 @@ export class OktaLogin {
         cy.clearAllCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookieALT()
-        cy.wait(1000)
 
         cy.visit('/login', { onBeforeLoad: (win) => { win.sessionStorage.clear() } })
 
@@ -33,7 +32,6 @@ export class OktaLogin {
         cy.get(this.usernameInput, { timeout: 110000 }).should('be.visible')
         cy.get(this.passwordInput, { timeout: 110000 }).should('be.enabled')
         cy.get(this.passwordInput, { timeout: 110000 }).should('be.visible')
-        cy.wait(3000)
         cy.get(this.usernameInput).type(Environment.credentials().harpUserALT)
         cy.get(this.passwordInput).type(Environment.credentials().passwordALT)
         cy.get(this.signInButton, { timeout: 110000 }).should('be.enabled')
@@ -72,7 +70,6 @@ export class OktaLogin {
         cy.get(this.usernameInput, { timeout: 110000 }).should('be.visible')
         cy.get(this.passwordInput, { timeout: 110000 }).should('be.enabled')
         cy.get(this.passwordInput, { timeout: 110000 }).should('be.visible')
-        cy.wait(3000)
         cy.get(this.usernameInput).type(Environment.credentials().harpUser)
         cy.get(this.passwordInput).type(Environment.credentials().password)
         cy.get(this.signInButton, { timeout: 110000 }).should('be.enabled')
@@ -94,7 +91,6 @@ export class OktaLogin {
 
         })
         cy.get(LandingPage.newMeasureButton).should('be.visible')
-        cy.wait(2050)
         cy.log('Login Successful')
     }
 
@@ -128,7 +124,6 @@ export class OktaLogin {
 
     public static UILogout(): void {
 
-        //cy.wait(7000)
         Utilities.waitForElementVisible(Header.userProfileSelect, 500000)
         cy.get(Header.userProfileSelect).scrollIntoView()
         cy.get(Header.userProfileSelect).click()

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -588,7 +588,6 @@ export class TestCasesPage {
         cy.readFile(elementIdPath).should('exist').then((fileContents) => {
             Utilities.waitForElementEnabled('[data-testid="view-element-btn-' + fileContents + '"]', 50000)
             cy.get('[data-testid="view-element-btn-' + fileContents + '"]').should('be.enabled')
-            cy.wait(6000)
             cy.get('[data-testid="view-element-btn-' + fileContents + '"]').scrollIntoView()
             cy.scrollTo(0, 500)
             Utilities.waitForElementVisible('[data-testid="view-element-btn-' + fileContents + '"]', 50000)
@@ -644,7 +643,7 @@ export class TestCasesPage {
             Utilities.waitForElementVisible('[data-testid="select-action-' + fileContents + '"]', 50000)
             cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid="select-action-' + fileContents + '"]', 50000)
-            cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled').wait(1000)
+            cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled')
             switch ((action.valueOf()).toString().toLowerCase()) {
                 case "edit": {
                     cy.get('[data-testid="select-action-' + fileContents + '"]').scrollIntoView().click({ force: true })
@@ -716,7 +715,7 @@ export class TestCasesPage {
 
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click().wait(3500)
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(this.newTestCaseButton).should('be.visible')
         cy.get(this.newTestCaseButton).should('be.enabled')
         cy.get(this.newTestCaseButton).click()
@@ -724,7 +723,7 @@ export class TestCasesPage {
         cy.get(this.createTestCaseDialog).should('exist')
         cy.get(this.createTestCaseDialog).should('be.visible')
 
-        cy.get(this.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(this.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(this.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(this.createTestCaseTitleInput, 30000)
         cy.get(this.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -755,7 +754,7 @@ export class TestCasesPage {
         cy.get(this.createTestCaseDialog).should('exist')
         cy.get(this.createTestCaseDialog).should('be.visible')
 
-        cy.get(this.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(this.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(this.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(this.createTestCaseTitleInput, 30000)
         cy.get(this.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -784,7 +783,7 @@ export class TestCasesPage {
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
         cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
-        cy.get(TestCasesPage.aceEditor).wait(500).type(err_TestCaseJson, { parseSpecialCharSequences: false })
+        cy.get(TestCasesPage.aceEditor).type(err_TestCaseJson, { parseSpecialCharSequences: false })
 
         cy.log('Erroneous JSON added to test case successfully')
     }
@@ -803,14 +802,14 @@ export class TestCasesPage {
         Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(800)
+        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
 
         cy.get(this.aceEditor).type(testCaseJson, { parseSpecialCharSequences: false })
 
         cy.get(this.detailsTab).click()
 
         //Save edited / updated to test case
-        cy.get(this.editTestCaseSaveButton).click().wait(1000)
+        cy.get(this.editTestCaseSaveButton).click()
         cy.log('JSON added to test case successfully')
 
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -1007,7 +1006,7 @@ export class TestCasesPage {
     public static ImportTestCaseFile(TestCaseFile: string | string[]): void {
 
         //Upload valid Json file
-        cy.get(this.testCaseFileImport).attachFile(TestCaseFile).wait(1000)
+        cy.get(this.testCaseFileImport).attachFile(TestCaseFile)
 
         cy.get(this.importTestCaseSuccessMsg).should('contain.text', 'Test Case JSON copied into editor. QI-Core Defaults have been added. Please review and save your Test Case.')
 
@@ -1018,7 +1017,7 @@ export class TestCasesPage {
     public static ValidateValueAddedToTestCaseJson(ValueToBeAdded: string | string[]): void {
 
         cy.get(this.aceEditor).should('exist')
-        cy.get(this.aceEditor).should('be.visible').wait(1000)
+        cy.get(this.aceEditor).should('be.visible')
         //cy.get(this.aceEditorJsonInput).should('exist')
         cy.get(this.aceEditor).invoke('text').then(
             (text) => {
@@ -1038,7 +1037,7 @@ export class TestCasesPage {
         cy.get(TestCasesPage.QDMGenderOption).contains(gender).click()
         cy.get(TestCasesPage.QDMEthnicity).click()
         cy.get('[data-value="' + ethnicity + '"]').click()
-        cy.get(TestCasesPage.QDMDob).clear().wait(1700).click().wait(1000)
+        cy.get(TestCasesPage.QDMDob).clear().click()
         cy.get(TestCasesPage.QDMDob).type(dob).click()
     }
 }

--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -621,18 +621,16 @@ export class Utilities {
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').wait(500).type('{enter}')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
     }
 
     public static validateErrors(errorElementObject: string, errorContainer: string, errorMsg1: string, errorMsg2?: string): void {
 
         cy.get(errorElementObject).should('exist')
         cy.get(errorElementObject).should('be.visible')
-        cy.get(errorElementObject).invoke('show').wait(1000).click({ force: true, multiple: true })
-        // cy.wait(1000)
+        cy.get(errorElementObject).invoke('show').click({ force: true, multiple: true })
         // cy.get(errorContainer).invoke('show').should('contain.text', errorMsg1)
         if ((errorMsg1 != null) || (errorMsg1 != undefined)) {
-            cy.wait(1000)
             cy.get(errorContainer).invoke('show').should('contain', errorMsg1)
         }
 

--- a/cypress/Shared/umlsLoginForm.ts
+++ b/cypress/Shared/umlsLoginForm.ts
@@ -23,8 +23,8 @@ export class umlsLoginForm {
         //umls login link appears and is available to click, at the top of the page
         cy.get(Header.umlsLoginButton).should('exist')
         cy.get(Header.umlsLoginButton).should('be.visible')
-        cy.get(Header.umlsLoginButton).should('be.enabled').wait(1000)
-        cy.get(Header.umlsLoginButton).click().wait(1000)
+        cy.get(Header.umlsLoginButton).should('be.enabled')
+        cy.get(Header.umlsLoginButton).click()
 
         //form to enter API and to actually log into UMLS appears and is available to read and enter API key
         cy.get(umlsLoginForm.umlsForm).should('exist')

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
@@ -59,7 +59,6 @@ describe('CQL Library Sharing', () => {
         cy.clearLocalStorage()
         //set local user that does not own the Library
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         //Share Library with ALT User
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
@@ -136,7 +135,6 @@ describe('CQL Library Sharing - Multiple instances', () => {
         cy.clearLocalStorage()
         //set local user that does not own the Library
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
@@ -157,7 +155,6 @@ describe('Remove user\'s share access from a library', () => {
         cy.clearAllCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.wait(1000)
 
         CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
@@ -55,7 +55,6 @@ describe('CQL Library Transfer', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         //Share Library with ALT User
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
@@ -128,7 +127,6 @@ describe('CQL Library Transfer - Multiple instances', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         //Share Library with ALT User
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 

--- a/cypress/e2e/WebInterface/CQL Library/CQLLibraryDelete.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQLLibraryDelete.cy.ts
@@ -89,7 +89,6 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         cy.clearAllCookies()
@@ -200,7 +199,6 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         cy.clearCookies()

--- a/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
@@ -179,7 +179,6 @@ describe('Measure Sharing - Multiple instances', () => {
         cy.clearLocalStorage()
         //set local user that does not own the measure
         cy.setAccessTokenCookie()
-        cy.wait(1000)
         //Share Measure with ALT User
         Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
 
@@ -248,7 +247,6 @@ describe('Remove user\'s share access from a measure', () => {
         cy.clearAllCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.wait(1000)
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL)
 

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateUpdateTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateUpdateTestCase.cy.ts
@@ -1,5 +1,5 @@
 import { OktaLogin } from "../../../Shared/OktaLogin"
-import {CreateMeasurePage, SupportedModels} from "../../../Shared/CreateMeasurePage"
+import { CreateMeasurePage, SupportedModels } from "../../../Shared/CreateMeasurePage"
 import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
 import { MeasuresPage } from "../../../Shared/MeasuresPage"
 import { TestCasesPage } from "../../../Shared/TestCasesPage"
@@ -132,7 +132,7 @@ describe('Create and Update Test Case for Qi Core 6 Measure', () => {
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -162,7 +162,7 @@ describe('Create and Update Test Case for Qi Core 6 Measure', () => {
         cy.get(TestCasesPage.detailsTab).click()
 
         //Save edited / updated to test case
-        cy.get(TestCasesPage.editTestCaseSaveButton).click().wait(1000)
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.log('JSON added to test case successfully')
 
         //Verify Last Saved Date on Test case list page

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
@@ -56,8 +56,8 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
         cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).wait(1000).check()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).wait(1000).should('be.checked')
+        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check()
+        cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Validate measure observation expected values
         cy.get(TestCasesPage.measureObservationRow).clear().type('@#')
@@ -89,7 +89,7 @@ describe('Measure Observation Expected values', () => {
 
         //Add Denominator Observation
         cy.log('Adding Measure Observations')
-        cy.get(MeasureGroupPage.addDenominatorObservationLink).wait(1000).click()
+        cy.get(MeasureGroupPage.addDenominatorObservationLink).click()
         cy.get(MeasureGroupPage.denominatorObservation).click()
         cy.get('[data-value="booleanFunction"]').click() //select booleanFunction
         cy.get(MeasureGroupPage.denominatorAggregateFunction).click()
@@ -118,10 +118,10 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
         cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).wait(1000).check()
-        cy.get(TestCasesPage.testCaseDENOMExpected).wait(1000).should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).wait(1000).check()
-        cy.get(TestCasesPage.testCaseNUMERExpected).wait(1000).should('be.checked')
+        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
+        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         //Validate measure observation expected values
         cy.get(TestCasesPage.denominatorObservationRow).type('@#')
@@ -161,8 +161,8 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
         cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).wait(1000).check()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).wait(1000).should('be.checked')
+        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check()
+        cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Enter value in to Measure observation Expected values
         cy.get(TestCasesPage.measureObservationRow).type('1.3')
@@ -297,7 +297,7 @@ describe('Measure observation expected result', () => {
 
         //Add Denominator Observation
         cy.log('Adding Measure Observations')
-        cy.get(MeasureGroupPage.addDenominatorObservationLink).wait(1000).click()
+        cy.get(MeasureGroupPage.addDenominatorObservationLink).click()
         cy.get(MeasureGroupPage.denominatorObservation).click()
         cy.get(MeasureGroupPage.measureObservationSelect).should('exist')
         cy.get(MeasureGroupPage.measureObservationSelect).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
@@ -133,7 +133,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).wait(1000).click()
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
         TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, validTestCaseJson)
@@ -165,7 +165,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).wait(1000).click()
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
         //Create Measure Group
@@ -270,7 +270,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).wait(1000).click()
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
         //Create Measure Group
@@ -357,7 +357,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).wait(1000).click()
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
         //Create Measure Group
@@ -536,7 +536,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
         cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
-        cy.get(TestCasesPage.aceEditor).wait(500).type(validTestCaseJson, { parseSpecialCharSequences: false })
+        cy.get(TestCasesPage.aceEditor).type(validTestCaseJson, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -574,7 +574,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
         //Click on Execute Test Case button on Edit Test Case page
         cy.get(EditMeasurePage.testCasesTab).should('exist')
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).wait(3000).click()
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('exist')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
@@ -718,16 +718,16 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         //Verify Highlighting tab before clicking on Run Test button
         cy.get(TestCasesPage.tcHighlightingTab).click()
-        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'').wait(1000)
+        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
 
         //Click on Execute Test Case button on Edit Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click().wait(1000)
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('exist')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
         cy.get(TestCasesPage.executeTestCaseButton).focus()
         cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
-        cy.get(TestCasesPage.executeTestCaseButton).click().wait(1000)
+        cy.get(TestCasesPage.executeTestCaseButton).click()
         //cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
 
@@ -812,7 +812,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
         cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
-        cy.get(TestCasesPage.aceEditor).wait(500).type(validTestCaseJson, { parseSpecialCharSequences: false })
+        cy.get(TestCasesPage.aceEditor).type(validTestCaseJson, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -839,7 +839,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         //Verify Highlighting tab before clicking on Run Test button
         cy.get(TestCasesPage.tcHighlightingTab).click()
-        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'').wait(1000)
+        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
 
         //create a test case that will fail:
 
@@ -878,11 +878,11 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
         cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
-        cy.get(TestCasesPage.aceEditor).wait(500).type(validTestCaseJson, { parseSpecialCharSequences: false })
+        cy.get(TestCasesPage.aceEditor).type(validTestCaseJson, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
 
@@ -986,7 +986,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
 
@@ -1139,7 +1139,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).click({ force: true }).wait(1000)
+        cy.get(TestCasesPage.editTestCaseSaveButton).click({ force: true })
 
         //Verify Highlighting tab before clicking on Run Test button
         cy.get(TestCasesPage.tcHighlightingTab).click()
@@ -1159,7 +1159,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         //refresh test case list page
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click().wait(2000)
+        cy.get(EditMeasurePage.testCasesTab).click()
 
         //open edit page for test case
         TestCasesPage.clickEditforCreatedTestCase()
@@ -1254,7 +1254,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
 
@@ -1276,12 +1276,12 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).click({ force: true }).wait(1000)
+        cy.get(TestCasesPage.editTestCaseSaveButton).click({ force: true })
 
         //Click on Execute Test Case button on Edit Test Case page
         Utilities.waitForElementVisible(EditMeasurePage.testCasesTab, 30000)
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).wait(500).click()
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
 
         //refresh test case list page
@@ -1380,7 +1380,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(2000).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
 
@@ -1406,7 +1406,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         //Click on Execute Test Case button on Edit Test Case page
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).wait(500).click()
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
 
         //refresh test case list page
@@ -1660,7 +1660,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             cy.get(TestCasesPage.confirmationMsg).should('have.text', 'Test case updated successfully with warnings in JSON')
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click().wait(2000)
+            cy.get(EditMeasurePage.testCasesTab).click()
 
             TestCasesPage.clickEditforCreatedTestCase()
 
@@ -1676,11 +1676,11 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-            cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
+            cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
             //Verify Highlighting tab before clicking on Run Test button
             cy.get(TestCasesPage.tcHighlightingTab).click()
-            cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'').wait(1500)
+            cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
 
             //Click on Execute Test Case button on Edit Test Case page
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -1696,7 +1696,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             //refresh test case list page
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click().wait(2000)
+            cy.get(EditMeasurePage.testCasesTab).click()
 
             //open edit page for test case
             TestCasesPage.clickEditforCreatedTestCase()
@@ -1735,7 +1735,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
 
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click().wait(2000)
+            cy.get(EditMeasurePage.testCasesTab).click()
 
             TestCasesPage.clickEditforCreatedTestCase()
 
@@ -1795,7 +1795,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
 
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click().wait(2000)
+            cy.get(EditMeasurePage.testCasesTab).click()
 
             TestCasesPage.clickEditforCreatedTestCase()
 
@@ -1838,7 +1838,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
 
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click().wait(2000)
+            cy.get(EditMeasurePage.testCasesTab).click()
 
             TestCasesPage.clickEditforCreatedTestCase()
 
@@ -1963,7 +1963,7 @@ describe('Verify multiple IPs on the highlighting tab', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).wait(4000).click()
+        cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
         TestCasesPage.testCaseAction('edit')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExpectedValues.cy.ts
@@ -173,11 +173,11 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         //Delete Measure group
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
         cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
-        cy.get(EditMeasurePage.measureGroupsTab).wait(2000).click()
+        cy.get(EditMeasurePage.measureGroupsTab).click()
         cy.get(MeasureGroupPage.deleteGroupbtn).should('exist').should('be.visible').should('be.enabled')
         cy.get(MeasureGroupPage.deleteGroupbtn).click()
         cy.get(MeasureGroupPage.yesDeleteModalbtn).should('exist').should('be.visible').should('be.enabled')
-        cy.get(MeasureGroupPage.yesDeleteModalbtn).click().wait(1000)
+        cy.get(MeasureGroupPage.yesDeleteModalbtn).click()
         cy.get('[data-testid="save-measure-group-validation-message"]').should('contain.text', 'You must set all required Populations.')
 
         //Navigate to Edit Test Case page and assert Measure group after deletion

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
@@ -64,12 +64,12 @@ describe('MADIE Zip Test Case Import', () => {
     it('MADIE Zip Test Case Import', () => {
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -125,7 +125,7 @@ describe('MADIE Zip Test Case Import', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.exportTestCasesBtn).scrollIntoView().click({ force: true })
         Utilities.waitForElementVisible(TestCasesPage.exportCollectionTypeOption, 35000)
-        cy.get(TestCasesPage.exportCollectionTypeOption).wait(2000).scrollIntoView().click({ force: true })
+        cy.get(TestCasesPage.exportCollectionTypeOption).scrollIntoView().click({ force: true })
 
         //verify that the export occurred
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
@@ -280,12 +280,12 @@ describe('MADIE Zip Test Case Import: error message should appear when the .madi
     it('MADIE Zip Test Case Import: error message appears when .madie file is missing from the .zip file', () => {
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -301,7 +301,7 @@ describe('MADIE Zip Test Case Import: error message should appear when the .madi
         Utilities.waitForElementVisible(TestCasesPage.tcImportButton, 3750)
 
         //Upload valid Json file via drag and drop
-        cy.get(TestCasesPage.tcFileDrop).find(TestCasesPage.tcFileDropInput).attachFile("TestCase7345TsteCQM-v0.0.000-FHIR4-TestCases.zip").wait(3000)
+        cy.get(TestCasesPage.tcFileDrop).find(TestCasesPage.tcFileDropInput).attachFile("TestCase7345TsteCQM-v0.0.000-FHIR4-TestCases.zip")
         cy.get(TestCasesPage.tcImportError).should('contain.text', 'Zip file is in an incorrect format. If this is an export prior to June 20, 2024 please reexport your test case and try again.')
 
         //close the test case import modal

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExport.cy.ts
@@ -48,12 +48,12 @@ describe('QI-Core Single Test Case Export', () => {
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit')
 
@@ -140,12 +140,12 @@ describe('QI-Core Test Case Export for all test cases', () => {
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit')
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
@@ -52,16 +52,16 @@ describe('QI-Core: Export Bundle options: Transaction or Collection', () => {
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(3000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(3000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
         cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
@@ -77,7 +77,7 @@ describe('QI-Core: Export Bundle options: Transaction or Collection', () => {
             Utilities.waitForElementVisible('[data-testid="select-action-' + fileContents + '"]', 50000)
             cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid="select-action-' + fileContents + '"]', 50000)
-            cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled').wait(1000)
+            cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled')
             cy.get('[data-testid="select-action-' + fileContents + '"]').click()
             cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
             Utilities.waitForElementVisible('[data-testid="export-transaction-bundle-' + fileContents + '"]', 55000)
@@ -94,16 +94,16 @@ describe('QI-Core: Export Bundle options: Transaction or Collection', () => {
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(3000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(3000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
         cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
@@ -119,7 +119,7 @@ describe('QI-Core: Export Bundle options: Transaction or Collection', () => {
             Utilities.waitForElementVisible('[data-testid="select-action-' + fileContents + '"]', 50000)
             cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.visible')
             Utilities.waitForElementEnabled('[data-testid="select-action-' + fileContents + '"]', 50000)
-            cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled').wait(1000)
+            cy.get('[data-testid="select-action-' + fileContents + '"]').should('be.enabled')
             cy.get('[data-testid="select-action-' + fileContents + '"]').click()
             cy.intercept('GET', '/api/measures/' + fileContents + '/exports').as('measureExport')
             Utilities.waitForElementVisible('[data-testid="export-collection-bundle-' + fileContents + '"]', 55000)
@@ -155,16 +155,16 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(3000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(3000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
 
@@ -181,8 +181,8 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         cy.log('Successfully verified zip file export')
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -204,14 +204,14 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
 
         //import the tests cases from selected / dragged and dropped .zip file
-        cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate + 'Select')
 
         //navigate to test case edit / detail page
         TestCasesPage.testCaseAction('edit')
 
-        cy.get(TestCasesPage.aceEditor).wait(3000).should('include.text', '"type": "transaction"')
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
 
     })
 })
@@ -242,16 +242,16 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(3000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(3000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
 
@@ -266,13 +266,13 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(TestCasesPage.exportTransactionTypeOption).scrollIntoView().click({ force: true })
 
         //verify that the export occurred 
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist').wait(1000)
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
         cy.log('Successfully verified zip file export')
 
         cy.reload()
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -294,14 +294,14 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
 
         //import the tests cases from selected / dragged and dropped .zip file
-        cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/A' + testCaseSeries + 'b' + 'Title for Auto Testb' + testCaseDescription + 'b' + todaysDate + 'Select1N/A' + testCaseSeries + 'a' + 'Title for Auto Testa' + testCaseDescription + 'a' + todaysDate + 'Select')
 
         //navigate to test case edit / detail page for the first test case
         TestCasesPage.testCaseAction('edit')
 
-        cy.get(TestCasesPage.aceEditor).wait(3000).should('include.text', '"type": "transaction"')
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
 
         //Navigate to Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -309,7 +309,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         //navigate to test case edit / detail page for the second test case
         TestCasesPage.testCaseAction('edit', true)
 
-        cy.get(TestCasesPage.aceEditor).wait(3000).should('include.text', '"type": "transaction"')
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
 
 
     })
@@ -341,16 +341,16 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(3000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(3000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
 
@@ -367,8 +367,8 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         cy.log('Successfully verified zip file export')
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -390,14 +390,14 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
 
         //import the tests cases from selected / dragged and dropped .zip file
-        cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate + 'Select')
 
         //navigate to test case edit / detail page
         TestCasesPage.testCaseAction('edit')
 
-        cy.get(TestCasesPage.aceEditor).wait(3000).should('include.text', '"type": "collection"')
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
 
     })
 })
@@ -428,16 +428,16 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(3000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(3000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
 
@@ -452,13 +452,13 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(TestCasesPage.exportCollectionTypeOption).scrollIntoView().click({ force: true })
 
         //verify that the export occurred 
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist').wait(1000)
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
         cy.log('Successfully verified zip file export')
 
         cy.reload()
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -480,14 +480,14 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
 
         //import the tests cases from selected / dragged and dropped .zip file
-        cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesbTitle for Auto Testb' + testCaseDescription + 'b' + todaysDate + 'Select1N/ASBTestSeriesaTitle for Auto Testa' + testCaseDescription + 'a' + todaysDate + 'Select')
 
         //navigate to test case edit / detail page for the first test case
         TestCasesPage.testCaseAction('edit')
 
-        cy.get(TestCasesPage.aceEditor).wait(3000).should('include.text', '"type": "collection"')
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
 
         //Navigate to Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -495,7 +495,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         //navigate to test case edit / detail page for the second test case
         TestCasesPage.testCaseAction('edit', true)
 
-        cy.get(TestCasesPage.aceEditor).wait(3000).should('include.text', '"type": "collection"')
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
 
 
     })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -87,12 +87,12 @@ describe('Test Case Import: functionality tests', () => {
 
         OktaLogin.Login()
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(3000)
-        cy.get(Header.cqlLibraryTab).click().wait(3000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -141,9 +141,9 @@ describe('Test Case Import: functionality tests', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //export test case
-        cy.get(TestCasesPage.exportTestCasesBtn).scrollIntoView().wait(1000).click({ force: true })
+        cy.get(TestCasesPage.exportTestCasesBtn).scrollIntoView().click({ force: true })
         Utilities.waitForElementVisible(TestCasesPage.exportCollectionTypeOption, 35000)
-        cy.get(TestCasesPage.exportCollectionTypeOption).wait(2000).scrollIntoView().click({ force: true })
+        cy.get(TestCasesPage.exportCollectionTypeOption).scrollIntoView().click({ force: true })
 
         //verify that the export occurred 
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
@@ -176,7 +176,7 @@ describe('Test Case Import: functionality tests', () => {
         //export test case
         cy.get(TestCasesPage.exportTestCasesBtn).scrollIntoView().click({ force: true })
         Utilities.waitForElementVisible(TestCasesPage.exportCollectionTypeOption, 35000)
-        cy.get(TestCasesPage.exportCollectionTypeOption).wait(2000).scrollIntoView().click({ force: true })
+        cy.get(TestCasesPage.exportCollectionTypeOption).scrollIntoView().click({ force: true })
 
         //verify that the export occurred 
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
@@ -280,16 +280,16 @@ describe('Test Case Import validations for versioned Measures', () => {
 
         //navigating to the All Measures tab
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 45000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible').wait(4000)
-        cy.get(MeasuresPage.allMeasuresTab).click().wait(4000)
+        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
+        cy.get(MeasuresPage.allMeasuresTab).click()
 
         Utilities.waitForElementVisible(Header.cqlLibraryTab, 45000)
-        cy.get(Header.cqlLibraryTab).should('be.visible').wait(4000)
-        cy.get(Header.cqlLibraryTab).click().wait(4000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 45000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(4000)
-        cy.get(Header.mainMadiePageButton).click().wait(4000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 45000)
         cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
@@ -460,7 +460,7 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         MeasuresPage.actionCenter('edit', 2)
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().wait(1000).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
@@ -481,8 +481,8 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         cy.get(MeasureGroupPage.successfulSaveMsg).should('contain.text', 'Population details for this group updated successfully.')
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit', 2)
@@ -493,7 +493,7 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         //export test case
         cy.get(TestCasesPage.exportTestCasesBtn).scrollIntoView().click({ force: true })
         Utilities.waitForElementVisible(TestCasesPage.exportCollectionTypeOption, 35000)
-        cy.get(TestCasesPage.exportCollectionTypeOption).wait(2000).scrollIntoView().click({ force: true })
+        cy.get(TestCasesPage.exportCollectionTypeOption).scrollIntoView().click({ force: true })
 
         //verify that the export occurred 
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
@@ -502,8 +502,8 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         cy.reload()
         cy.get(EditMeasurePage.testCasesTab).click()
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -529,11 +529,11 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
-     
+
         // checks for details of tc1 and tc2, but does not care about order
         cy.get(TestCasesPage.testCaseListTable).contains(/SBTestSeriesFb2Failing Test Caseb2DENOMFailb2/).should('exist')
         cy.get(TestCasesPage.testCaseListTable).contains(/SBTestSeriesPb1Passing Test Caseb1DENOMPassb1/).should('exist')
-        
+
         //verify confirmation message
         Utilities.waitForElementVisible(TestCasesPage.importTestCaseSuccessInfo, 35000)
 
@@ -601,7 +601,7 @@ describe('Test case uniqueness error validation', () => {
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle + 'b1')
@@ -620,8 +620,8 @@ describe('Test case uniqueness error validation', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -643,7 +643,7 @@ describe('Test case uniqueness error validation', () => {
         cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
 
         //import the tests cases from selected / dragged and dropped .zip file
-        cy.get(TestCasesPage.importTestCaseBtnOnModal).click().wait(2000)
+        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1InvalidSBTestSeriesPb1Passing Test Caseb1' + testCaseDescription + 'b1' + todaysDate + 'Select')
 
@@ -708,8 +708,8 @@ describe('Test Case Import: New Test cases on measure validations: PC does not m
         cy.get(EditMeasurePage.testCasesTab).click()
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible').wait(3000)
-        cy.get(Header.mainMadiePageButton).click().wait(3000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -736,7 +736,7 @@ describe('Test Case Import: New Test cases on measure validations: PC does not m
         // checks for details of tc1 and tc2, but does not care about order
         cy.get(TestCasesPage.testCaseListTable).contains(/SBTestSeriesFb2Failing Test Caseb2DENOMFailb2/).should('exist')
         cy.get(TestCasesPage.testCaseListTable).contains(/SBTestSeriesPb1Passing Test Caseb1DENOMPassb1/).should('exist')
-        
+
         //verifies alert message at tope of page informing user that no test case was imported
         Utilities.waitForElementVisible(TestCasesPage.importTestCaseAlertMessage, 35000)
         cy.get(TestCasesPage.importTestCaseAlertMessage).find('[id="content"]').should('contain.text', 'Following test case(s) were imported successfully, but the measure populations do not match the populations in the import file. The Test Case has been imported, but no expected values have been')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
@@ -84,7 +84,7 @@ describe('Test Case sorting by Test Case number', () => {
 
         // test for https://jira.cms.gov/browse/MAT-7893
         TestCasesPage.testCaseAction('edit')
-        cy.get(TestCasesPage.testCasesBCText).should('contain.text', 'Case #1:')    
+        cy.get(TestCasesPage.testCasesBCText).should('contain.text', 'Case #1:')
 
         TestCasesPage.createTestCase(testCaseTitle2nd, testCaseDescription2nd, testCaseSeries2nd, testCaseJson2nd)
 
@@ -111,9 +111,9 @@ describe('Test Case sorting by Test Case number', () => {
         cy.get(TestCasesPage.tcColumnHeading).contains('Case #').find(TestCasesPage.tcColumnAscendingArrow).should('exist')
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ATest Series 1Test Case 1' + testCaseDescription + todaysDate + 'Select2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate + 'Select')
         Utilities.waitForElementVisible(TestCasesPage.testCaseAction0Btn, 5000)
-        cy.get(TestCasesPage.testCaseAction0Btn).find('[class="action-button"]').should('contain.text', 'Select').wait(2500).click()
+        cy.get(TestCasesPage.testCaseAction0Btn).find('[class="action-button"]').should('contain.text', 'Select').click()
         cy.get('[class="popover-content"]').find('[class="btn-container"]').find('[aria-label="edit-test-case-Test Case 1"]').contains('edit').click()
-        cy.get(TestCasesPage.detailsTab).scrollIntoView().wait(2500).click()
+        cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
         cy.get(TestCasesPage.testCaseTitle).click()
         cy.get(TestCasesPage.testCaseTitle).type('{moveToEnd}')
         cy.get(TestCasesPage.testCaseTitle).type('12')
@@ -223,27 +223,27 @@ describe('Import Test cases onto an existing Qi Core measure via file and ensure
         Utilities.waitForElementVisible(TestCasesPage.testCaseListTable, 5000)
         cy.get(TestCasesPage.tcColumnHeading).contains('Case #').click()
         Utilities.waitForElementVisible(TestCasesPage.tcColumnAscendingArrow, 35000)
-        
+
         /*
         Used these 2 articles to piece this together
         selector: https://www.geeksforgeeks.org/how-to-select-first-and-last-td-in-a-row-with-css/
         process: https://glebbahmutov.com/cypress-examples/recipes/get-text-list.html#collect-the-items-then-assert-the-list
         */
-        const ascCases = [] 
+        const ascCases = []
         cy.get('tr td:first-child').each(el => {
             ascCases.push(el.text())
         })
-        cy.wrap(ascCases).should('deep.equal', ['1','2','3','4'])
-     
+        cy.wrap(ascCases).should('deep.equal', ['1', '2', '3', '4'])
+
         //second click sorts in descending order
         cy.get(TestCasesPage.tcColumnHeading).contains('Case #').click()
         Utilities.waitForElementVisible(TestCasesPage.tcColumnDescendingArrow, 35000)
 
-        const descCases = [] 
+        const descCases = []
         cy.get('tr td:first-child').each(el => {
             descCases.push(el.text())
         })
-        cy.wrap(descCases).should('deep.equal', ['4','3','2','1'])
+        cy.wrap(descCases).should('deep.equal', ['4', '3', '2', '1'])
 
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -280,7 +280,7 @@ describe('Qi Core Measure - Test case number on a Draft Measure', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New version of measure is Successfully created')
         MeasuresPage.validateVersionNumber(newMeasureName, versionNumber)
-        cy.log('Version Created Successfully').wait(5000)
+        cy.log('Version Created Successfully')
 
         //Draft the Versioned Measure
         MeasuresPage.actionCenter('draft')
@@ -303,7 +303,7 @@ describe('Qi Core Measure - Test case number on a Draft Measure', () => {
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(secondTestCaseTitle.toString())

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseSearch/QiCoreTestCaseSearch.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseSearch/QiCoreTestCaseSearch.cy.ts
@@ -99,7 +99,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         Utilities.waitForElementVisible(TestCasesPage.testCaseResultrow2, 5000)
 
         //the filter by field
-        cy.get(TestCasesPage.tcFilterInput).scrollIntoView().wait(1500).click()
+        cy.get(TestCasesPage.tcFilterInput).scrollIntoView().click()
         cy.get(TestCasesPage.tcFilterByGroup).click()
         cy.get(TestCasesPage.tcSearchInput).type('NA')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
@@ -92,7 +92,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Create test
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -123,7 +123,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Create test
 
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(800)
+        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
 
         cy.get(TestCasesPage.aceEditor).type(TCJsonRace, { parseSpecialCharSequences: false })
 
@@ -212,7 +212,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -243,7 +243,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
 
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(800)
+        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
 
         cy.get(TestCasesPage.aceEditor).type(TCJsonRace, { parseSpecialCharSequences: false })
 
@@ -361,7 +361,7 @@ describe.only('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -392,7 +392,7 @@ describe.only('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
 
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(800)
+        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
 
         cy.get(TestCasesPage.aceEditor).type(TCJsonRace, { parseSpecialCharSequences: false })
 
@@ -529,7 +529,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -560,7 +560,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
 
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(800)
+        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
 
         cy.get(TestCasesPage.aceEditor).type(TCJsonRace, { parseSpecialCharSequences: false })
 
@@ -723,7 +723,6 @@ describe('Attempting to create a test case without a title', () => {
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.wait(4500)
         OktaLogin.Logout()
         MeasureGroupPage.CreateRatioMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Surgical Absence of Cervix', 'Surgical Absence of Cervix', 'Procedure')
         OktaLogin.Login()
@@ -925,7 +924,7 @@ describe('Duplicate Test Case Title and Group validations', () => {
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
         cy.get(TestCasesPage.createTestCaseTitleInput).type(testCaseTitle.toString())
@@ -959,10 +958,10 @@ describe('Duplicate Test Case Title and Group validations', () => {
         cy.get(TestCasesPage.createTestCaseDialog).should('exist')
         cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
 
-        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist').wait(500)
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
         Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 30000)
         Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 30000)
-        cy.get(TestCasesPage.createTestCaseTitleInput).wait(2000).type('SecondTestCase'.toString())
+        cy.get(TestCasesPage.createTestCaseTitleInput).type('SecondTestCase'.toString())
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
@@ -970,17 +969,17 @@ describe('Duplicate Test Case Title and Group validations', () => {
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCaseDescription)
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-        cy.get(TestCasesPage.createTestCaseGroupInput).wait(1000).type('SecondTestCaseGroup').type('{enter}')
+        cy.get(TestCasesPage.createTestCaseGroupInput).type('SecondTestCaseGroup').type('{enter}')
 
         cy.get(TestCasesPage.createTestCaseSaveButton).click()
 
         //Edit First Test case
         TestCasesPage.clickEditforCreatedTestCase()
         cy.get(TestCasesPage.detailsTab).click()
-        cy.get(TestCasesPage.testCaseTitle).clear().wait(2000).type('{selectall}{backspace}{selectall}{backspace}').type('SecondTestCase'.toString())
+        cy.get(TestCasesPage.testCaseTitle).clear().type('{selectall}{backspace}{selectall}{backspace}').type('SecondTestCase'.toString())
         cy.get(TestCasesPage.testCaseSeriesTextBox).should('exist')
         cy.get(TestCasesPage.testCaseSeriesTextBox).should('be.visible')
-        cy.get(TestCasesPage.testCaseSeriesTextBox).clear().wait(1000).type('SecondTestCaseGroup').type('{enter}')
+        cy.get(TestCasesPage.testCaseSeriesTextBox).clear().type('SecondTestCaseGroup').type('{enter}')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get('[data-testid="error-toast"]').should('contain.text', 'The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')


### PR DESCRIPTION
This PR removes additional wait lines. This will reduce the length of time it takes to run full regression tests.