### PR TITLE
More cql cleanup

### DIFF
--- a/cypress/Shared/FHIRMeasuresCQL.ts
+++ b/cypress/Shared/FHIRMeasuresCQL.ts
@@ -655,6 +655,36 @@ public static readonly ICFCleanTestQICore = 'library SimpleFhirLibrary version \
         '  14\n\n' +
         'define function daysObs(e Encounter):\n' +
         '  duration in days of e.period\n'
+
+    public static readonly EpisodeWithStrat = 'library CohortEpisodeWithStrat1668108456699 version \'0.0.000\'\n' +
+        'using QICore version \'4.1.1\'\n' +
+        'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
+        'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
+        'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
+        'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
+        'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
+        'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
+        'valueset "End Stage Renal Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353\'\n\n' +
+        'parameter "Measurement Period" Interval<DateTime>\n' +
+        'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n\n' +
+        'context Patient\n\n' +
+        'define "Initial Population":\n' +
+        ' "Qualifying Encounters"\n\n' +
+        'define "Qualifying Encounters":\n' +
+        '(\n' +
+        '[Encounter: "Office Visit"]\n' +
+        'union [Encounter: "Annual Wellness Visit"]\n' +
+        'union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
+        'union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
+        'union [Encounter: "Home Healthcare Services"]\n' +
+        ') ValidEncounter\n' +
+        'where ValidEncounter.period during "Measurement Period"\n' +
+        'and ValidEncounter.isFinishedEncounter()\n\n' +
+        'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
+        '(Enc E where E.status = \'finished\') is not null\n\n' +
+        'define "Stratificaction 1":\n' +
+        ' "Qualifying Encounters" Enc\n' +
+        ' where Enc.type in "Annual Wellness Visit"'
 }
 
 export class QiCore6Cql {

--- a/cypress/Shared/QDMMeasuresCQL.ts
+++ b/cypress/Shared/QDMMeasuresCQL.ts
@@ -2,7 +2,7 @@ const standardSdeBlock =
     'define \"SDE Ethnicity\":\n' +
     '  [\"Patient Characteristic Ethnicity\": \"Ethnicity\"]\n\n' +
     'define \"SDE Payer\":\n' +
-    '  [\"Patient Characteristic Payer\": \"Payer Type\"]\n\n' +
+    '  [\"Patient Characteristic Payer\": \"Payer\"]\n\n' +
     'define \"SDE Race\":\n' +
     '  [\"Patient Characteristic Race\": \"Race\"]\n\n' +
     'define \"SDE Sex\":\n' +

--- a/cypress/e2e/Services/CQL Builder lookups/QI Core CQL Builder Lookups.cy.ts
+++ b/cypress/e2e/Services/CQL Builder lookups/QI Core CQL Builder Lookups.cy.ts
@@ -1,41 +1,6 @@
-import { Utilities } from "../../../Shared/Utilities"
+import { QiCore4Cql } from "../../../Shared/FHIRMeasuresCQL"
 
-let cql = 'library CohortEpisodeWithStrat1723121043645 version \'0.0.000\'\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
-    'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
-    'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
-    'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
-    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
-    'valueset "End Stage Renal Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    ' "Qualifying Encounters"\n' +
-    ' \n' +
-    'define "Qualifying Encounters":\n' +
-    '(\n' +
-    '[Encounter: "Office Visit"]\n' +
-    'union [Encounter: "Annual Wellness Visit"]\n' +
-    'union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
-    'union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
-    'union [Encounter: "Home Healthcare Services"]\n' +
-    ') ValidEncounter\n' +
-    'where ValidEncounter.period during "Measurement Period"\n' +
-    'and ValidEncounter.isFinishedEncounter()\n' +
-    '\n' +
-    'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '(Enc E where E.status = \'finished\') is not null\n' +
-    '\n' +
-    'define "Stratificaction 1":\n' +
-    ' "Qualifying Encounters" Enc\n' +
-    ' where Enc.type in "Annual Wellness Visit"'
-
+const cql = QiCore4Cql.EpisodeWithStrat
 
 describe('CQL Builder Lookups: QI Core', () => {
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Cohort_ListQDMPositiveEncounterPerformed.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Cohort_ListQDMPositiveEncounterPerformed.cy.ts
@@ -8,6 +8,7 @@ import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { QDMElements } from "../../../../Shared/QDMElements"
 import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage";
+import { QdmCql } from "../../../../Shared/QDMMeasuresCQL"
 
 let measureName = 'CohortListQDMPositiveEncounterPerformed' + Date.now()
 let CqlLibraryName = 'CohortListQDMPositiveEncounterPerformed' + Date.now()
@@ -15,139 +16,12 @@ let firstTestCaseTitle = 'Combo2 ThreeEncounter'
 let testCaseDescription = 'DENOMFail' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let secondTestCaseTitle = 'SBPFail GT24beforeAndGT2after'
-let measureCQL = 'library HybridHospitalWideReadmission version \'4.0.000\'\n' +
-    '\n' +
-    'using QDM version \'5.6\'\n' +
-    '\n' +
-    'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n' +
-    '\n' +
-    'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\' \n' +
-    '\n' +
-    'valueset "Acute care hospital Inpatient Encounter": \'urn:oid:2.16.840.1.113883.3.666.5.2289\' \n' +
-    'valueset "Bicarbonate lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.139\' \n' +
-    'valueset "Body temperature": \'urn:oid:2.16.840.1.113762.1.4.1045.152\' \n' +
-    'valueset "Body weight": \'urn:oid:2.16.840.1.113762.1.4.1045.159\' \n' +
-    'valueset "Creatinine lab test": \'urn:oid:2.16.840.1.113883.3.666.5.2363\' \n' +
-    'valueset "Emergency Department Visit": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.292\' \n' +
-    'valueset "Encounter Inpatient": \'urn:oid:2.16.840.1.113883.3.666.5.307\' \n' +
-    'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\' \n' +
-    'valueset "Glucose lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.134\' \n' +
-    'valueset "Heart Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.149\' \n' +
-    'valueset "Hematocrit lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.114\' \n' +
-    'valueset "Medicare Advantage payer": \'urn:oid:2.16.840.1.113762.1.4.1104.12\' \n' +
-    'valueset "Medicare FFS payer": \'urn:oid:2.16.840.1.113762.1.4.1104.10\' \n' +
-    'valueset "Observation Services": \'urn:oid:2.16.840.1.113762.1.4.1111.143\' \n' +
-    'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\' \n' +
-    'valueset "Oxygen Saturation by Pulse Oximetry": \'urn:oid:2.16.840.1.113762.1.4.1045.151\' \n' +
-    'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\' \n' +
-    'valueset "Potassium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.117\' \n' +
-    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\' \n' +
-    'valueset "Respiratory Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.130\' \n' +
-    'valueset "Sodium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.119\' \n' +
-    'valueset "Systolic Blood Pressure": \'urn:oid:2.16.840.1.113762.1.4.1045.163\' \n' +
-    'valueset "White blood cells count lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.129\' \n' +
-    '\n' +
-    'code "Birth date": \'21112-8\' from "LOINC" display \'Birth date\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "Denominator":\n' +
-    '  "Initial Population"\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    '  "Inpatient Encounters"\n' +
-    '\n' +
-    'define "Numerator":\n' +
-    '  "Initial Population"\n' +
-    '\n' +
-    'define "SDE Ethnicity":\n' +
-    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
-    '\n' +
-    'define "SDE Payer":\n' +
-    '  ["Patient Characteristic Payer": "Payer"]\n' +
-    '\n' +
-    'define "SDE Race":\n' +
-    '  ["Patient Characteristic Race": "Race"]\n' +
-    '\n' +
-    'define "SDE Sex":\n' +
-    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n' +
-    '\n' +
-    'define "SDE Results":\n' +
-    '  {\n' +
-    '  // First physical exams\n' +
-    '    FirstHeartRate: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Heart Rate"]),\n' +
-    '    FirstSystolicBloodPressure: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Systolic Blood Pressure"]),\n' +
-    '    FirstRespiratoryRate: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Respiratory Rate"]),\n' +
-    '    FirstBodyTemperature: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Body temperature"]),\n' +
-    '    FirstOxygenSaturation: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Oxygen Saturation by Pulse Oximetry"]),\n' +
-    '  // Weight uses lab test timing\n' +
-    '    FirstBodyWeight: "FirstPhysicalExamWithEncounterIdUsingLabTiming"(["Physical Exam, Performed": "Body weight"]),\n' +
-    '  \n' +
-    '  // First lab tests\n' +
-    '    FirstHematocritLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Hematocrit lab test"]),\n' +
-    '    FirstWhiteBloodCellCount: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "White blood cells count lab test"]),\n' +
-    '    FirstPotassiumLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Potassium lab test"]),\n' +
-    '    FirstSodiumLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Sodium lab test"]),\n' +
-    '    FirstBicarbonateLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Bicarbonate lab test"]),\n' +
-    '    FirstCreatinineLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Creatinine lab test"]),\n' +
-    '    FirstGlucoseLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Glucose lab test"])\n' +
-    '  }\n' +
-    '\n' +
-    'define "Inpatient Encounters":\n' +
-    '  ["Encounter, Performed": "Encounter Inpatient"] InpatientEncounter\n' +
-    '    with ( ["Patient Characteristic Payer": "Medicare FFS payer"]\n' +
-    '      union ["Patient Characteristic Payer": "Medicare Advantage payer"] ) Payer\n' +
-    '      such that Global."HospitalizationWithObservationLengthofStay" ( InpatientEncounter ) < 365\n' +
-    '        and InpatientEncounter.relevantPeriod ends during day of "Measurement Period"\n' +
-    '        and AgeInYearsAt(date from start of InpatientEncounter.relevantPeriod)>= 65\n' +
-    '\n' +
-    'define function "LengthOfStay"(Stay Interval<DateTime> ):\n' +
-    '  difference in days between start of Stay and \n' +
-    '  end of Stay\n' +
-    '\n' +
-    'define function "FirstPhysicalExamWithEncounterId"(ExamList List<QDM.PositivePhysicalExamPerformed> ):\n' +
-    '  "Inpatient Encounters" Encounter\n' +
-    '    let FirstExam: First(ExamList Exam\n' +
-    '        where Global."EarliestOf"(Exam.relevantDatetime, Exam.relevantPeriod)during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 120 minutes]\n' +
-    '        sort by Global."EarliestOf"(relevantDatetime, relevantPeriod)\n' +
-    '    )\n' +
-    '    return {\n' +
-    '      EncounterId: Encounter.id,\n' +
-    '      FirstResult: FirstExam.result as Quantity,\n' +
-    '      Timing: Global."EarliestOf" ( FirstExam.relevantDatetime, FirstExam.relevantPeriod )\n' +
-    '    }\n' +
-    '\n' +
-    'define function "FirstPhysicalExamWithEncounterIdUsingLabTiming"(ExamList List<QDM.PositivePhysicalExamPerformed> ):\n' +
-    '  "Inpatient Encounters" Encounter\n' +
-    '    let FirstExamWithLabTiming: First(ExamList Exam\n' +
-    '        where Global."EarliestOf"(Exam.relevantDatetime, Exam.relevantPeriod)during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 1440 minutes]\n' +
-    '        sort by Global."EarliestOf"(relevantDatetime, relevantPeriod)\n' +
-    '    )\n' +
-    '    return {\n' +
-    '      EncounterId: Encounter.id,\n' +
-    '      FirstResult: FirstExamWithLabTiming.result as Quantity,\n' +
-    '      Timing: Global."EarliestOf" ( FirstExamWithLabTiming.relevantDatetime, FirstExamWithLabTiming.relevantPeriod )\n' +
-    '    }\n' +
-    '\n' +
-    'define function "FirstLabTestWithEncounterId"(LabList List<QDM.PositiveLaboratoryTestPerformed> ):\n' +
-    '  "Inpatient Encounters" Encounter\n' +
-    '    let FirstLab: First(LabList Lab\n' +
-    '        where Lab.resultDatetime during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 1440 minutes]\n' +
-    '        sort by resultDatetime\n' +
-    '    )\n' +
-    '    return {\n' +
-    '      EncounterId: Encounter.id,\n' +
-    '      FirstResult: FirstLab.result as Quantity,\n' +
-    '      Timing: FirstLab.resultDatetime\n' +
-    '    }'
+let measureCQL = QdmCql.QDMTestCaseCQLFullElementSection
 
 describe('Measure Creation: Cohort ListQDMPositiveEncounterPerformed', () => {
 
     before('Create Measure', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false, false,
             '2012-01-01', '2012-12-31')
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
@@ -158,9 +32,7 @@ describe('Measure Creation: Cohort ListQDMPositiveEncounterPerformed', () => {
     after('Clean up', () => {
 
         OktaLogin.Logout()
-
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('End to End Cohort ListQDMPositiveEncounterPerformed', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
@@ -7,6 +7,7 @@ import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { QiCore4Cql } from "../../../../Shared/FHIRMeasuresCQL"
 
 let measureName = 'CohortEpisodeWithStrat' + Date.now()
 let CqlLibraryName = 'CohortEpisodeWithStrat' + Date.now()
@@ -14,45 +15,7 @@ let testCaseTitle = 'PASS'
 let testCaseDescription = 'PASS' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let testCaseJson = TestCaseJson.TestCaseJson_CohortEpisodeWithStrat_PASS
-
-let measureCQL = 'library CohortEpisodeWithStrat1668108456699 version \'0.0.000\'\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
-    'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
-    'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
-    'valueset "Preventive Care Services-Initial Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
-    'valueset "Home Healthcare Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
-    'valueset "End Stage Renal Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    ' "Qualifying Encounters"\n' +
-    ' \n' +
-    'define "Qualifying Encounters":\n' +
-    '(\n' +
-    '[Encounter: "Office Visit"]\n' +
-    'union [Encounter: "Annual Wellness Visit"]\n' +
-    'union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
-    'union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
-    'union [Encounter: "Home Healthcare Services"]\n' +
-    ') ValidEncounter\n' +
-    'where ValidEncounter.period during "Measurement Period"\n' +
-    'and ValidEncounter.isFinishedEncounter()\n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '(Enc E where E.status = \'finished\') is not null\n' +
-    '\n' +
-    'define "Stratificaction 1":\n' +
-    ' "Qualifying Encounters" Enc\n' +
-    ' where Enc.type in "Annual Wellness Visit"'
+let measureCQL = QiCore4Cql.EpisodeWithStrat
 
 //MAT-7727
 describe('Measure Creation and Testing: Cohort Episode w/ Stratification', () => {

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/ExcelTestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/ExcelTestCaseExport.cy.ts
@@ -8,9 +8,8 @@ import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
 import { QDMElements } from "../../../../../Shared/QDMElements"
 import { CQLLibraryPage } from "../../../../../Shared/CQLLibraryPage"
+import { QdmCql } from "../../../../../Shared/QDMMeasuresCQL"
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
-const path = require('path')
-const downloadsFolder = Cypress.config('downloadsFolder')
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'QDMCQLLibrary' + Date.now()
@@ -18,133 +17,7 @@ let firstTestCaseTitle = 'Combo2 ThreeEncounter'
 let testCaseDescription = 'DENOMFail'
 let testCaseSeries = 'SBTestSeries'
 let secondTestCaseTitle = 'SBPFail GT24beforeAndGT2after'
-let measureCQL = 'library HybridHospitalWideReadmission version \'4.0.000\'\n' +
-    '\n' +
-    'using QDM version \'5.6\'\n' +
-    '\n' +
-    'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n' +
-    '\n' +
-    'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\' \n' +
-    '\n' +
-    'valueset "Acute care hospital Inpatient Encounter": \'urn:oid:2.16.840.1.113883.3.666.5.2289\' \n' +
-    'valueset "Bicarbonate lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.139\' \n' +
-    'valueset "Body temperature": \'urn:oid:2.16.840.1.113762.1.4.1045.152\' \n' +
-    'valueset "Body weight": \'urn:oid:2.16.840.1.113762.1.4.1045.159\' \n' +
-    'valueset "Creatinine lab test": \'urn:oid:2.16.840.1.113883.3.666.5.2363\' \n' +
-    'valueset "Emergency Department Visit": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.292\' \n' +
-    'valueset "Encounter Inpatient": \'urn:oid:2.16.840.1.113883.3.666.5.307\' \n' +
-    'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\' \n' +
-    'valueset "Glucose lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.134\' \n' +
-    'valueset "Heart Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.149\' \n' +
-    'valueset "Hematocrit lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.114\' \n' +
-    'valueset "Medicare Advantage payer": \'urn:oid:2.16.840.1.113762.1.4.1104.12\' \n' +
-    'valueset "Medicare FFS payer": \'urn:oid:2.16.840.1.113762.1.4.1104.10\' \n' +
-    'valueset "Observation Services": \'urn:oid:2.16.840.1.113762.1.4.1111.143\' \n' +
-    'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\' \n' +
-    'valueset "Oxygen Saturation by Pulse Oximetry": \'urn:oid:2.16.840.1.113762.1.4.1045.151\' \n' +
-    'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\' \n' +
-    'valueset "Potassium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.117\' \n' +
-    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\' \n' +
-    'valueset "Respiratory Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.130\' \n' +
-    'valueset "Sodium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.119\' \n' +
-    'valueset "Systolic Blood Pressure": \'urn:oid:2.16.840.1.113762.1.4.1045.163\' \n' +
-    'valueset "White blood cells count lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.129\' \n' +
-    '\n' +
-    'code "Birth date": \'21112-8\' from "LOINC" display \'Birth date\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "Denominator":\n' +
-    '  "Initial Population"\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    '  "Inpatient Encounters"\n' +
-    '\n' +
-    'define "Numerator":\n' +
-    '  "Initial Population"\n' +
-    '\n' +
-    'define "SDE Ethnicity":\n' +
-    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
-    '\n' +
-    'define "SDE Payer":\n' +
-    '  ["Patient Characteristic Payer": "Payer"]\n' +
-    '\n' +
-    'define "SDE Race":\n' +
-    '  ["Patient Characteristic Race": "Race"]\n' +
-    '\n' +
-    'define "SDE Sex":\n' +
-    '  ["Patient Characteristic Sex": "ONC Administrative Sex"]\n' +
-    '\n' +
-    'define "SDE Results":\n' +
-    '  {\n' +
-    '  // First physical exams\n' +
-    '    FirstHeartRate: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Heart Rate"]),\n' +
-    '    FirstSystolicBloodPressure: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Systolic Blood Pressure"]),\n' +
-    '    FirstRespiratoryRate: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Respiratory Rate"]),\n' +
-    '    FirstBodyTemperature: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Body temperature"]),\n' +
-    '    FirstOxygenSaturation: "FirstPhysicalExamWithEncounterId"(["Physical Exam, Performed": "Oxygen Saturation by Pulse Oximetry"]),\n' +
-    '  // Weight uses lab test timing\n' +
-    '    FirstBodyWeight: "FirstPhysicalExamWithEncounterIdUsingLabTiming"(["Physical Exam, Performed": "Body weight"]),\n' +
-    '  \n' +
-    '  // First lab tests\n' +
-    '    FirstHematocritLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Hematocrit lab test"]),\n' +
-    '    FirstWhiteBloodCellCount: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "White blood cells count lab test"]),\n' +
-    '    FirstPotassiumLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Potassium lab test"]),\n' +
-    '    FirstSodiumLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Sodium lab test"]),\n' +
-    '    FirstBicarbonateLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Bicarbonate lab test"]),\n' +
-    '    FirstCreatinineLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Creatinine lab test"]),\n' +
-    '    FirstGlucoseLab: "FirstLabTestWithEncounterId"(["Laboratory Test, Performed": "Glucose lab test"])\n' +
-    '  }\n' +
-    '\n' +
-    'define "Inpatient Encounters":\n' +
-    '  ["Encounter, Performed": "Encounter Inpatient"] InpatientEncounter\n' +
-    '    with ( ["Patient Characteristic Payer": "Medicare FFS payer"]\n' +
-    '      union ["Patient Characteristic Payer": "Medicare Advantage payer"] ) Payer\n' +
-    '      such that Global."HospitalizationWithObservationLengthofStay" ( InpatientEncounter ) < 365\n' +
-    '        and InpatientEncounter.relevantPeriod ends during day of "Measurement Period"\n' +
-    '        and AgeInYearsAt(date from start of InpatientEncounter.relevantPeriod)>= 65\n' +
-    '\n' +
-    'define function "LengthOfStay"(Stay Interval<DateTime> ):\n' +
-    '  difference in days between start of Stay and \n' +
-    '  end of Stay\n' +
-    '\n' +
-    'define function "FirstPhysicalExamWithEncounterId"(ExamList List<QDM.PositivePhysicalExamPerformed> ):\n' +
-    '  "Inpatient Encounters" Encounter\n' +
-    '    let FirstExam: First(ExamList Exam\n' +
-    '        where Global."EarliestOf"(Exam.relevantDatetime, Exam.relevantPeriod)during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 120 minutes]\n' +
-    '        sort by Global."EarliestOf"(relevantDatetime, relevantPeriod)\n' +
-    '    )\n' +
-    '    return {\n' +
-    '      EncounterId: Encounter.id,\n' +
-    '      FirstResult: FirstExam.result as Quantity,\n' +
-    '      Timing: Global."EarliestOf" ( FirstExam.relevantDatetime, FirstExam.relevantPeriod )\n' +
-    '    }\n' +
-    '\n' +
-    'define function "FirstPhysicalExamWithEncounterIdUsingLabTiming"(ExamList List<QDM.PositivePhysicalExamPerformed> ):\n' +
-    '  "Inpatient Encounters" Encounter\n' +
-    '    let FirstExamWithLabTiming: First(ExamList Exam\n' +
-    '        where Global."EarliestOf"(Exam.relevantDatetime, Exam.relevantPeriod)during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 1440 minutes]\n' +
-    '        sort by Global."EarliestOf"(relevantDatetime, relevantPeriod)\n' +
-    '    )\n' +
-    '    return {\n' +
-    '      EncounterId: Encounter.id,\n' +
-    '      FirstResult: FirstExamWithLabTiming.result as Quantity,\n' +
-    '      Timing: Global."EarliestOf" ( FirstExamWithLabTiming.relevantDatetime, FirstExamWithLabTiming.relevantPeriod )\n' +
-    '    }\n' +
-    '\n' +
-    'define function "FirstLabTestWithEncounterId"(LabList List<QDM.PositiveLaboratoryTestPerformed> ):\n' +
-    '  "Inpatient Encounters" Encounter\n' +
-    '    let FirstLab: First(LabList Lab\n' +
-    '        where Lab.resultDatetime during Interval[start of Encounter.relevantPeriod - 1440 minutes, start of Encounter.relevantPeriod + 1440 minutes]\n' +
-    '        sort by resultDatetime\n' +
-    '    )\n' +
-    '    return {\n' +
-    '      EncounterId: Encounter.id,\n' +
-    '      FirstResult: FirstLab.result as Quantity,\n' +
-    '      Timing: FirstLab.resultDatetime\n' +
-    '    }'
+const measureCQL = QdmCql.QDMTestCaseCQLFullElementSection
 
 describe('QDM Test Case Excel Export', () => {
 
@@ -162,9 +35,7 @@ describe('QDM Test Case Excel Export', () => {
     after('Clean up', () => {
 
         OktaLogin.Logout()
-
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Successful Excel Export for QDM Test Cases', () => {
@@ -388,12 +259,11 @@ describe('QDM Test Case Excel Export', () => {
         cy.get(TestCasesPage.testCaseStatus).eq(1).should('contain.text', 'Pass')
 
         //Export Test cases and assert the values
-        cy.get(TestCasesPage.testcaseQRDAExportBtn).click()
+        cy.get(TestCasesPage.actionCenterExport).click()
         cy.get('[class="btn-container"]').contains('Excel').click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Excel exported successfully')
 
-
-        const file = path.join(downloadsFolder, 'eCQMTitle-v0.0.000-QDM-TestCases.xlsx')
+        const file = 'cypress/downloads/eCQMTitle-v0.0.000-QDM-TestCases.xlsx'
         cy.readFile(file, { timeout: 15000 }).should('exist')
         cy.log('Successfully verified Excel file export')
 


### PR DESCRIPTION
These tests were all using CQL hardcoded into themselves that is actually shared with other tests.
I removed the hardcoded string & replaced them with shared CQL.
I'm sure there are many more instances of this, and we'll have to continually do this as we find them.

Note: these tests are also the first few to use my new split CQL files.