### PR TITLE
Resolve manifest test failure in the QDMTestCaseCreation regression test file

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -173,6 +173,7 @@ export class TestCasesPage {
     public static readonly qdmManifestSelectDropDownBox = '[id="manifest-select"]'
     public static readonly qdmManifestFirstOption = '[data-value="ecqm-update-4q2017-eh"]'
     public static readonly qdmManifestMaySecondOption = '[data-value="ecqm-update-2024-05-02"]'
+    public static readonly qdmMantifestMayFailTestOption = '[data-testid="manifest-option-ecqm-update-2022-05-05"]'
     public static readonly qdmManifestSaveBtn = '[data-testid="manifest-expansion-save-button"]'
     public static readonly qdmManifestDiscardBtn = '[data-testid="manifest-expansion-discard-changes-button"]'
     public static readonly qdmManifestSuccess = '[data-testid="manifest-expansion-success-text"]'
@@ -493,7 +494,7 @@ export class TestCasesPage {
         let testCaseId: string
         const testCaseIdPath = 'cypress/fixtures/testCaseId'
 
-       cy.contains('td[data-testid*="caseNumber"]', testCaseNumber)
+        cy.contains('td[data-testid*="caseNumber"]', testCaseNumber)
             .parent('tr')
             .find('button.qpp-c-button')
             .invoke('attr', 'data-testid')
@@ -1031,7 +1032,7 @@ export class TestCasesPage {
                 break
 
             case TestCaseAction.copyToMeasure:
-                
+
                 cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled').click()
 
                 cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -282,18 +282,16 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.qdmExpansionRadioOptionGroup)
             .find('[type="radio"]')
             .then((radio) => {
-                //check / select radio button for manifest
-                cy.wrap(radio).eq(1).check({ force: true }).should('be.checked');
-                cy.contains('[id="manifest-select-label"]', 'Manifest');
 
-                cy.get(TestCasesPage.qdmManifestSelectDropDownBox).click()
-                cy.get(TestCasesPage.qdmManifestMaySecondOption).click()
-                cy.get(TestCasesPage.qdmManifestSaveBtn).click()
-                cy.get(TestCasesPage.qdmManifestSuccess).should('contain.text', 'Expansion details Updated Successfully')
+                //check / select radio button for the value of 'Latest'
+                cy.wrap(radio).eq(0).check({ force: true }).should('be.checked');
+                cy.contains('[data-testid="manifest-expansion-radio-buttons-group"] > :nth-child(1) > .MuiTypography-root', 'Latest');
 
+                cy.get(TestCasesPage.qdmManifestSelectDropDownBox).should('not.exist')
+
+                // Verify that first radio button is no longer checked
+                cy.wrap(radio).eq(1).should('not.be.checked');
             })
-        //confirm that manifest drop down has selected value
-        cy.get(TestCasesPage.qdmManifestSelectDropDownBox).should('contain.text', 'ecqm-update-2024-05-02')
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -447,22 +445,20 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.qdmExpansionRadioOptionGroup)
             .find('[type="radio"]')
             .then((radio) => {
-                //confirm that initial value is set to 'Manifest'
-                cy.wrap(radio).eq(1).should('be.checked');
+                //check / select radio button for manifest
+                cy.wrap(radio).eq(1).check({ force: true }).should('be.checked');
                 cy.contains('[id="manifest-select-label"]', 'Manifest');
 
-                //check / select radio button for the value of 'Latest'
-                cy.wrap(radio).eq(0).check({ force: true }).should('be.checked');
-                cy.contains('[data-testid="manifest-expansion-radio-buttons-group"] > :nth-child(1) > .MuiTypography-root', 'Latest');
+                cy.get(TestCasesPage.qdmManifestSelectDropDownBox).click()
+                cy.get(TestCasesPage.qdmMantifestMayFailTestOption).click()
+                cy.get(TestCasesPage.qdmManifestSaveBtn).click()
+                cy.get(TestCasesPage.qdmManifestSuccess).should('contain.text', 'Expansion details Updated Successfully')
 
-                cy.get(TestCasesPage.qdmManifestSelectDropDownBox).should('not.exist')
-
-                // Verify that first radio button is no longer checked
-                cy.wrap(radio).eq(1).should('not.be.checked');
             })
-        cy.get(TestCasesPage.qdmManifestSaveBtn).click()
-        cy.get(TestCasesPage.qdmManifestSuccess).should('contain.text', 'Expansion details Updated Successfully')
+
         Utilities.waitForElementToNotExist(TestCasesPage.qdmManifestSuccess, 25000)
+        //confirm that manifest drop down has selected value
+        cy.get(TestCasesPage.qdmManifestSelectDropDownBox).should('contain.text', 'ecqm-update-2022-05-05')
         cy.reload()
         //Navigate to Test Cases page
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')


### PR DESCRIPTION
This PR contains updates to the QDMTestCaseCreation regression test file as well as to the TestCasesPage support file, to resolve recent regression test run failure.