### PR TITLE
Update to MeasureGroupTabs regression test file

### DIFF
--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureGroupTabs.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureGroupTabs.cy.ts
@@ -636,23 +636,6 @@ describe('Validating Stratification tabs', () => {
         cy.get(MeasureGroupPage.stratDescTwo).should('contain.text', 'StratificationFour')
     })
 
-    it('Stratification tab is not present / available when the Ratio scoring value is selected', () => {
-
-        //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
-
-        //Click on Measure Group tab
-        Utilities.waitForElementVisible(EditMeasurePage.measureGroupsTab, 30000)
-        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-
-        //select Ratio scoring type
-        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringRatio)
-
-        //assert that Stratification is no longer available
-        cy.get(MeasureGroupPage.stratificationTab).should('not.exist')
-    })
-
     it('Verify error message when the Stratification return type does not match with population basis', () => {
 
         //Click on Edit Measure
@@ -833,9 +816,9 @@ describe('Validating Reporting tabs', () => {
         // IN should contain previously saved selected value
         cy.get(MeasureGroupPage.improvementNotationSelect).should('exist').should('be.visible')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Increased score indicates improvement')
- 
+
         // and here?
- 
+
     })
 })
 


### PR DESCRIPTION
This PR removes a test in the MeasureGroupTabs regression test file that validated that the Stratification tab, on the PC area, no longer appears if Ratio scoring is selected. Stratification tab now appears regardless of scoring.