### PR TITLE
feat: add extra clicks to clear dropdown

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureHighlighting.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureHighlighting.cy.ts
@@ -797,6 +797,9 @@ describe('Measure Highlighting', () => {
             }
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+       
+        cy.get(MeasureGroupPage.QDMPopCriteria1Desc).click()
+
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial PopulationOne')
         Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Initial Population')
@@ -900,6 +903,9 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Highlighting ac
             }
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+     
+        cy.get(MeasureGroupPage.QDMPopCriteria1Desc).click()
+
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial PopulationOne')
         Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Initial Population')
@@ -1013,6 +1019,9 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Highlighting ac
             }
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+       
+        cy.get(MeasureGroupPage.QDMPopCriteria1Desc).click()
+       
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial PopulationOne')
         Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Initial Population')
@@ -1180,6 +1189,9 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Includes Result
             }
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+        
+        cy.get(MeasureGroupPage.QDMPopCriteria1Desc).click()
+        
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
         Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
@@ -1314,6 +1326,9 @@ describe('QI-Core: Test Case Highlighting Left navigation panel: Includes Result
             }
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
+        
+        cy.get(MeasureGroupPage.QDMPopCriteria1Desc).click()
+        
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
         Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Denominator')


### PR DESCRIPTION
Same fix used in https://github.com/MeasureAuthoringTool/madie-cypress/pull/1742 applied to this set of tests.

I added a meaningless extra click to clear off the scoring dropdown before the test continues to its next step.