### PR TITLE
feat: add scoring precision test

### DIFF
--- a/cypress/e2e/Services/Measure Service/EditMeasure.cy.ts
+++ b/cypress/e2e/Services/Measure Service/EditMeasure.cy.ts
@@ -558,6 +558,50 @@ describe('Measure Service: Edit Measure', () => {
             })
         })
     })
+
+    it('Add scoring precision value to the measure', () => {
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                cy.readFile(versionIdPath).should('exist').then((vId) => {
+                    cy.request({
+                        url: '/api/measures/' + id,
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'PUT',
+                        body: {
+                            'id': id,
+                            'measureName': updatedMeasureName,
+                            'cql': "library xyz version '1.5.000'\n\nusing FHIR version '4.0.1'\n\ninclude FHIRHelpers version '4.1.000' called FHIRHelpers\ninclude SupplementalDataElementsFHIR4 version '2.0.000' called SDE\ninclude MATGlobalCommonFunctionsFHIR4 version '6.1.000' called Global\n\nparameter \"Measurement Period\" Interval<DateTime>\n\ncontext Patient\n\ndefine \"SDE Ethnicity\":\n  SDE.\"SDE Ethnicity\"\n\ndefine \"SDE Payer\":\n  SDE.\"SDE Payer\"\n\ndefine \"SDE Race\":\n  SDE.\"SDE Race\"\n\ndefine \"SDE Sex\":\n  SDE.\"SDE Sex\"",
+                            'cqlLibraryName': updatedCQLLibraryName,
+                            'model': model,
+                            "version": "0.0.000",
+                            'measureScoring': 'Ratio',
+                            'versionId': vId,
+                            'measureSetId': uuidv4(),
+                            "ecqmTitle": "eCQMTitle",
+                            'measureMetaData': {
+                                "experimental": false,
+                                "endorsements": [
+                                    {
+                                        "endorser": "NQF",
+                                        "endorserSystemId": "78888",
+                                        "endorsementId": "1234"
+                                    }
+                                ]
+                            },
+                            "measurementPeriodStart": mpStartDate,
+                            "measurementPeriodEnd": mpEndDate,
+                            "scoringPrecision": 2
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                    })
+                })
+            })
+        })
+    })
 })
 describe('Measure Service: Attempt to add RA when user is not owner of measure', () => {
 


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-7980

Added very basic test to cover editing a measure & adding "scoring precision" value.

No UI available for this yet - service tests are the only way to do this.