### PR TITLE
Removing NegativeFeatureFlagTests test for the Library check box test

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Feature Flag Testing/NegativeFeatureFlagTests.cy.ts
@@ -10,14 +10,8 @@ import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
 import { Header } from "../../../../Shared/Header"
 import { LandingPage } from "../../../../Shared/LandingPage"
-import { Environment } from "../../../../Shared/Environment"
-import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
-import { MadieObject, PermissionActions } from "../../../../Shared/Utilities"
 
-let CQLLibraryName = 'TestLibrary' + Date.now()
-let newCQLLibraryName = ''
-let CQLLibraryPublisher = 'SemanticBits'
-let harpUserALT = Environment.credentials().harpUserALT
+
 let measureName = 'TestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
 let testCaseTitle = 'test case title'
@@ -167,46 +161,6 @@ describe('QI Core v6: UI Elements Builder tab is not shown', () => {
         cy.get(TestCasesPage.aceEditorJsonInput).should('be.empty')
     })
 
-})
-
-//"LibraryListCheckboxes": false
-describe('Confirm that check boxes for CQL Libraries do not appear', () => {
-
-    beforeEach('Create CQL Library', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        newCQLLibraryName = CQLLibraryName + randValue + randValue + 1
-
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.setAccessTokenCookie()
-        CQLLibraryPage.createCQLLibraryAPI(newCQLLibraryName, CQLLibraryPublisher)
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        //set local user that does not own the Library
-        cy.setAccessTokenCookie()
-    })
-
-    after('Log out and Clean up', () => {
-
-        OktaLogin.UILogout()
-
-    })
-
-    it('Confirm that check boxes do not exist, for CQL Libraries, while the feature flag is set to false', () => {
-
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.setAccessTokenCookie()
-
-        //Share Library with ALT User
-        Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
-
-        OktaLogin.Login()
-        cy.get(Header.cqlLibraryTab).click()
-
-        Utilities.waitForElementToNotExist('[data-testid*="cqlLibrary-button-0_select"]', 50000)
-    })
 })
 
 // "QICoreIncludeSDEValues": false


### PR DESCRIPTION
This PR removes the test from the NegativeFeatureFlagTests that verifies the flag for the Library check boxes are set to false, due to this flag being set to true in PROD, at the release of 2.2.0.