### PR TITLE
feat: update tests for story

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
@@ -232,10 +232,15 @@ describe('QDM CQL Definitions', () => {
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         Utilities.waitForElementVisible('[data-testid="definitions-row-0"] > :nth-child(1)', 60000)
         cy.get('[data-testid="definitions-row-0"] > :nth-child(1)').should('contain.text', 'SDE Ethnicity')
+        cy.get('[data-testid="definitions-row-0"] > :nth-child(2)').should('contain.text', 'PatientCharacteristicEthnicity')
+
         cy.get('[data-testid="definitions-row-1"] > :nth-child(1)').should('contain.text', 'SDE Payer')
         cy.get('[data-testid="definitions-row-2"] > :nth-child(1)').should('contain.text', 'SDE Race')
+        cy.get('[data-testid="definitions-row-2"] > :nth-child(2)').should('contain.text', 'PatientCharacteristicRace')
+
         cy.get('[data-testid="definitions-row-3"] > :nth-child(1)').should('contain.text', 'SDE Sex')
         cy.get('[data-testid="definitions-row-4"] > :nth-child(1)').should('contain.text', 'ipp')
+        cy.get('[data-testid="definitions-row-4"] > :nth-child(2)').should('contain.text', 'Boolean')
     })
 
     it('Edit Saved QDM CQL Definitions', () => {
@@ -249,15 +254,12 @@ describe('QDM CQL Definitions', () => {
         //Return type populated for Saved Definitions
         cy.get('[data-testid="return-type"]').should('contain.text', 'Return TypePatientCharacteristicSex')
 
-        //Edit Definition
-        cy.get(CQLEditorPage.expressionEditorTypeDropdown).click()
-        cy.get(CQLEditorPage.definitionOption).click()
-        cy.get(CQLEditorPage.expressionEditorNameDropdown).click()
-        Utilities.waitForElementVisible(CQLEditorPage.expressionEditorNameList, 60000)
-        cy.get(CQLEditorPage.expressionEditorNameList).contains('Common.Inpatient Encounter').click()
-        //Insert
-        cy.get(CQLEditorPage.expressionInsertBtn).click()
-        cy.get('[class="ace_content"]').eq(1).should('contain', 'Common."Inpatient Encounter"')
+        //Edit Definition name
+        cy.get(CQLEditorPage.definitionNameTextBox).type(' updated')
+
+        cy.get(CQLEditorPage.saveDefinitionBtn).click()
+
+        cy.get('.ace_content').should('contain', 'SDE Sex updated')
     })
 
     it('Dirty check pops up when there are changes in CQL and Edit CQL definition button is clicked', () => {
@@ -405,6 +407,10 @@ describe('QDM CQL Definitions - Measure ownership Validations', () => {
         //Navigate to Saved Definitions tab
         cy.get(CQLEditorPage.definitionsTab).click()
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
+
+        // return type is visible
+        cy.get('[data-testid="definitions-row-2"] > :nth-child(2)').should('contain.text', 'PatientCharacteristicRace')
+        cy.get('[data-testid="definitions-row-4"] > :nth-child(2)').should('contain.text', 'Boolean')
 
         //Edit button should not be visible
         cy.get(CQLEditorPage.editCQLDefinitions).should('not.exist')

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
@@ -249,8 +249,12 @@ describe('Qi-Core CQL Definitions Builder', () => {
         //Navigate to Saved Definitions tab
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
         Utilities.waitForElementVisible('[data-testid="definitions-row-0"] > :nth-child(1)', 60000)
+        
         cy.get('[data-testid="definitions-row-0"] > :nth-child(1)').should('contain.text', 'Initial Population')
+        cy.get('[data-testid="definitions-row-0"] > :nth-child(2)').should('contain.text', 'Boolean')
+        
         cy.get('[data-testid="definitions-row-1"] > :nth-child(1)').should('contain.text', 'Qualifying Encounters')
+        cy.get('[data-testid="definitions-row-1"] > :nth-child(2)').should('contain.text', 'Encounter')
     })
 
     it('Edit Saved Qi-Core CQL Definitions', () => {
@@ -270,15 +274,12 @@ describe('Qi-Core CQL Definitions Builder', () => {
         //Return type populated for Saved Definitions
         cy.get('[data-testid="return-type"]').should('contain.text', 'Return TypeBoolean')
 
-        //Edit Definition
-        cy.get(CQLEditorPage.expressionEditorTypeDropdown).click()
-        cy.get(CQLEditorPage.definitionOption).click()
-        cy.get(CQLEditorPage.expressionEditorNameDropdown).click()
-        Utilities.waitForElementVisible(CQLEditorPage.expressionEditorNameList, 60000)
-        cy.get(CQLEditorPage.expressionEditorNameList).contains('Initial Population').click()
-        //Insert
-        cy.get(CQLEditorPage.expressionInsertBtn).click()
-        cy.get('[class="ace_content"]').should('contain', 'Initial Population')
+        //Edit Definition name
+        cy.get(CQLEditorPage.definitionNameTextBox).type(' updated')
+
+        cy.get(CQLEditorPage.saveDefinitionBtn).click()
+ 
+        cy.get('.ace_content').should('contain', 'Initial Population updated')
     })
 
     it('Dirty check pops up when there are changes in CQL and Edit CQL definition button is clicked', () => {
@@ -441,8 +442,11 @@ describe('Qi-Core CQL Definitions - Measure ownership Validations', () => {
         cy.get(CQLEditorPage.definitionsTab).click()
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
 
-        //Edit button should not be visible
         Utilities.waitForElementVisible('[data-testid="definitions-row-0"] > :nth-child(1)', 60000)
+        // "return type" is visible"
+        cy.get('[data-testid="definitions-row-0"] > :nth-child(2)').should('contain.text', 'Boolean')
+
+        //Edit button should not be visible
         cy.get(CQLEditorPage.editCQLDefinitions).should('not.exist')
 
         //Delete button should not be visible


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-7937

Added additional checks into existing tests to look specifically for data in new column "Return Type".

I also re-worked the existing checks for "edit definitions" so that both models change the definition name in an easy to follow way - the older versions of these checks were trying to make complicated updates & it wasn't clear to me how they were working.