### PR TITLE
feat: updates to tests for new action center option

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -445,6 +445,7 @@ export class TestCasesPage {
     public static readonly actionCenterClone = '[data-testid="clone-action-btn"]'
     public static readonly actionCenterCopyToMeasure = '[data-testid="copy-action-btn"]'
     public static readonly actionCenterExport = '[data-testid="export-action-btn"]'
+    public static readonly actionCenterShiftDates = '[data-testid="shift-test-case-dates-action-btn"]'
 
     //This function grabs the data-testid value off of the view button and extracts the id out of it.
     //Then, it puts that id in a file. For added control, the optional "eleTableEntry" parameter can be

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseButtons.cy.ts
@@ -1,14 +1,13 @@
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { CreateMeasurePage, SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
 import { OktaLogin } from "../../../../Shared/OktaLogin"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { EditMeasureActions, EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage, MeasureGroups, MeasureScoring, MeasureType, PopulationBasis } from "../../../../Shared/MeasureGroupPage"
+import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { TestCase, TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { Header } from "../../../../Shared/Header"
-
 
 const now = Date.now()
 const measure = {
@@ -27,12 +26,6 @@ const testCase2: TestCase = {
     group: 'ICFTestSeries',
     json: TestCaseJson.tcJSON_QDM_Value
 }
-const populations: MeasureGroups = {
-    initialPopulation: 'Initial Population',
-    denominator: 'Denominator',
-    numerator: 'Numerator'
-}
-
 
 describe('Test case list page - Action Center icons for measure owner', () => {
 
@@ -73,7 +66,6 @@ describe('Test case list page - Action Center icons for measure owner', () => {
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
-
 
     it('Delete icon is present and enables correctly', () => {
 
@@ -120,6 +112,24 @@ describe('Test case list page - Action Center icons for measure owner', () => {
             cy.get(excelButton).should('be.visible').click()
         })
     })
+
+    it('Shift dates icon is present and enables correctly', () => {
+
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.disabled')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to shift test case dates')
+
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Shift test case dates')
+
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
+
+        cy.get(TestCasesPage.actionCenterShiftDates).click()
+
+        Utilities.waitForElementVisible(TestCasesPage.shiftSpecificTestCasesCancelBtn, 5500)
+        cy.get(TestCasesPage.shiftSpecificTestCasesSaveBtn).should('be.disabled')
+    })
 })
 
 describe('Test case list page - Action Center icons for versioned measure', () => {
@@ -161,19 +171,14 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         Utilities.deleteVersionedMeasure(measure.name, measure.cqlLibraryName)
     })
 
-    it('Only Export icon is present and it enables correctly', () => {
-        // checks that delete and clone are not present at all
+    it('Export icon is present and it enables correctly', () => {
+        // checks that delete, clone, and shift dates are not present at all
         cy.get(TestCasesPage.actionCenterDelete).should('not.exist')
         cy.get(TestCasesPage.actionCenterClone).should('not.exist')
-    
+        cy.get(TestCasesPage.actionCenterShiftDates).should('not.exist')
 
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Test cases must be executed prior to exporting.')
-
-        TestCasesPage.checkTestCase(2)
-        cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
-        TestCasesPage.checkTestCase(1)
-        cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
 
         cy.get(TestCasesPage.executeTestCaseButton).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 30500)
@@ -190,6 +195,22 @@ describe('Test case list page - Action Center icons for versioned measure', () =
             cy.get(qrdaButton).should('be.visible')
             cy.get(excelButton).should('be.visible').click()
         })
+    })
+
+    it('Copy To icon is present and it enables correctly', () => {
+
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
+        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).click()
+
+        cy.contains('Copy To').should('be.visible')
+        cy.get(MeasuresPage.measureListTitles).should('be.visible')
     })
 })
 
@@ -235,29 +256,46 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
 
-    it('Non-owner only sees Export icon; it enables correctly', () => {
-         // checks that delete and clone are not present at all
-         cy.get(TestCasesPage.actionCenterDelete).should('not.exist')
-         cy.get(TestCasesPage.actionCenterClone).should('not.exist')
-     
-         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
-         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Test cases must be executed prior to exporting.')
- 
-         cy.get(TestCasesPage.executeTestCaseButton).click()
-         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 30500)
- 
-         cy.get(TestCasesPage.actionCenterExport).should('be.enabled').click()
- 
-         let qrdaButton: string
-         let excelButton: string
-         cy.readFile('cypress/fixtures/measureId').then(measureId => {
- 
-             qrdaButton = 'button[data-testid="export-qrda-' + measureId + '"]'
-             excelButton = 'button[data-testid="export-excel-' + measureId + '"]'
- 
-             cy.get(qrdaButton).should('be.visible')
-             cy.get(excelButton).should('be.visible').click()
-         })
-    })
+    it('Non-owner sees Export icon; it enables correctly', () => {
+        // checks that delete, clone, shift dates are not present at all
+        cy.get(TestCasesPage.actionCenterDelete).should('not.exist')
+        cy.get(TestCasesPage.actionCenterClone).should('not.exist')
+        cy.get(TestCasesPage.actionCenterShiftDates).should('not.exist')
+
+       cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
+       cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Test cases must be executed prior to exporting.')
+
+       cy.get(TestCasesPage.executeTestCaseButton).click()
+        Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 30500)
+
+        cy.get(TestCasesPage.actionCenterExport).should('be.enabled').click()
+
+        let qrdaButton: string
+        let excelButton: string
+        cy.readFile('cypress/fixtures/measureId').then(measureId => {
+
+            qrdaButton = 'button[data-testid="export-qrda-' + measureId + '"]'
+            excelButton = 'button[data-testid="export-excel-' + measureId + '"]'
+
+            cy.get(qrdaButton).should('be.visible')
+            cy.get(excelButton).should('be.visible').click()
+        })
+   })
+
+   it('Non-owner sees Copy To icon; it enables correctly', () => {
+
+       cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
+       cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+
+       TestCasesPage.checkTestCase(2)
+       cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+       TestCasesPage.checkTestCase(1)
+       cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+
+       cy.get(TestCasesPage.actionCenterCopyToMeasure).click()
+
+       cy.contains('Copy To').should('be.visible')
+       cy.get(MeasuresPage.measureListTitles).should('be.visible')
+   })
 })
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseButtons.cy.ts
@@ -8,7 +8,6 @@ import { Utilities } from "../../../../Shared/Utilities"
 import { MeasureGroupPage, MeasureGroups, MeasureScoring, MeasureType, PopulationBasis } from "../../../../Shared/MeasureGroupPage"
 import { TestCase, TestCasesPage } from "../../../../Shared/TestCasesPage"
 
-
 const now = Date.now()
 const measure = {
     name: 'TestCaseButtons' + now,
@@ -93,6 +92,24 @@ describe('Test case list page - Action Center icons for measure owner', () => {
         cy.get(TestCasesPage.exportCollectionTypeOption).should('be.visible')
         cy.get(TestCasesPage.exportTransactionTypeOption).should('be.visible').click()
     })
+
+    it('Shift dates icon is present and enables correctly', () => {
+
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.disabled')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to shift test case dates')
+
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Shift test case dates')
+
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
+
+        cy.get(TestCasesPage.actionCenterShiftDates).click()
+
+        Utilities.waitForElementVisible(TestCasesPage.shiftSpecificTestCasesCancelBtn, 5500)
+        cy.get(TestCasesPage.shiftSpecificTestCasesSaveBtn).should('be.disabled')
+    })
 })
 
 describe('Test case list page - Action Center icons for versioned measure', () => {
@@ -116,11 +133,11 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         Utilities.deleteVersionedMeasure(measure.name, measure.cqlLibraryName)
     })
 
-    it('Only Export icon is present and it enables correctly', () => {
-        // checks that delete and clone are not present at all
+    it('Export icon is present and it enables correctly', () => {
+        // checks that delete, clone, and shift dates are not present at all
         cy.get(TestCasesPage.actionCenterDelete).should('not.exist')
         cy.get(TestCasesPage.actionCenterClone).should('not.exist')
-    
+        cy.get(TestCasesPage.actionCenterShiftDates).should('not.exist')
 
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to export')
@@ -135,6 +152,23 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         cy.get(TestCasesPage.exportCollectionTypeOption).should('be.visible')
         cy.get(TestCasesPage.exportTransactionTypeOption).should('be.visible').click()
     })
+
+    it('Copy To icon is present and it enables correctly', () => {
+
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
+        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).click()
+
+        cy.contains('Copy To').should('be.visible')
+        cy.get(MeasuresPage.measureListTitles).should('be.visible')
+    })
+
 })
 
 describe('Test case list page - Action Center icons for non-owner', () => {
@@ -158,10 +192,11 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
 
-    it('Non-owner only sees Export icon; it enables correctly', () => {
-         // checks that delete and clone are not present at all
+    it('Non-owner sees Export icon; it enables correctly', () => {
+         // checks that delete, clone, shift dates are not present at all
          cy.get(TestCasesPage.actionCenterDelete).should('not.exist')
          cy.get(TestCasesPage.actionCenterClone).should('not.exist')
+         cy.get(TestCasesPage.actionCenterShiftDates).should('not.exist')
 
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to export')
@@ -175,6 +210,22 @@ describe('Test case list page - Action Center icons for non-owner', () => {
 
         cy.get(TestCasesPage.exportCollectionTypeOption).should('be.visible')
         cy.get(TestCasesPage.exportTransactionTypeOption).should('be.visible').click()
+    })
+
+    it('Non-owner sees Copy To icon; it enables correctly', () => {
+
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
+        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).click()
+
+        cy.contains('Copy To').should('be.visible')
+        cy.get(MeasuresPage.measureListTitles).should('be.visible')
     })
 })
 


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-8194

Updated tests for test case list action center buttons, specifically the basic UI tests for when the buttons enable/disable & their tooltip values.

This story contains the changes for both the basic UI and the functionality changes - my next PR will update tests for the functionality changes.

Note: I also updated to include that same basic UI aspect of https://jira.cms.gov/browse/MAT-8003 since it's also happening right now.