### PR TITLE
fix: update function usage for current version

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
@@ -89,7 +89,7 @@ describe('QI Core: Elements tab is not present', () => {
         MeasuresPage.actionCenter("edit")
 
         cy.get(EditMeasurePage.testCasesTab).click()
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Elements tab should not be visible
         Utilities.waitForElementToNotExist(TestCasesPage.elementsTab, 20000)
@@ -148,7 +148,7 @@ describe('QI Core v6: UI Elements Builder tab is not shown', () => {
         Utilities.waitForElementVisible(EditMeasurePage.testCasesTab, 30000)
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         // no options show, only default editor
         cy.get(TestCasesPage.jsonTab).should('not.exist')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Clone/CloneQDMTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Clone/CloneQDMTestCase.cy.ts
@@ -7,38 +7,32 @@ import {Utilities} from "../../../../../Shared/Utilities"
 import {MeasuresPage} from "../../../../../Shared/MeasuresPage"
 import {EditMeasurePage} from "../../../../../Shared/EditMeasurePage"
 
-let testCaseDescription = 'DENOMFail' + Date.now()
-let measureName = 'QDMTestMeasure' + Date.now()
-let CqlLibraryName = 'TestLibrary' + Date.now()
+const now = Date.now()
+let testCaseDescription = 'DENOMFail test case'
+let measureName = 'QDMTestMeasure' + now
+let CqlLibraryName = 'TestLibrary' + now
 let testCaseTitle = 'test case title'
 let testCaseSeries = 'SBTestSeries'
 let measureCQL = MeasureCQL.SBTEST_CQL
 let measureScoring = 'Cohort'
-let newMeasureName = ''
-let newCqlLibraryName = ''
 
 describe('Clone QDM Test Case', () => {
 
     before('Create measure and login', () => {
 
-        let randValue = (Math.floor((Math.random() * 1000) + 2))
-        newMeasureName = measureName + randValue
-        newCqlLibraryName = CqlLibraryName + randValue
-
         //Create QDM Measure, PC and Test Case with ALT user
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCqlLibraryName, measureScoring, true, measureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureName, CqlLibraryName, measureScoring, true, measureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp')
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
-
     })
 
     after('Logout and Clean up Measures', () => {
 
         OktaLogin.UILogout()
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
     })
+
     it('Clone QDM Test Case - Success scenario', () => {
 
         //click on Edit button to edit measure
@@ -48,12 +42,8 @@ describe('Clone QDM Test Case', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        cy.readFile('cypress/fixtures/testCaseId').should('exist').then((tcId) => {
-            cy.get('[data-testid=select-action-' + tcId + ']').click()
-            cy.get('[data-testid=clone-test-case-btn-' + tcId + ']').should('be.visible')
-            cy.get('[data-testid=clone-test-case-btn-' + tcId + ']').should('be.enabled')
-            cy.get('[data-testid=clone-test-case-btn-' + tcId + ']').click({force: true})
-        })
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterClone).click()
 
         cy.get('[class="toast success"]').should('contain.text', 'Test case cloned successfully')
     })
@@ -73,11 +63,6 @@ describe('Clone QDM Test Case', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        cy.readFile('cypress/fixtures/testCaseId').should('exist').then((tcId) => {
-            cy.get('[data-testid=select-action-' + tcId + ']').click()
-            cy.get('[data-testid=clone-test-case-btn-' + tcId + ']').should('not.exist')
-            cy.get('[data-testid=view-edit-test-case-' + tcId + ']').click()
-        })
-
+        cy.get(TestCasesPage.actionCenterClone).should('not.exist')
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/MeasureHighlightingQDM.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/MeasureHighlightingQDM.cy.ts
@@ -91,7 +91,7 @@ describe('QDM: Test Case Highlighting Left navigation panel: Includes validate /
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //navigate to the highlighting sub tab
         Utilities.waitForElementVisible(TestCasesPage.tcHighlightingTab, 60000)
@@ -175,7 +175,7 @@ describe('QDM: Test Case Highlighting Left navigation panel: Includes Result sub
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //navigate to the highlighting sub tab
         cy.get(TestCasesPage.tcHighlightingTab).should('exist')
@@ -273,7 +273,7 @@ describe('QDM Measure: Test Case Highlighting Left navigation panel: Highlightin
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //run test case
         cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('be.visible')
@@ -400,7 +400,7 @@ describe('QDM Measure:: Test Case Highlighting Left navigation panel: Highlighti
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //run test case
         cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -193,7 +193,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('07/01/2002 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/ElementTable.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/ElementTable.cy.ts
@@ -56,7 +56,7 @@ describe('Quantity Attribute -- Adding multiple attributes', () => {
         TestCasesPage.createQDMTestCase(testCaseTitle, testCaseDescription, testCaseSeries)
 
         //Navigate to Edit Test Case page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('01/01/2020 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMSDESubTabValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMSDESubTabValidations.cy.ts
@@ -82,7 +82,7 @@ describe('QDM Test Cases : SDE Sub tab validations', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
         //Navigate to Edit Test Case page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('01/01/2020 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
@@ -168,7 +168,7 @@ describe('QDM Test Cases : SDE Sub tab validations', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to Edit Test Case page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Execute test case
         cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.visible')
@@ -217,7 +217,7 @@ describe('QDM Test Cases : SDE Sub tab validations', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to Edit Test Case page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('01/01/2020 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -414,7 +414,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 50000)
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('01/01/2000 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
         //add element - code system to TC
@@ -436,7 +436,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 50000)
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
         TestCasesPage.grabElementId()
         TestCasesPage.qdmTestCaseElementAction('edit')
         //add negation
@@ -464,7 +464,7 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 50000)
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
         //Element - Encounter:Performed: Nonelective Inpatient Encounter
         cy.get('[data-testid="elements-tab-encounter"]').scrollIntoView().click()
         cy.get('[data-testid="data-type-Encounter, Performed: Nonelective Inpatient Encounter"]').click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/QDMShiftTestCaseDatesValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/QDMShiftTestCaseDatesValidations.cy.ts
@@ -37,7 +37,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
-        TestCasesPage.testCaseAction('edit', false)
+        TestCasesPage.clickEditforCreatedTestCase()
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('01/01/2000 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
         //add element - code system to TC
@@ -107,7 +107,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 50000)
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
         //enter a value of the dob, Race and gender
         TestCasesPage.enterPatientDemographics('02/29/1980 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
         //add element - code system to TC
@@ -233,7 +233,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', false)
+        TestCasesPage.clickEditforCreatedTestCase()
         //confirm that the test case DOB field is visible and enabled
         Utilities.waitForElementVisible(TestCasesPage.QDMDob, 3500)
         Utilities.waitForElementEnabled(TestCasesPage.QDMDob, 3500)
@@ -254,7 +254,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //confirm value that is in test case
         cy.get(TestCasesPage.QDMDob).should('contain.value', '02/28/1983')
@@ -291,7 +291,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', false)
+        TestCasesPage.clickEditforCreatedTestCase()
         //confirm that the test case DOB field is visible and enabled
         Utilities.waitForElementVisible(TestCasesPage.QDMDob, 3500)
         Utilities.waitForElementEnabled(TestCasesPage.QDMDob, 3500)
@@ -312,7 +312,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //confirm value that is in test case
         cy.get(TestCasesPage.QDMDob).should('contain.value', '02/28/1980')
@@ -365,7 +365,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', false)
+        TestCasesPage.clickEditforCreatedTestCase()
         //confirm that the test case DOB field is visible and enabled
         Utilities.waitForElementVisible(TestCasesPage.QDMDob, 3500)
         Utilities.waitForElementEnabled(TestCasesPage.QDMDob, 3500)
@@ -400,7 +400,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(TestCasesPage.shiftSpecificTestCasesSuccessMsg).should('contain.text', 'Test Case Shift Dates for QDMManifestTCGroup2 - QDMManifestTC2 successful.')
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //confirm value that is in test case
         cy.get(TestCasesPage.QDMDob).should('contain.value', '02/28/1983')
@@ -436,7 +436,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', false)
+        TestCasesPage.clickEditforCreatedTestCase()
         //confirm that the test case DOB field is visible and enabled
         Utilities.waitForElementVisible(TestCasesPage.QDMDob, 3500)
         Utilities.waitForElementEnabled(TestCasesPage.QDMDob, 3500)
@@ -472,7 +472,7 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(TestCasesPage.shiftSpecificTestCasesSuccessMsg).should('contain.text', 'Test Case Shift Dates for QDMManifestTCGroup2 - QDMManifestTC2 successful.')
 
         //navigate to the edit page for the first test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //confirm value that is in test case
         cy.get(TestCasesPage.QDMDob).should('contain.value', '02/28/1980')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/QI-CoreTestCaseElementsJSON.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/QI-CoreTestCaseElementsJSON.cy.ts
@@ -101,7 +101,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Create
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -128,7 +128,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Create
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -222,7 +222,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -249,7 +249,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -278,7 +278,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         //verify updated list of values
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -374,7 +374,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -401,7 +401,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -432,7 +432,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -449,7 +449,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         //verify updated list of values
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -545,7 +545,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -572,7 +572,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -602,7 +602,7 @@ describe.skip('QI Core DOB, Gender, Race, and Ethnicity data validations: Edit T
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/Qi-CoreTestCaseElementsBuilder.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Elements/Qi-CoreTestCaseElementsBuilder.cy.ts
@@ -35,7 +35,7 @@ describe.skip('Check for UI Elements Builder on QiCore 6.0.0 measures only', () 
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         // these only show for STU6
         cy.get(TestCasesPage.jsonTab).should('be.visible').and('be.enabled')
@@ -64,7 +64,7 @@ describe.skip('Check for UI Elements Builder on QiCore 6.0.0 measures only', () 
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         // these should not show, since with is QiCore 4.1.1
         cy.get(TestCasesPage.jsonTab).should('not.exist')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureHighlighting.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureHighlighting.cy.ts
@@ -822,7 +822,7 @@ describe('Measure Highlighting', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Navigate to the Expected / Actual sub tab
         Utilities.waitForElementVisible(TestCasesPage.tctExpectedActualSubTab, 35000)
@@ -925,7 +925,7 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Highlighting ac
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Navigate to the Expected / Actual sub tab
         Utilities.waitForElementVisible(TestCasesPage.tctExpectedActualSubTab, 35000)
@@ -1073,7 +1073,7 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Highlighting ac
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Navigate to the Expected / Actual sub tab
         Utilities.waitForElementVisible(TestCasesPage.tctExpectedActualSubTab, 35000)
@@ -1205,7 +1205,7 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Includes Result
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Navigate to the Expected / Actual sub tab
         Utilities.waitForElementVisible(TestCasesPage.tctExpectedActualSubTab, 35000)
@@ -1339,7 +1339,7 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Includes Result
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //Navigate to the Expected / Actual sub tab
         Utilities.waitForElementVisible(TestCasesPage.tctExpectedActualSubTab, 35000)
@@ -1459,7 +1459,7 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Highlighting ac
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 55000)
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //run test case
         cy.get(TestCasesPage.runTestButton).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
@@ -1920,7 +1920,7 @@ describe('Verify multiple IPs on the highlighting tab', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //Navigate to test case detail / edit page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //navigate to the highlighting sub tab
         cy.get(TestCasesPage.tcHighlightingTab).should('exist')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
@@ -69,7 +69,7 @@ describe('MADIE Zip Test Case Import', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the second test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
@@ -93,7 +93,7 @@ describe('MADIE Zip Test Case Import', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the second test case
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
@@ -165,7 +165,7 @@ describe('MADIE Zip Test Case Import', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the second test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
@@ -188,7 +188,7 @@ describe('MADIE Zip Test Case Import', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the second test case
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
@@ -209,7 +209,7 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate + 'Select')
 
         //navigate to test case edit / detail page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
 
@@ -299,7 +299,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/A' + testCaseSeries + 'b' + 'Title for Auto Testb' + testCaseDescription + 'b' + todaysDate + 'Select1N/A' + testCaseSeries + 'a' + 'Title for Auto Testa' + testCaseDescription + 'a' + todaysDate + 'Select')
 
         //navigate to test case edit / detail page for the first test case
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
 
@@ -307,7 +307,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to test case edit / detail page for the second test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
 
@@ -395,7 +395,7 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate + 'Select')
 
         //navigate to test case edit / detail page
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
 
@@ -485,7 +485,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesbTitle for Auto Testb' + testCaseDescription + 'b' + todaysDate + 'Select1N/ASBTestSeriesaTitle for Auto Testa' + testCaseDescription + 'a' + todaysDate + 'Select')
 
         //navigate to test case edit / detail page for the first test case
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
 
@@ -493,7 +493,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to test case edit / detail page for the second test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -101,7 +101,7 @@ describe('Test Case Import: functionality tests', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //navigate to the edit page for the second test case
-        TestCasesPage.testCaseAction('edit', true)
+        TestCasesPage.clickEditforCreatedTestCase(true)
 
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
@@ -81,7 +81,7 @@ describe('Test Case sorting by Test Case number', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
         cy.get(TestCasesPage.testCaseNameDropdown).should('contain.text', 'Case #1: Test Series 1 - Test Case 1')
 
         TestCasesPage.createTestCase(testCaseTitle2nd, testCaseDescription2nd, testCaseSeries2nd, testCaseJson2nd)

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
@@ -111,7 +111,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Create test
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -138,7 +138,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Create test
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -231,7 +231,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -258,7 +258,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -285,7 +285,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         //verify updated list of values
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -380,7 +380,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -407,7 +407,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -437,7 +437,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -453,7 +453,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         //verify updated list of values
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -548,7 +548,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         //Verify created test case Title and Series exists on Test Cases Page
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         //add json value to measure's test case
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
@@ -575,7 +575,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()
@@ -604,7 +604,7 @@ describe.skip('QI Core Gender, Race, and Ethnicity data validations: Edit Test C
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.elementsTab, 20000)
         cy.get(TestCasesPage.elementsTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
@@ -80,7 +80,7 @@ describe('Sort by each of the test case list page\'s columns', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //edit test case to cause it to fail
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')

--- a/cypress/e2e/WebInterface/lighthouse/lighthousedemo.cy.ts
+++ b/cypress/e2e/WebInterface/lighthouse/lighthousedemo.cy.ts
@@ -372,7 +372,7 @@ describe('Navigate to the Qi Core "Test Cases" edit page, for a specific test ca
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        TestCasesPage.testCaseAction('edit')
+        TestCasesPage.clickEditforCreatedTestCase()
 
         const thresholds = {
             performance: 3,


### PR DESCRIPTION
Regression updates for https://jira.cms.gov/browse/MAT-7109

This is a ton of files, but the changes are small & consistently the same across each one.

Previous usage of `TestCasesPage.testCaseAction('edit')` is now becoming `TestCasesPage.clickEditforCreatedTestCase()` across the board.
There are a few variations to account for 2 test cases in the same scenario.

Note: this change only accounts for the edit action. Further updates will be needed for actions like export, clone, etc.