### PR TITLE
feat: refactor Shared/Global and update usages

### DIFF
--- a/cypress/Shared/Global.ts
+++ b/cypress/Shared/Global.ts
@@ -1,6 +1,5 @@
 export class Global {
 
-    //dirty modal
     public static readonly dirtCheckModal = '[class="MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-aa4ov7 react-draggable"]'
     public static readonly discardChangesBtn = '[data-testid="group-form-discard-btn"]'
     public static readonly discardChangesContinue = '[data-testid="discard-dialog-continue-button"]'
@@ -14,30 +13,11 @@ export class Global {
         cy.get(this.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
         cy.get(this.discardChangesContinue).click()
     }
-    public static clickOnCancelChanges(): void {
+
+    public static clickOnKeepWorking(): void {
 
         cy.get(this.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
         cy.get(this.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
         cy.get(this.keepWorkingCancel).click()
     }
-
-    public static clickOnDirtyCheckDiscardChanges(): void {
-
-        cy.get(this.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
-        cy.get(this.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
-        cy.get(this.discardChangesContinue).click()
-    }
-    public static clickOnDirtyCheckCancelChanges(): void {
-
-        cy.get(this.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
-        cy.get(this.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
-        cy.get(this.keepWorkingCancel).click()
-    }
-    public static clickDiscardAndKeepWorking(): void {
-
-        cy.get(this.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
-        cy.get(this.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
-        cy.get(this.discardChangesContinue).click()
-    }
-
 }

--- a/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
@@ -224,15 +224,8 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        //confirm dirty check window
-        cy.get(EditMeasurePage.dirtCheckModal).should('exist')
-        cy.get(EditMeasurePage.dirtCheckModal).should('be.visible')
-
-        //select continue working on page
-        cy.get(Global.keepWorkingCancel).should('exist')
-        cy.get(Global.keepWorkingCancel).should('be.visible')
-        cy.get(Global.keepWorkingCancel).should('be.enabled')
-        cy.get(Global.keepWorkingCancel).click()
+        // confirm dirty check window
+        Global.clickOnKeepWorking()
 
         //discard previous entry
         cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
@@ -1098,15 +1091,8 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         //attempt to navigate away from the test cases tab / page
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
-        //confirm dirty check window
-        cy.get(EditMeasurePage.dirtCheckModal).should('exist')
-        cy.get(EditMeasurePage.dirtCheckModal).should('be.visible')
-
-        //select continue working on page
-        cy.get(Global.keepWorkingCancel).should('exist')
-        cy.get(Global.keepWorkingCancel).should('be.visible')
-        cy.get(Global.keepWorkingCancel).should('be.enabled')
-        cy.get(Global.keepWorkingCancel).click()
+        // confirm dirty check window
+        Global.clickOnKeepWorking()
 
         //confirm that previous edit is still present
         cy.get(MeasureGroupPage.qdmSDERadioButtons)

--- a/cypress/e2e/WebInterface/Measure/Measure Group/CreateMeasureGroup.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/CreateMeasureGroup.cy.ts
@@ -301,16 +301,12 @@ describe('Validate Measure Group -- scoring and populations', () => {
         //Warning Modal displayed when user navigated to another Measure Group without saving changes
         cy.log('Navigate to another Measure Group')
         cy.get(MeasureGroupPage.addMeasureGroupButton).click()
-        cy.get(Global.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
-        cy.get(Global.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
-        cy.get(Global.keepWorkingCancel).click()
+        Global.clickOnKeepWorking()
 
         //Warning Modal displayed when user navigated to a different tab without saving changes
         cy.log('Navigating to CQL Editor tab')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(Global.discardChangesConfirmationModal).should('contain.text', 'Discard Changes?')
-        cy.get(Global.discardChangesConfirmationText).should('contain.text', 'Are you sure you want to discard your changes?')
-        cy.get(Global.keepWorkingCancel).click()
+        Global.clickOnKeepWorking()
 
         //Warning Modal displayed when user clicks Discard Changes for that measure group
         cy.log('Click on Discard Changes button')

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLFunctions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLFunctions.cy.ts
@@ -196,6 +196,12 @@ describe('QDM CQL Functions', () => {
         cy.get(Global.discardChangesConfirmationModal).should('contain.text', 'Discard changes?')
         cy.get(CQLEditorPage.modalConfirmationText).should('contain.text', 'Are you sure you want to discard your changes in the CQL and edit the Function in the CQL?')
         cy.get(Global.keepWorkingCancel).click()
+         /*
+        Note: should be
+        Global.clickOnKeepWorking()
+        but this modal title has Discard changes? instead of Discard Changes?
+        */
+
 
         //Click on Delete button
         cy.get(CQLEditorPage.deleteSavedFunctions).click()

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
@@ -163,9 +163,8 @@ describe('QDM Library Includes fields', () => {
         cy.get(CQLEditorPage.deleteSavedLibrary).scrollIntoView()
         Utilities.waitForElementVisible(CQLEditorPage.deleteSavedLibrary, 5000)
         cy.get(CQLEditorPage.deleteSavedLibrary).click()
-        Utilities.waitForElementVisible('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]', 5000)
-        cy.get('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]').should('contain.text', 'Discard Changes?')
-        cy.get(Global.keepWorkingCancel).click()
+
+        Global.clickOnKeepWorking()
 
         //confirm contents in CQL editor still contains changes and save button is still available
         cy.get('[data-testid="editor-search-button"]').click()
@@ -317,9 +316,8 @@ describe('QDM Library Includes fields', () => {
         cy.get(CQLEditorPage.editSavedLibrary).scrollIntoView()
         Utilities.waitForElementVisible(CQLEditorPage.editSavedLibrary, 5000)
         cy.get(CQLEditorPage.editSavedLibrary).click()
-        Utilities.waitForElementVisible('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]', 5000)
-        cy.get('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]').should('contain.text', 'Discard Changes?')
-        cy.get(Global.keepWorkingCancel).click()
+
+        Global.clickOnKeepWorking()
 
         //confirm contents in CQL editor still contains changes and save button is still available
         cy.get('[data-testid="editor-search-button"]').click()

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLFunctions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLFunctions.cy.ts
@@ -176,6 +176,11 @@ describe('Qi Core CQL Functions', () => {
         cy.get(Global.discardChangesConfirmationModal).should('contain.text', 'Discard changes?')
         cy.get(CQLEditorPage.modalConfirmationText).should('contain.text', 'Are you sure you want to discard your changes in the CQL and edit the Function in the CQL?')
         cy.get(Global.keepWorkingCancel).click()
+        /*
+        Note: should be
+        Global.clickOnKeepWorking()
+        but this modal title wants Discard changes? instead of Discard Changes?
+        */
 
         //Click on Delete button
         cy.get(CQLEditorPage.deleteSavedFunctions).click()

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreLibraryIncludes.cy.ts
@@ -141,9 +141,8 @@ describe('Qi-Core Library Includes fields', () => {
         cy.get(CQLEditorPage.deleteSavedLibrary).scrollIntoView()
         Utilities.waitForElementVisible(CQLEditorPage.deleteSavedLibrary, 5000)
         cy.get(CQLEditorPage.deleteSavedLibrary).click()
-        Utilities.waitForElementVisible('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]', 5000)
-        cy.get('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]').should('contain.text', 'Discard Changes?')
-        cy.get(Global.keepWorkingCancel).click()
+
+        Global.clickOnKeepWorking()
 
         //confirm contents in CQL editor still contains changes and save button is still available
         cy.get('[data-testid="SearchIcon"]').click()
@@ -291,9 +290,8 @@ describe('Qi-Core Library Includes fields', () => {
         cy.get(CQLEditorPage.editSavedLibrary).scrollIntoView()
         Utilities.waitForElementVisible(CQLEditorPage.editSavedLibrary, 5000)
         cy.get(CQLEditorPage.editSavedLibrary).click()
-        Utilities.waitForElementVisible('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]', 5000)
-        cy.get('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]').should('contain.text', 'Discard Changes?')
-        cy.get(Global.keepWorkingCancel).click()
+
+        Global.clickOnKeepWorking()
 
         //confirm contents in CQL editor still contains changes and save button is still available
         cy.get('[data-testid="SearchIcon"]').click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseValidations.cy.ts
@@ -41,15 +41,14 @@ describe('Test Case Ownership Validations for QDM Measures', () => {
         MeasureGroupPage.CreateRatioMeasureGroupAPI(false, false, 'Initial Population', 'Initial Population', 'Initial Population')
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, QDMTCJson, false, true)
         OktaLogin.Login()
-
     })
 
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.UILogout()
         Utilities.deleteMeasure(altMeasureName, altCqlLibraryName, false, true)
-
     })
+
     it('Fields on Test Case page are not editable by Non Measure Owner', () => {
 
         //navigate to the all measures tab
@@ -84,7 +83,6 @@ describe('Test Case Ownership Validations for QDM Measures', () => {
         //Navigate to Expected/Actual tab
         cy.get(TestCasesPage.tctExpectedActualSubTab).click()
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.enabled')
-
     })
 })
 
@@ -98,15 +96,14 @@ describe('Create Test Case Validations', () => {
     beforeEach('Login', () => {
         OktaLogin.Login()
     })
+
     afterEach('Logout', () => {
         OktaLogin.Logout()
-
     })
 
     after('Clean up', () => {
 
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Description more than 250 characters', () => {
@@ -167,9 +164,9 @@ describe('Edit Test Case Validations', () => {
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
     })
+
     afterEach('Logout', () => {
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Description more than 250 characters', () => {
@@ -268,7 +265,7 @@ describe('Edit Test Case Validations', () => {
         Utilities.waitForElementVisible(CQLLibrariesPage.cqlLibraryDirtyCheck, 37000)
 
         //verify that the discard modal appears
-        Global.clickOnDirtyCheckCancelChanges()
+        Global.clickOnKeepWorking()
 
         //attempt to navigate away from the test case page
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -276,8 +273,7 @@ describe('Edit Test Case Validations', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
         Utilities.waitForElementVisible(CQLLibrariesPage.cqlLibraryDirtyCheck, 37000)
         //verify that the discard modal appears
-        Global.clickOnDirtyCheckDiscardChanges()
-
+        Global.clickOnDiscardChanges()
     })
 })
 
@@ -304,7 +300,6 @@ describe('Dirty Check Validations', () => {
     afterEach('Logout and cleanup', () => {
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Validate dirty check on the test case title, in the test case details tab', () => {
@@ -333,7 +328,7 @@ describe('Dirty Check Validations', () => {
         Utilities.waitForElementVisible(CQLLibrariesPage.cqlLibraryDirtyCheck, 37000)
 
         //verify that the discard modal appears
-        Global.clickOnDirtyCheckCancelChanges()
+        Global.clickOnKeepWorking()
 
         //attempt to navigate away from the test case page
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -341,8 +336,7 @@ describe('Dirty Check Validations', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
         Utilities.waitForElementVisible(CQLLibrariesPage.cqlLibraryDirtyCheck, 37000)
         //verify that the discard modal appears
-        Global.clickOnDirtyCheckDiscardChanges()
-
+        Global.clickOnDiscardChanges()
     })
 
     it('Validate dirty check on Testcase Expected/Actual tab', () => {
@@ -369,7 +363,7 @@ describe('Dirty Check Validations', () => {
         cy.get(TestCasesPage.QDMTcDiscardChangesButton).click()
 
         //verify discard modal and click on keep working
-        Global.clickDiscardAndKeepWorking()
+        Global.clickOnDiscardChanges()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.empty')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.empty')
@@ -402,8 +396,8 @@ describe.skip('QDM Measure / Test Case: Dirty Check on attribute: Quantity Attri
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
+
     it('Validate dirty check on the test case attributes', () => {
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
@@ -437,7 +431,7 @@ describe.skip('QDM Measure / Test Case: Dirty Check on attribute: Quantity Attri
         //attempt to navigate away without clicking on the add button (for the attribute)
         cy.get(Header.measures).click()
         Utilities.waitForElementVisible(TestCasesPage.QDMDiscardChangesDialog, 35000)
-        Global.clickOnDirtyCheckCancelChanges()
+        Global.clickOnKeepWorking()
         //user stays on current page
         cy.readFile('cypress/fixtures/measureId').should('exist').then((measureid) => {
             cy.readFile('cypress/fixtures/testCaseId').should('exist').then((testCaseId) => {
@@ -453,7 +447,7 @@ describe.skip('QDM Measure / Test Case: Dirty Check on attribute: Quantity Attri
         //another attempt to navigate away from current page after clicking on the add button
         cy.get(Header.measures).click()
         Utilities.waitForElementVisible(TestCasesPage.QDMDiscardChangesDialog, 35000)
-        Global.clickOnDirtyCheckDiscardChanges()
+        Global.clickOnDiscardChanges()
 
         //user is navigated away from test case page
         cy.location('pathname', { timeout: 60000 }).should('include', '/measures')
@@ -568,7 +562,6 @@ describe('QDM CQM-Execution failure error validations: CQL Errors and missing gr
 
         //confirm that the Run Test button is disabled
         cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('not.be.enabled')
-
     })
 })
 
@@ -671,16 +664,14 @@ describe('QDM CQM-Execution failure error validations: Data transformation- MADi
         cy.clearAllCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-
-
     })
 
     afterEach('Logout and Clean up', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
+
     it("A message is displayed if the measure's CQL Valueset not found in Vsac", () => {
 
         //log into MADiE
@@ -721,7 +712,6 @@ describe('QDM CQM-Execution failure error validations: Data transformation- MADi
 
         //confirm that the Run Test button is disabled
         cy.get(TestCasesPage.QDMRunTestCasefrmTestCaseListPage).should('not.be.enabled')
-
     })
 })
 
@@ -739,7 +729,6 @@ describe('Non Boolean Population basis Expected values', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
 
     it('Validate Non Boolean Expected values', () => {
@@ -785,7 +774,6 @@ describe('Non Boolean Population basis Expected values', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).clear().type('1.9')
         cy.get(TestCasesPage.nonBooleanExpectedValueError).should('contain.text', 'Decimals values cannot be entered in the population expected values')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-
     })
 })
 


### PR DESCRIPTION
Shared/Global had several functions that were all functionally the same & only named differently.
I removed all the duplicates (and their usage across tests) and centralized all usage around only 2 that were needed.

In the test files:
I made updates for whitespace, the needed Global functions, and converted some tests that used the same selectors to use the functions instead.