### PR TITLE
feat: update to tc for more exact check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ cypress/fixtures/cqlLibraryId
 cypress/fixtures/cqlLibraryId*
 cypress/fixtures/draftId
 cypress/fixtures/draftId*
+cypress/fixtures/elementId
+cypress/fixtures/elementId*
 cypress/fixtures/groupId
 cypress/fixtures/groupId*
 cypress/fixtures/measureBundle

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -190,7 +190,8 @@ describe('Validating the creation of QDM Test Case', () => {
 
         //verify that the user is, now, on the test case list page
         cy.readFile(measurePath).should('exist').then((measureId) => {
-            cy.url().should('contain', measureId + '/edit/test-cases')
+            Utilities.waitForElementVisible(TestCasesPage.testCaseListTable, 12500)
+            cy.url().should('contain', measureId + '/edit/test-cases/list-page?filter=&search=&page=1&limit=10')
         })
     })
 })


### PR DESCRIPTION
This regression test still passed even when the page in question threw 404.
The older url check was not long enough to capture the relevant query params.
If this issue ever happens again, the new check should find it.

Also added another local processing file to gitignore.