### PR TITLE
Fix for MeasureSearching Service file as well as additional update to TestCaseImportValidations file

### DIFF
--- a/cypress/e2e/Services/Measure Service/MeasureSearching.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureSearching.cy.ts
@@ -21,8 +21,8 @@ describe('Measure List Page Searching', () => {
 
         cy.getCookie('accessToken').then((accessToken) => {
             cy.request({
-                url: '/api/measures/search?query=TestMeasure',
-                method: 'GET',
+                url: '/api/measures/searches?query=' + measureName,
+                method: 'PUT',
                 headers: {
                     authorization: 'Bearer ' + accessToken.value
                 }

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -594,7 +594,8 @@ describe('Test case uniqueness error validation', () => {
         cy.log('Successfully verified zip file export')
 
         //delete test case
-        TestCasesPage.testCaseAction('delete')
+        cy.get('[data-testid="delete-action-icon"]').click()
+        Utilities.waitForElementVisible(TestCasesPage.deleteTestCaseContinueBtn, 35000)
         cy.get(TestCasesPage.deleteTestCaseContinueBtn).click()
 
         //Create test case


### PR DESCRIPTION
This PR contains fix to resolve regression test failure in the MeasureSearching service-level regression test as well as some additional updates to the TestCaseImportValidations test file, in light of the fix for bug MAT-8195.