### PR TITLE
fix: pause for editor to load, correct groups

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -742,6 +742,7 @@ export class TestCasesPage {
             cy.get(TestCasesPage.aceEditor).should('be.visible')
             cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
 
+            cy.wait(1500)
             cy.get(this.aceEditor).type(testCaseJson, { parseSpecialCharSequences: false })
 
             cy.get(this.detailsTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
@@ -235,13 +235,7 @@ describe('Qi Core Measure - Test case number on a Draft Measure', () => {
     beforeEach('Create Measure, Test case & Login', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-
-        const pops: MeasureGroups = {
-            initialPopulation: 'Qualifying Encounters',
-            denominator: 'Qualifying Encounters',
-            numerator: 'Qualifying Encounters'
-        }
-        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.Ratio, pops)
+        MeasureGroupPage.CreateRatioMeasureGroupAPI(false, false, 'Qualifying Encounters', 'Qualifying Encounters','Qualifying Encounters', 'Encounter') 
         TestCasesPage.CreateTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase1.json)
         OktaLogin.Login()
     })


### PR DESCRIPTION
Added a small pause to allow CQL editor to fully load - I observed that the .type() command was sometimes starting before the editor was ready & we would effectively miss the 1st few characters of the entry.

Also corrected a "create group" API call that was failing.