### PR TITLE
feat: add tests for error when definition has no name

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/CQL Editor/QDMValidateCqlLibraryEditor.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Editor/QDMValidateCqlLibraryEditor.cy.ts
@@ -3,19 +3,17 @@ import { Utilities } from "../../../../Shared/Utilities"
 import { Header } from "../../../../Shared/Header"
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 
 let apiCQLLibraryName = ''
 let CQLLibraryPublisher = 'SemanticBits'
 
-describe('Validate Qi-Core CQL on CQL Library page', () => {
+describe('Validate QDM CQL on CQL Library page', () => {
 
     beforeEach('Create CQL library', () => {
 
-        apiCQLLibraryName = 'CqlValidationsLib' + Date.now()
+        apiCQLLibraryName = 'QdmValidationsLib' + Date.now()
 
-        CQLLibraryPage.createCQLLibraryAPI(apiCQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createQDMCQLLibraryAPI(apiCQLLibraryName, CQLLibraryPublisher)
         OktaLogin.Login()
     })
 
@@ -29,7 +27,8 @@ describe('Validate Qi-Core CQL on CQL Library page', () => {
         cy.get(Header.cqlLibraryTab).click()
         //Click Edit CQL Library
         CQLLibrariesPage.clickEditforCreatedLibrary()
-        Utilities.typeFileContents('cypress/fixtures/CQLForTestCaseExecution.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
+
+        Utilities.typeFileContents('cypress/fixtures/QDMMeasureCQL.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
         //enter description detail
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('exist')
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('be.visible')
@@ -52,16 +51,13 @@ describe('Validate Qi-Core CQL on CQL Library page', () => {
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('not.exist')
     })
 
-    it('Verify errors appear on CQL Library page and in the CQL Editor object, on save and on tab / page load', () => {
+    it('Verify that on save, errors appear on CQL Library page and in the CQL Editor object', () => {
         //Navigate to CQL Library Page
         cy.get(Header.cqlLibraryTab).click()
         //Click Edit CQL Library
         CQLLibrariesPage.clickEditforCreatedLibrary()
-        //Clear the text in CQL Library Editor
-        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
-
         //Update text in the CQL Library Editor that will cause error
-        Utilities.typeFileContents('cypress/fixtures/cqlCQLEditor.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
+        Utilities.typeFileContents('cypress/fixtures/QDMMeasureInvalidCQL.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
 
         //enter description detail
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('exist')
@@ -86,89 +82,14 @@ describe('Validate Qi-Core CQL on CQL Library page', () => {
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').click({ force: true, multiple: true })
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 1:3 | Could not resolve identifier SDE in the current library.")
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 5:13 | Member SDE Sex not found for type null.")
-
-        //Navigate away from the page
-        cy.get(Header.mainMadiePageButton).click()
-        //Navigate to CQL Library Page
-        cy.get(Header.cqlLibraryTab).click()
-
-        //Navigate back to the CQL Library page
-        CQLLibrariesPage.clickEditforCreatedLibrary()
-
-        //Validate error(s) in CQL Editor windows
-        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
-        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').click({ force: true, multiple: true })
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 1:3 | Could not resolve identifier SDE in the current library.")
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 5:13 | Member SDE Sex not found for type null.")
-    })
-
-    it('Verify errors appear on CQL Editor page and in the CQL Editor object, on save and on tab / page load, when included library is not found', () => {
-        //Navigate to CQL Library Page
-        cy.get(Header.cqlLibraryTab).click()
-        //Click Edit CQL Library
-        CQLLibrariesPage.clickEditforCreatedLibrary()
-        //Clear the text in CQL Library Editor
-        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
-
-        //Update text in the CQL Library Editor that will cause error
-        Utilities.typeFileContents('cypress/fixtures/EXM124v7QICore4Entry_FHIR_404.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
-
-        //enter description detail
-        cy.get(CQLLibraryPage.cqlLibraryDesc).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryDesc).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryDesc).type('Some random data')
-
-        //enter / select a publisher value
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('exist')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).should('be.visible')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('Able Health')
-        cy.get(CQLLibraryPage.cqlLibraryEditPublisher).type('{downArrow}').type('{enter}')
-
-        //save the value in the CQL Editor
-        cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.visible')
-        cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.enabled')
-        cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
-
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-
-        //Validate error(s) in CQL Editor after saving
-        cy.scrollTo('top')
-        cy.get(EditMeasurePage.cqlEditorTextBox).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{pageUp}')
-
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, "ELM: 1:55 | Library resource HospiceQICore4 version \'2.0.000\' is not found.")
-    })
-
-    it('FHIRHelpers library alias is force corrected when changed by the user', () => {
-
-        cy.get(Header.cqlLibraryTab).click()
-        CQLLibrariesPage.clickEditforCreatedLibrary()
-
-        //Clear the text in CQL Library Editor
-        cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
-
-        //Update text in the CQL Library Editor that will cause error
-        Utilities.typeFileContents('cypress/fixtures/CQLlibraryFHIRHelpersAliasWrong.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
-
-        //save the value in the CQL Editor
-        cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
-
-        cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'CQL updated successfully but the following issues were found')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'FHIRHelpers was incorrectly aliased. MADiE has overwritten the alias with \'FHIRHelpers\'.')
+        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 5:12 | Could not resolve identifier truetest in the current library.")
     })
 
     it('Verify that adding a definition without a name will throw an exact error for that issue', () => {
 
         cy.get(Header.cqlLibraryTab).click()
         CQLLibrariesPage.clickEditforCreatedLibrary()
-        Utilities.typeFileContents('cypress/fixtures/CQLWithDefNoName.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
+        Utilities.typeFileContents('cypress/fixtures/QDMNoNameDefCQL.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
         
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
@@ -184,12 +105,12 @@ describe('Validate Qi-Core CQL on CQL Library page', () => {
     })
 })
 
-describe('CQL Library: CQL Editor: Qi-Core valueSet', () => {
+describe('CQL Library: CQL Editor: QDM valueSet', () => {
 
     beforeEach('Create CQL library', () => {
 
-        apiCQLLibraryName = 'TestLibrary' + Date.now()
-        CQLLibraryPage.createCQLLibraryAPI(apiCQLLibraryName, CQLLibraryPublisher)
+        apiCQLLibraryName = 'QDMValueSetLib' + Date.now()
+        CQLLibraryPage.createQDMCQLLibraryAPI(apiCQLLibraryName, CQLLibraryPublisher)
 
         OktaLogin.Login()
     })
@@ -204,7 +125,9 @@ describe('CQL Library: CQL Editor: Qi-Core valueSet', () => {
         cy.get(Header.cqlLibraryTab).click()
         //Click Edit CQL Library
         CQLLibrariesPage.clickEditforCreatedLibrary()
-        Utilities.typeFileContents('cypress/fixtures/ValueSetTestingEntryValid.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
+
+        // need qdm version
+        Utilities.typeFileContents('cypress/fixtures/QDMMeasureCQL.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
 
         //enter description detail
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('exist')
@@ -228,7 +151,7 @@ describe('CQL Library: CQL Editor: Qi-Core valueSet', () => {
         cy.get(Header.cqlLibraryTab).click()
         //Click Edit CQL Library
         CQLLibrariesPage.clickEditforCreatedLibrary()
-        Utilities.typeFileContents('cypress/fixtures/ValueSetTestingEntryInValid.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
+        Utilities.typeFileContents('cypress/fixtures/QDMInvalidValuesetCQL.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
 
         //enter description detail
         cy.get(CQLLibraryPage.cqlLibraryDesc).should('exist')
@@ -256,19 +179,6 @@ describe('CQL Library: CQL Editor: Qi-Core valueSet', () => {
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
         cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').click({ force: true, multiple: true })
         cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text',
-            'ELM: 0:101 | Request failed with status code 404 for oid = 2.16.840.1.113883.3.464.1003.110.12.105900 ' +
-            'location = 18:0-18:101')
-    })
-
-    it('Dirty Check Modal is displayed', () => {
-        //Navigate to CQL Library Page
-        cy.get(Header.cqlLibraryTab).click()
-        //Click Edit CQL Library
-        CQLLibrariesPage.clickEditforCreatedLibrary()
-        Utilities.typeFileContents('cypress/fixtures/ValueSetTestingEntryInValid.txt', CQLLibraryPage.cqlLibraryEditorTextBox)
-
-        cy.get(Header.mainMadiePageButton).click()
-
-        cy.get(CQLLibrariesPage.cqlLibraryDirtyCheck).should('be.visible')
+            'ELM: 0:69 | Request failed with status code 404 for oid = 2.16.840.1.113762.1.4.136 location = 5:0-5:69')
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
@@ -12,58 +12,81 @@ let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMLibrary' + Date.now()
 let measureCQL = 'library TestLibrary1685544523170534 version \'0.0.000\'\n' +
     'using QDM version \'5.6\'\n' +
-    '\n' +
-    'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Common\n' +
+    'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Common\n\n' +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
     'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
-    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
-    '\n' +
+    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n\n' +
     'parameter "Measurement Period" Interval<DateTime>\n' +
-    'context Patient\n' +
+    'context Patient\n\n' +
     '//Test Comments\n' +
     'define "SDE Ethnicity":\n' +
-    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
+    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n\n' +
     'define "SDE Payer":\n' +
-    '  ["Patient Characteristic Payer": "Payer"]\n' +
+    '  ["Patient Characteristic Payer": "Payer"]\n\n' +
     'define "SDE Race":\n' +
-    '  ["Patient Characteristic Race": "Race"]\n' +
+    '  ["Patient Characteristic Race": "Race"]\n\n' +
     'define "SDE Sex":\n' +
-    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n' +
+    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n\n' +
     'define "ipp":\n' +
-    '\ttrue\n' +
+    '\ttrue\n\n' +
     'define "d":\n' +
-    '\t true\n' +
+    '\t true\n\n' +
     'define "n":\n' +
-    '\ttrue\n' +
+    '\ttrue\n\n' +
     'define fluent function "test"():\n' +
-    '\t true\n'
+    '\t true'
 
 let measureCQL_withError = 'library QDMLibrary1724174199255 version \'0.0.000\'\n' +
     'using QDM version \'5.6\'\n' +
-    'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Common\n' +
+    'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Common\n\n' +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
     'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
-    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
-    '\n' +
+    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n\n' +
     'parameter "Measurement Period" Interval<DateTime>\n' +
-    'context Patient\n' +
+    'context Patient\n\n' +
     'define "SDE Ethnicity":\n' +
-    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
+    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n\n' +
     'define "SDE Payer":\n' +
-    '  ["Patient Characteristic Payer": "Payer"]\n' +
+    '  ["Patient Characteristic Payer": "Payer"]\n\n' +
     'define "SDE Race":\n' +
-    '  ["Patient Characteristic Race": "Race"]\n' +
+    '  ["Patient Characteristic Race": "Race"]\n\n' +
     'define "SDE Sex":\n' +
-    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n' +
+    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n\n' +
     'define "ipp":\n' +
-    '\ttrue\n' +
+    '\ttrue\n\n' +
     'define "d":\n' +
-    '\t true\n' +
-    '\t \n' +
+    '\ttrue\n\n' +
     'define "n":\n' +
     '\ttruetest'
+
+const cqlMissingDefinitionName = 'library TestLibrary1685544523170534 version \'0.0.000\'\n' +
+    'using QDM version \'5.6\'\n' +
+    'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Common\n\n' +
+    'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
+    'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
+    'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
+    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n\n' +
+    'parameter "Measurement Period" Interval<DateTime>\n' +
+    'context Patient\n\n' +
+    '//Test Comments\n' +
+    'define "SDE Ethnicity":\n' +
+    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n\n' +
+    'define :\n' +
+    '  ["Patient Characteristic Payer": "Payer"]\n\n' +
+    'define "SDE Race":\n' +
+    '  ["Patient Characteristic Race": "Race"]\n\n' +
+    'define "SDE Sex":\n' +
+    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n\n' +
+    'define "ipp":\n' +
+    '\ttrue\n\n' +
+    'define "d":\n' +
+    '\t true\n\n' +
+    'define "n":\n' +
+    '\ttrue\n\n' +
+    'define fluent function "test"():\n' +
+    '\t true'
 
 describe('QDM CQL Definitions', () => {
 
@@ -316,23 +339,6 @@ describe('QDM CQL Definitions', () => {
 
 describe('QDM CQL Definitions - Expression Editor Name Option Validations', () => {
 
-    beforeEach('Create Measure and Login', () => {
-
-        CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL_withError)
-        OktaLogin.Login()
-
-        MeasuresPage.actionCenter('edit')
-
-        //Save CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('contain.text', 'CQL updated successfully but the following issues were found')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLEditorPage.expandCQLBuilder).click()
-    })
-
     afterEach('Clean up and Logout', () => {
 
         OktaLogin.Logout()
@@ -341,6 +347,13 @@ describe('QDM CQL Definitions - Expression Editor Name Option Validations', () =
 
     it('QDM CQL Definitions Expression editor Name options are not available when CQL has errors', () => {
 
+        CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL_withError)
+        OktaLogin.Login()
+
+        MeasuresPage.actionCenter('edit')
+
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(CQLEditorPage.expandCQLBuilder).click()
         //Click on Definitions tab
         cy.get(CQLEditorPage.definitionsTab).click()
         cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
@@ -351,6 +364,19 @@ describe('QDM CQL Definitions - Expression Editor Name Option Validations', () =
 
         //Expression editor name dropdown should be empty when there are CQL errors
         cy.get('.MuiAutocomplete-noOptions').should('contain.text', 'No options')
+    })
+
+    it('QDM CQL Definitions throws specific error when Definition has no name', () => {
+
+        CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, cqlMissingDefinitionName)
+        OktaLogin.Login()
+
+        //Click on Edit Button
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(CQLEditorPage.expandCQLBuilder).click()
+
+        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer,  "Row: 17, Col:7: Parse: 7:8 | Definition is missing a name.")
     })
 })
 

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
@@ -4,76 +4,99 @@ import { Utilities } from "../../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import {CQLLibraryPage} from "../../../../Shared/CQLLibraryPage";
-import {Global} from "../../../../Shared/Global";
+import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage";
+import { Global } from "../../../../Shared/Global";
 
-let measureName = 'QiCoreTestMeasure' + Date.now()
-let CqlLibraryName = 'QiCoreTestLibrary' + Date.now()
-let measureCQL = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
+const now = Date.now()
+const measureName = 'QiCoreDefinitions' + now
+const CqlLibraryName = 'QiCoreDefinitionsLib' + now
+const measureCQL = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
     'using QICore version \'4.1.1\'\n' +
     'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
     'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n' +
-    'include CQMCommon version \'2.2.000\' called CQMCommon\n' +
+    'include CQMCommon version \'2.2.000\' called CQMCommon\n\n' +
     'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
     'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
     'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
-    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
+    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n\n' +
     'parameter "Measurement Period" Interval<DateTime>\n' +
-    ' default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
-    ' context Patient\n' +
+    'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n\n' +
+    'context Patient\n\n' +
     '//Test Comments\n' +
-    ' define "Initial Population":\n' +
-    '   exists "Qualifying Encounters"\n' +
-    '   define "Qualifying Encounters":\n' +
-    '      (\n' +
-    '          [Encounter: "Office Visit"]\n' +
-    '                   union [Encounter: "Annual Wellness Visit"]\n' +
-    '                            union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
-    '                                     union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
-    '                                              union [Encounter: "Home Healthcare Services"]\n' +
-    '                                               ) ValidEncounter\n' +
-    '                                                       where ValidEncounter.period during "Measurement Period"\n' +
-    '                                                                 and ValidEncounter.isFinishedEncounter()\n' +
-    '          \n' +
-    '                                                                 \n' +
+    'define "Initial Population":\n' +
+    '   exists "Qualifying Encounters"\n\n' +
+    'define "Qualifying Encounters":\n' +
+    '   (\n[Encounter: "Office Visit"]\n' +
+    '   union [Encounter: "Annual Wellness Visit"]\n' +
+    '   union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
+    '   union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
+    '   union [Encounter: "Home Healthcare Services"]\n' +
+    '   ) ValidEncounter\n' +
+    'where ValidEncounter.period during "Measurement Period"\n' +
+    'and ValidEncounter.isFinishedEncounter()\n\n' +
     'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '  (Enc E where E.status = \'finished\') is not null '
+    '   (Enc E where E.status = \'finished\') is not null '
 
-let measureCQL_withError = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
+const measureCQL_withError = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
     'using QICore version \'4.1.1\'\n' +
     'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n' +
+    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n\n' +
     'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
     'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
     'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
-    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
+    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n\n' +
     'parameter "Measurement Period" Interval<DateTime>\n' +
-    ' default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
-    ' context Patient\n' +
-    ' define "Initial Population":\n' +
-    '   exists "Qualifying Encounters"\n' +
-    '   define "Qualifying Encounters":\n' +
-    '      (\n' +
-    '          [Encounter: "Office Visit"]\n' +
-    '                   union [Encounter: "Annual Wellness Visit"]\n' +
-    '                            union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
-    '                                     union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
-    '                                              union [Encounter: "Home Healthcare Services"]\n' +
-    '                                               ) ValidEncounter\n' +
-    '                                                       where ValidEncounter.period during "Measurement Period"\n' +
-    '                                                                 and ValidEncounter.isFinishedEncounter()test\n' +
-    '          \n' +
-    '                                                                 \n' +
+    '   default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n\n' +
+    'context Patient\n' +
+    'define "Initial Population":\n' +
+    '   exists "Qualifying Encounters"\n\n' +
+    'define "Qualifying Encounters":\n' +
+    '   (\n[Encounter: "Office Visit"]\n' +
+    '   union [Encounter: "Annual Wellness Visit"]\n' +
+    '   union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
+    '   union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
+    '   union [Encounter: "Home Healthcare Services"]\n' +
+    '   ) ValidEncounter\n' +
+    'where ValidEncounter.period during "Measurement Period"\n' +
+    'and ValidEncounter.isFinishedEncounter()test\n\n' +
     'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '  (Enc E where E.status = \'finished\') is not null'
+    '   (Enc E where E.status = \'finished\') is not null'
 
-describe('Qi-Core CQL Definitions', () => {
+const cqlMissingDefinitionName = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
+    'using QICore version \'4.1.1\'\n' +
+    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
+    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n' +
+    'include CQMCommon version \'2.2.000\' called CQMCommon\n\n' +
+    'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
+    'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
+    'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
+    'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
+    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n\n' +
+    'parameter "Measurement Period" Interval<DateTime>\n' +
+    'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n\n' +
+    'context Patient\n\n' +
+    'define :\n' +
+    '   true\n' +
+    'define "Initial Population":\n' +
+    '   exists "Qualifying Encounters"\n\n' +
+    'define "Qualifying Encounters":\n' +
+    '   (\n[Encounter: "Office Visit"]\n' +
+    '   union [Encounter: "Annual Wellness Visit"]\n' +
+    '   union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
+    '   union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
+    '   union [Encounter: "Home Healthcare Services"]\n' +
+    '   ) ValidEncounter\n' +
+    'where ValidEncounter.period during "Measurement Period"\n' +
+    'and ValidEncounter.isFinishedEncounter()\n\n' +
+    'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
+    '   (Enc E where E.status = \'finished\') is not null '
+
+describe('Qi-Core CQL Definitions Builder', () => {
 
     beforeEach('Create Measure and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         OktaLogin.Login()
     })
@@ -104,7 +127,6 @@ describe('Qi-Core CQL Definitions', () => {
 
         //Expression Editor Name dropdown should also contain Included Library name.Definition name
         cy.get(CQLEditorPage.expressionEditorNameList).should('contain.text', 'SupplementalData.SDE Ethnicity')
-
     })
 
     it('Search for Qi-Core CQL Definitions Expression Editor Fluent Function Options', () => {
@@ -127,7 +149,6 @@ describe('Qi-Core CQL Definitions', () => {
 
         //Expression Editor Name dropdown should also contain Fluent functions from Included Library
         cy.get(CQLEditorPage.expressionEditorNameList).should('contain.text', 'abatementInterval()')
-
     })
 
     it('Insert Qi-Core CQL Definitions through Expression Editor and Apply to CQL editor', () => {
@@ -213,7 +234,6 @@ describe('Qi-Core CQL Definitions', () => {
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', '"emergencyDepartmentArrivalTime"()')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'after end')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'AgeInDays()')
-
     })
 
     it('Verify Included Qi-Core CQL Definitions under Saved Definitions tab', () => {
@@ -261,7 +281,6 @@ describe('Qi-Core CQL Definitions', () => {
         cy.get('[class="ace_content"]').eq(1).should('contain', 'Initial Population')
         //Save
         cy.get(CQLEditorPage.saveDefinitionBtn).click()
-
     })
 
     it('Dirty check pops up when there are changes in CQL and Edit CQL definition button is clicked', () => {
@@ -346,28 +365,21 @@ describe('Qi-Core CQL Definitions', () => {
         //Navigate to Saved Definitions tab and verify comment
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         cy.get('[data-testid="definitions-row-0"] > :nth-child(2)').should('contain.text', 'Updated Test Comment')
-
     })
 })
 
 describe('Qi-Core CQL Definitions - Expression Editor Name Option Validations', () => {
 
-    beforeEach('Create Measure and Login', () => {
-
-        //Create New Measure
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL_withError)
-        OktaLogin.Login()
-    })
-
     afterEach('Clean up and Logout', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Qi-Core CQL Definitions Expression editor Name options are not available when CQL has errors', () => {
 
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL_withError)
+        OktaLogin.Login()
 
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
@@ -385,23 +397,33 @@ describe('Qi-Core CQL Definitions - Expression Editor Name Option Validations', 
         //Expression editor name dropdown should be empty when there are CQL errors
         cy.get('.MuiAutocomplete-noOptions').should('contain.text', 'No options')
     })
+
+    it('Qi-Core CQL Definitions throws specific error when Definition has no name', () => {
+
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, cqlMissingDefinitionName)
+        OktaLogin.Login()
+
+        //Click on Edit Button
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(CQLEditorPage.expandCQLBuilder).click()
+
+        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer,  "Row: 18, Col:7: Parse: 7:8 | Definition is missing a name.")
+    })
 })
 
 describe('Qi-Core CQL Definitions - Measure ownership Validations', () => {
 
     beforeEach('Create Measure and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         OktaLogin.AltLogin()
-
     })
 
     afterEach('Clean up and Logout', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Verify Non Measure owner unable to Edit/Delete saved Definitions', () => {
@@ -422,6 +444,5 @@ describe('Qi-Core CQL Definitions - Measure ownership Validations', () => {
 
         //Delete button should not be visible
         cy.get(CQLEditorPage.deleteCQLDefinitions).should('not.exist')
-
     })
 })

--- a/cypress/fixtures/CQLWithDefNoName.txt
+++ b/cypress/fixtures/CQLWithDefNoName.txt
@@ -1,0 +1,35 @@
+library CQLWithMulipleVersions version '1.0.000'
+
+using QICore version '4.1.1'
+include FHIRHelpers version '4.1.000' called FHIRHelpers
+
+valueset "Office Visit": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001'
+valueset "Annual Wellness Visit": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240'
+valueset "Preventive Care Services - Established Office Visit, 18 and Up": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025'
+valueset "Preventive Care Services-Initial Office Visit, 18 and Up": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023'
+valueset "Home Healthcare Services": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016'
+
+{home}parameter "Measurement Period" Interval<DateTime>
+	default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
+
+{home}context Patient
+
+{home}define "Initial Population":
+  exists "Qualifying Encounters"
+
+{home}define "Qualifying Encounters": (
+	[Encounter: "Office Visit"]
+{home}	union [Encounter: "Annual Wellness Visit"]
+{home}	union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]
+{home}	union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]
+{home}	union [Encounter: "Home Healthcare Services"]
+{home}) ValidEncounter
+{home}	where ValidEncounter.period during "Measurement Period"
+{home}	and ValidEncounter.isFinishedEncounter()
+
+{home}define fluent function "isFinishedEncounter"(Enc Encounter):
+	(Enc E where E.status = 'finished') is not null
+
+{home}define :
+	true
+	

--- a/cypress/fixtures/QDMInvalidValuesetCQL.txt
+++ b/cypress/fixtures/QDMInvalidValuesetCQL.txt
@@ -1,0 +1,24 @@
+library TestLibrary1685544523170534 version '0.0.000'
+using QDM version '5.6'
+
+valueset "Ethnicity": 'urn:oid:2.16.840.1.114222.4.11.837'
+valueset "ONC Administrative Sex": 'urn:oid:2.16.840.1.113762.1.4.136'
+valueset "Payer": 'urn:oid:2.16.840.1.114222.4.11.3591'
+valueset "Race": 'urn:oid:2.16.840.1.114222.4.11.836'
+
+parameter "Measurement Period" Interval<DateTime>
+context Patient
+{home}define "SDE Ethnicity":
+  ["Patient Characteristic Ethnicity": "Ethnicity"]
+{home}define "SDE Payer":
+  ["Patient Characteristic Payer": "Payer"]
+{home}define "SDE Race":
+  ["Patient Characteristic Race": "Race"]
+{home}define "SDE Sex":
+  ["Patient Characteristic Sex": "ONC Administrative Sex"]
+{home}define "ipp":
+	true
+{home}define "d":
+	 true
+{home}define "n":
+	true

--- a/cypress/fixtures/QDMMeasureInvalidCQL.txt
+++ b/cypress/fixtures/QDMMeasureInvalidCQL.txt
@@ -1,0 +1,24 @@
+library TestLibrary1685544523170534 version '0.0.000'
+using QDM version '5.6'
+
+valueset "Ethnicity": 'urn:oid:2.16.840.1.114222.4.11.837'
+valueset "ONC Administrative Sex": 'urn:oid:2.16.840.1.113762.1.4.1'
+valueset "Payer": 'urn:oid:2.16.840.1.114222.4.11.3591'
+valueset "Race": 'urn:oid:2.16.840.1.114222.4.11.836'
+
+parameter "Measurement Period" Interval<DateTime>
+context Patient
+{home}define "SDE Ethnicity":
+  ["Patient Characteristic Ethnicity": "Ethnicity"]
+{home}define "SDE Payer":
+  ["Patient Characteristic Payer": "Payer"]
+{home}define "SDE Race":
+  ["Patient Characteristic Race": "Race"]
+{home}define "SDE Sex":
+  ["Patient Characteristic Sex": "ONC Administrative Sex"]
+{home}define "ipp":
+	true
+{home}define "d":
+	 true
+{home}define "n":
+	truetest

--- a/cypress/fixtures/QDMNoNameDefCQL.txt
+++ b/cypress/fixtures/QDMNoNameDefCQL.txt
@@ -1,0 +1,27 @@
+library TestLibrary1685544523170534 version '0.0.000'
+using QDM version '5.6'
+
+valueset "Ethnicity": 'urn:oid:2.16.840.1.114222.4.11.837'
+valueset "ONC Administrative Sex": 'urn:oid:2.16.840.1.113762.1.4.1'
+valueset "Payer": 'urn:oid:2.16.840.1.114222.4.11.3591'
+valueset "Race": 'urn:oid:2.16.840.1.114222.4.11.836'
+
+parameter "Measurement Period" Interval<DateTime>
+context Patient
+{home}define "SDE Ethnicity":
+  ["Patient Characteristic Ethnicity": "Ethnicity"]
+{home}define "SDE Payer":
+  ["Patient Characteristic Payer": "Payer"]
+{home}define "SDE Race":
+  ["Patient Characteristic Race": "Race"]
+{home}define "SDE Sex":
+  ["Patient Characteristic Sex": "ONC Administrative Sex"]
+{home}define "ipp":
+	true
+{home}define "d":
+	 true
+{home}define "n":
+	true
+{home}define :
+	true
+


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-7995

Add tests to cover scenario: CQL throws a specific error when a definition is missing a name declaration for QDM measure, QDM library, QiCore measure, QiCore library.