### PR TITLE
Updates to the EditMeasureAddMetaData regression test file

### DIFF
--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
@@ -123,16 +123,17 @@ describe('Edit Measure: Add Meta Data', () => {
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
+        //commenting out until definition flag is removed
         //Definition
-        cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
-        cy.get(EditMeasurePage.createDefinitionBtn).click()
-        Utilities.waitForElementVisible(EditMeasurePage.editReferenceModal, 50000)
-        cy.get(EditMeasurePage.definitionTermInput).type('DefinitionTerm')
-        cy.get(EditMeasurePage.definitionInput).type('Definition details for DefinitionTerm')
-        Utilities.waitForElementEnabled(EditMeasurePage.saveButton, 50000)
-        cy.get(EditMeasurePage.saveButton).click()
-        cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).should('include.text', 'DefinitionTermDefinition details for DefinitionTerm')
-        cy.log('Measure Definition added successfully')
+        /*         cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
+                cy.get(EditMeasurePage.createDefinitionBtn).click()
+                Utilities.waitForElementVisible(EditMeasurePage.editReferenceModal, 50000)
+                cy.get(EditMeasurePage.definitionTermInput).type('DefinitionTerm')
+                cy.get(EditMeasurePage.definitionInput).type('Definition details for DefinitionTerm')
+                Utilities.waitForElementEnabled(EditMeasurePage.saveButton, 50000)
+                cy.get(EditMeasurePage.saveButton).click()
+                cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).should('include.text', 'DefinitionTermDefinition details for DefinitionTerm')
+                cy.log('Measure Definition added successfully') */
 
         cy.get(Header.mainMadiePageButton).click()
         //wait until page / tabs loads
@@ -217,28 +218,29 @@ describe('Edit Measure: Add Meta Data', () => {
         })
         cy.log('Measure Clinical Recommendation added successfully')
 
+        //commenting out until definition flag is removed
         //definition
-        cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
-        cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).find('[class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1ns8gjm"]').should('have.attr', 'aria-label', 'Edit').click()
-        Utilities.waitForElementVisible(EditMeasurePage.editReferenceModal, 50000)
-        cy.get(EditMeasurePage.definitionTermInput).clear().type('DefinitionTermUpdate')
-        cy.get(EditMeasurePage.definitionInput).clear().type('Definition details for DefinitionTerm')
-        Utilities.waitForElementEnabled(EditMeasurePage.saveButton, 50000)
-        cy.get(EditMeasurePage.saveButton).click()
-        cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).should('include.text', 'DefinitionTermUpdateDefinition details for DefinitionTerm')
-        cy.log('Measure Definition updated successfully')
-
-        //delete definition
-        cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
-        cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).find('[class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1tb4h4m"]').should('have.attr', 'aria-label', 'Delete').click()
-        Utilities.waitForElementVisible(EditMeasurePage.defDeleteContinueButton, 50000)
-        cy.get(EditMeasurePage.defDeleteContinueButton).click()
-        Utilities.waitForElementToNotExist
-        cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).find(EditMeasurePage.emptyDefinitionVal).should('include.text', 'There are currently no definitions. Click the (Add Term) button above to add one.')
-        cy.log('Measure Definition deleted successfully')
+        /*         cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
+                cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).find('[class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1ns8gjm"]').should('have.attr', 'aria-label', 'Edit').click()
+                Utilities.waitForElementVisible(EditMeasurePage.editReferenceModal, 50000)
+                cy.get(EditMeasurePage.definitionTermInput).clear().type('DefinitionTermUpdate')
+                cy.get(EditMeasurePage.definitionInput).clear().type('Definition details for DefinitionTerm')
+                Utilities.waitForElementEnabled(EditMeasurePage.saveButton, 50000)
+                cy.get(EditMeasurePage.saveButton).click()
+                cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).should('include.text', 'DefinitionTermUpdateDefinition details for DefinitionTerm')
+                cy.log('Measure Definition updated successfully')
+        
+                //delete definition
+                cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
+                cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).find('[class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1tb4h4m"]').should('have.attr', 'aria-label', 'Delete').click()
+                Utilities.waitForElementVisible(EditMeasurePage.defDeleteContinueButton, 50000)
+                cy.get(EditMeasurePage.defDeleteContinueButton).click()
+                Utilities.waitForElementToNotExist
+                cy.get(EditMeasurePage.definitionMetaTable).find(EditMeasurePage.definitionMetaTableBody).find(EditMeasurePage.emptyDefinitionVal).should('include.text', 'There are currently no definitions. Click the (Add Term) button above to add one.')
+                cy.log('Measure Definition deleted successfully') */
     })
-
-    it('Verify alphabetical order and pagination of Measure Definitions', () => {
+    //skipping until definition flag is removed
+    it.skip('Verify alphabetical order and pagination of Measure Definitions', () => {
 
         MeasuresPage.actionCenter('edit')
 


### PR DESCRIPTION
This PR contains updates to the EditMeasureAddMetaData regression test file to skip or comment tests or references to the new but not live definition meta sub-section, on Qi Core measures.