### PR TITLE
Reducing redundancy: canel button

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -15,7 +15,6 @@ export class CQLLibraryPage {
     public static readonly cqlLibraryDeleteDialogContinueBtn = '[data-testid="delete-dialog-continue-button"]'
     public static readonly applyEditsSavedLibraryBtn = '[data-testid="apply-button"]'
     public static readonly cqlLibraryDeleteDialogCancelBtn = '[data-testid="delete-dialog-cancel-button"]'
-    public static readonly savedLibrariesEditDetailsCancelBtn = '[data-testid="cancel-button"]'
     public static readonly cqlLibraryDeleteDialog = '[data-testid="delete-dialog"]'
     public static readonly cqlLibSaveSuccessMessage = '[class="madie-alert success"]'
     public static readonly cqlLibSearchResultsTable = '[data-testid="table-body"]'
@@ -447,8 +446,8 @@ export class CQLLibraryPage {
                 cy.get(this.cqlLibraryDeleteDialogContinueBtn).click()
                 break
             }
-            default: {}
+            default: { }
         }
     }
-    
+
 }

--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -35,7 +35,6 @@ export class EditMeasurePage {
     //Associate QDM and QI Core measures:
     public static readonly associateCmsIdDialog = '[data-testid="associate-cms-id-dialog-tbl"]'
     public static readonly cpyMetaDataCheckBox = '[data-testid="copy-cms-id-checkbox"]'
-    public static readonly associateCmsCancel = '[data-testid="cancel-button"]'
     public static readonly sureDialog = '[class="MuiDialog-paper MuiDialog-paperScrollPaper MuiDialog-paperWidthSm MuiDialog-paperFullWidth css-aa4ov7 react-draggable"]'
     public static readonly sureDialogCancelBtn = '[data-testid="associate-cms-identifier-confirmation-dialog-cancel-button"]'
     public static readonly sureDialogContinueBtn = '[data-testid="associate-cms-identifier-confirmation-dialog-continue-button"]'
@@ -101,7 +100,6 @@ export class EditMeasurePage {
     public static readonly saveButton = '[data-testid="save-button"]'
     public static readonly successMessage = '[class="toast success"]'
     public static readonly measureReferenceTable = '[data-testid="measure-references-table-body"]'
-    public static readonly measureReferenceDiscardChanges = '[data-testid="cancel-button"]'
     public static readonly deleteReference = '[data-testid*="delete-measure-reference"]'
     public static readonly editReference = '[data-testid*="edit-measure-reference"]'
 
@@ -130,7 +128,6 @@ export class EditMeasurePage {
     public static readonly cqlEditorSaveButton = '[data-testid="save-cql-btn"]'
     //discard changes
     public static readonly cqlEditorDiscardButton = '[data-testid="reset-cql-btn"]'
-    public static readonly measureDetailsDiscardChangesBtn = '[data-testid="cancel-button"]'
 
     //Delete Measure
     public static readonly deleteMeasureButton = '[data-testid=delete-measure-button]'

--- a/cypress/Shared/Global.ts
+++ b/cypress/Shared/Global.ts
@@ -6,6 +6,7 @@ export class Global {
     public static readonly discardChangesConfirmationModal = '.MuiBox-root'
     public static readonly discardChangesConfirmationText = '.strong'
     public static readonly keepWorkingCancel = '[data-testid="discard-dialog-cancel-button"]'
+    public static readonly DiscardCancelBtn = '[data-testid="cancel-button"]'
 
     public static clickOnDiscardChanges(): void {
 

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -5,7 +5,7 @@ import { Environment } from "./Environment"
 import { Utilities } from "./Utilities"
 import { v4 as uuidv4 } from 'uuid'
 
-export enum MeasureType  {
+export enum MeasureType {
     outcome = 'Outcome',
     patientReportedOutcome = 'Patient Reported Outcome',
     process = 'Process',
@@ -219,7 +219,6 @@ export class MeasureGroupPage {
     public static readonly qdmSDERadioButtons = '[data-testid="sde-option-radio-buttons-group"]'
     public static readonly qdmTypeOptionZero = '[id="base-configuration-types-option-0"]'
     public static readonly qdmTypeValuePill = '[class="MuiChip-label MuiChip-labelSmall css-1pjtbja"]'
-    public static readonly qdmDiscardButton = '[data-testid="cancel-button"]'
     public static readonly qdmDirtyCheckDiscardModal = '[data-testid="discard-dialog"]'
     public static readonly qdmDiscardModalContinueButton = '[data-testid="discard-dialog-continue-button"]'
     public static readonly qdmDiscardModalCancelButton = '[data-testid="discard-dialog-cancel-button"]'
@@ -291,9 +290,9 @@ export class MeasureGroupPage {
             }
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
-       // this clears the previous step's dropdown
+        // this clears the previous step's dropdown
         cy.get(this.QDMPopCriteria1Desc).click()
-       
+
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
         Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'denom')
@@ -388,7 +387,7 @@ export class MeasureGroupPage {
         cy.get(MeasureGroupPage.reportingTab).click()
         cy.get(MeasureGroupPage.improvementNotationSelect).click()
         cy.contains('Increased score indicates improvement').click()
-        
+
         cy.get(this.saveMeasureGroupDetails).click()
 
         //validation successful save message
@@ -796,7 +795,7 @@ export class MeasureGroupPage {
                         "scoring": scoring,
                         "populationBasis": populationBasis,
                         "populations": popsArray
-                          ,
+                        ,
                         "measureGroupTypes": [
                             measureType
                         ],

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -20,9 +20,6 @@ export enum TestCaseAction {
 }
 
 export class TestCasesPage {
-    //QI Core element tab enabled test case detail page elements
-    public static readonly QiCoreEleEnabledJSONTab = '[data-testid="json-tab"]'
-
     //observation fields
     public static readonly denom0Observation = '[id="denominatorObservation0-expected-cb"]'
     public static readonly denom1Observation = '[id="denominatorObservation1-expected-cb"]'
@@ -38,7 +35,6 @@ export class TestCasesPage {
     //QDM Shift Test Case dates
     public static readonly testCaseDataSideLink = '[data-testid="test-case-data"]'
     public static readonly shiftAllTestCaseDates = '[data-testid="shift-test-case-dates-input"]'
-    public static readonly shiftAllTestCasesDiscardBtn = '[data-testid="cancel-button"]'
     public static readonly shftAllTestCasesSaveBtn = '[data-testid="test-case-data-save"]'
     public static readonly shiftAllTestCasesSuccessMsg = '[data-testid="shift-all-test-case-dates-success-text"]'
     public static readonly shiftSpecificTestCaseDates = '[data-testid="shift-dates-input"]'
@@ -163,7 +159,6 @@ export class TestCasesPage {
     public static readonly cqlHasErrorsMsg = '[data-testid="test-case-cql-has-errors-message"]'
     public static readonly detailsTab = '[data-testid="details-tab"]'
     public static readonly tctExpectedActualSubTab = '[data-testid="expectoractual-tab"]'
-    public static readonly tcJsonTab = '[data-testid=json-tab]'
 
     //QDM Test Case
     public static readonly qdmCQLFailureErrorList = '[data-testid="execution_context_loading_errors"]'

--- a/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
@@ -170,12 +170,12 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.measureStewardDevelopersSaveButton).should('be.disabled')
 
         //discard button becomes available
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('exist')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.visible')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('exist')
+        cy.get(Global.DiscardCancelBtn).should('be.visible')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
 
         //discard previous entry
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         cy.get(Global.discardChangesContinue).click()
 
         //verify that empty fields
@@ -194,9 +194,9 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.measureStewardDevelopersSaveButton).should('be.disabled')
 
         //discard button becomes available
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('exist')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.visible')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('exist')
+        cy.get(Global.DiscardCancelBtn).should('be.visible')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
     })
 
     it('Validate dirty check on Steward & Developers section of Measure Details page', () => {
@@ -228,7 +228,7 @@ describe('Validations on Measure Details page', () => {
         Global.clickOnKeepWorking()
 
         //discard previous entry
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         cy.get(Global.discardChangesContinue).click()
 
         //verify that empty fields
@@ -331,7 +331,7 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.visible')
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).type('Some test value')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         Global.clickOnDiscardChanges()
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.empty')
 
@@ -343,12 +343,12 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('exist')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('be.visible')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('be.enabled')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('exist')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.visible')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('exist')
+        cy.get(Global.DiscardCancelBtn).should('be.visible')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('be.disabled')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).should('be.disabled')
+        cy.get(Global.DiscardCancelBtn).should('be.disabled')
 
         //verify save success message
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('exist')
@@ -395,7 +395,7 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.visible')
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).type('Some new test value')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         Global.clickOnDiscardChanges()
         cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('contain.text', 'Some test value')
     })

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociation.cy.ts
@@ -7,6 +7,7 @@ import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { Header } from "../../../../Shared/Header"
+import { Global } from "../../../../Shared/Global"
 
 let randValue = (Math.floor((Math.random() * 1000) + 1))
 let measureCQLPFTests = MeasureCQL.CQL_Populations
@@ -440,7 +441,7 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         MeasuresPage.actionCenter('associatemeasure')
 
         cy.get(EditMeasurePage.associateCmsIdDialog).should('include.text', '0.0.000QI-Core v4.1.1Copy QDM Metadata to QI-Core measure')
-        Utilities.waitForElementVisible(EditMeasurePage.associateCmsCancel, 35000)
+        Utilities.waitForElementVisible(Global.DiscardCancelBtn, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.associateCmsAssociateBtn, 37000)
         cy.get(EditMeasurePage.associateCmsAssociateBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.sureDialog, 35000)

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
@@ -338,9 +338,9 @@ describe('QDM Library Includes fields', () => {
         cy.get('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]').should('contain.text', 'Details')
 
         //choose cancel
-        cy.get(CQLLibraryPage.savedLibrariesEditDetailsCancelBtn).scrollIntoView()
-        Utilities.waitForElementVisible(CQLLibraryPage.savedLibrariesEditDetailsCancelBtn, 5000)
-        cy.get(CQLLibraryPage.savedLibrariesEditDetailsCancelBtn).click()
+        cy.get(Global.DiscardCancelBtn).scrollIntoView()
+        Utilities.waitForElementVisible(Global.DiscardCancelBtn, 5000)
+        cy.get(Global.DiscardCancelBtn).click()
 
         //confirm that CQL value is the same as it was prior to change and the save button is not available
         cy.reload()

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureDefinitions.cy.ts
@@ -48,7 +48,7 @@ describe('QDM Measure Definition', () => {
         //Navigate to References page
         cy.get(EditMeasurePage.leftPanelDefinition).click()
         cy.get(EditMeasurePage.definitionInputTextbox).type('Measure Definition')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         Global.clickOnDiscardChanges()
 
     })

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureReferences.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureReferences.cy.ts
@@ -4,6 +4,7 @@ import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { Utilities } from "../../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import { Global } from "../../../../Shared/Global"
 
 let randValue = Cypress._.random(100)
 let newMeasureName = ''
@@ -63,7 +64,7 @@ describe('QDM Measure Reference', () => {
         cy.get(EditMeasurePage.referenceTypeDropdown).click()
         cy.get(EditMeasurePage.documentationOption).click()
         cy.get(EditMeasurePage.measureReferenceText).type('Measure Reference')
-        cy.get(EditMeasurePage.measureReferenceDiscardChanges).click()
+        cy.get(Global.DiscardCancelBtn).click()
         cy.get('[data-testid="dialog-form"]').should('not.exist')
     })
 

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
@@ -48,7 +48,7 @@ describe('QDM Measure Set', () => {
         //Navigate to Measure set page
         cy.get(EditMeasurePage.leftPanelMeasureSet).click()
         cy.get(EditMeasurePage.measureSetText).type('Measure Set')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         Global.clickOnDiscardChanges()
         cy.get(EditMeasurePage.measureSetText).should('be.empty')
     })

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureTransmissionFormat.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureTransmissionFormat.cy.ts
@@ -49,7 +49,7 @@ describe('QDM Measure: Transmission Format', () => {
         //Navigate to References page
         cy.get(EditMeasurePage.leftPanelTransmissionFormat).click()
         cy.get(EditMeasurePage.transmissionFormatDescription).type('Test Transmission format')
-        cy.get(EditMeasurePage.measureDetailsDiscardChangesBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
         Global.clickOnDiscardChanges()
         cy.get(EditMeasurePage.transmissionFormatDescription).should('be.empty')
     })

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/BaseConfigurationValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/BaseConfigurationValidations.cy.ts
@@ -116,11 +116,11 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
                 .check()
 
             //verify availability of the discard button and the un-availability of the save button
-            cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+            cy.get(Global.DiscardCancelBtn).should('be.enabled')
             cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.disabled')
 
             //discard current changges
-            cy.get(MeasureGroupPage.qdmDiscardButton).click()
+            cy.get(Global.DiscardCancelBtn).click()
             Global.clickOnDiscardChanges()
 
             //validate that 'Yes" radio button is selected / checked
@@ -137,7 +137,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
             cy.get(MeasureGroupPage.qdmTypeValuePill).should('contain.text', 'Appropriate Use Process')
 
             //verify availability of the discard button and the un-availability of the save button
-            cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+            cy.get(Global.DiscardCancelBtn).should('be.enabled')
             cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.disabled')
 
             //validate the values and the selection of the values, for the scoring field
@@ -146,11 +146,11 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
             cy.get(MeasureGroupPage.qdmScoring).should('contain.text', 'Cohort')
 
             //verify availability of the discard and save buttons
-            cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+            cy.get(Global.DiscardCancelBtn).should('be.enabled')
             cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
 
             //discard current changes
-            cy.get(MeasureGroupPage.qdmDiscardButton).click()
+            cy.get(Global.DiscardCancelBtn).click()
             Global.clickOnDiscardChanges()
 
             //navigate to the main measures page
@@ -168,7 +168,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
             cy.get(MeasureGroupPage.qdmScoring).should('contain.text', 'Cohort')
 
             //verify availability of the discard and save buttons
-            cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+            cy.get(Global.DiscardCancelBtn).should('be.enabled')
             cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.disabled')
 
             //validate that a value can be selected for the Type field
@@ -185,7 +185,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
                 .check()
 
             //verify availability of the discard button and the availability of the save button
-            cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+            cy.get(Global.DiscardCancelBtn).should('be.enabled')
             cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
 
             //click on the save button and confirm save success message
@@ -222,11 +222,11 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
         cy.get(MeasureGroupPage.qdmScoring).should('contain.text', 'Cohort')
 
         //verify availability of the discard and save buttons
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.disabled')
 
         //click on discard changes button
-        cy.get(MeasureGroupPage.qdmDiscardButton).click()
+        cy.get(Global.DiscardCancelBtn).click()
 
         //click on 'No, Keep working' button
         cy.get(MeasureGroupPage.qdmDiscardModalCancelButton).click()
@@ -235,7 +235,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
         cy.get(MeasureGroupPage.qdmScoring).should('contain.text', 'Cohort')
 
         //verify availability of the discard and save buttons
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.disabled')
 
         //validate that a value can be selected for the Type field
@@ -245,11 +245,11 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
         cy.get(MeasureGroupPage.qdmTypeValuePill).should('contain.text', 'Appropriate Use Process')
 
         //verify availability of the discard button and the availability of the save button
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
 
         //click on discard changes button
-        cy.get(MeasureGroupPage.qdmDiscardButton).click()
+        cy.get(Global.DiscardCancelBtn).click()
 
         //click on 'No, Keep working' button
         cy.get(MeasureGroupPage.qdmDiscardModalCancelButton).click()
@@ -259,7 +259,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
         cy.get(MeasureGroupPage.qdmTypeValuePill).should('contain.text', 'Appropriate Use Process')
 
         //verify availability of the discard and save buttons
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
 
         //*check* the 'No' radio button
@@ -270,13 +270,13 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
             .check()
 
         //verify availability of the discard button and the un-availability of the save button
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
 
         //click on discard changes button
-        Utilities.waitForElementVisible(MeasureGroupPage.qdmDiscardButton, 5000)
-        Utilities.waitForElementEnabled(MeasureGroupPage.qdmDiscardButton, 5000)
-        cy.get(MeasureGroupPage.qdmDiscardButton).click()
+        Utilities.waitForElementVisible(Global.DiscardCancelBtn, 5000)
+        Utilities.waitForElementEnabled(Global.DiscardCancelBtn, 5000)
+        cy.get(Global.DiscardCancelBtn).click()
 
         //click on 'No, Keep working' button
         cy.get(MeasureGroupPage.qdmDiscardModalCancelButton).click()
@@ -308,7 +308,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
         cy.get(MeasureGroupPage.qdmScoring).click({ force: true })
 
         //verify availability of the discard and save buttons
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
 
         //attempt to navigate to the main measures page
@@ -404,7 +404,7 @@ describe('Validating Population tabs and fields, specific to QDM', () => {
             .should('not.be.enabled')
 
         //verify the unavailability of the discard and save buttons
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('not.be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('not.be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('not.be.enabled')
 
     })
@@ -503,7 +503,7 @@ describe('Updates on Base Configuration page', () => {
         cy.get(MeasureGroupPage.qdmScoring).should('contain.text', 'Proportion')
         cy.get(MeasureGroupPage.qdmTypeValuePill).should('contain.text', 'Process')
         //verify availability of the discard and save buttons
-        cy.get(MeasureGroupPage.qdmDiscardButton).should('be.enabled')
+        cy.get(Global.DiscardCancelBtn).should('be.enabled')
         cy.get(MeasureGroupPage.qdmBCSaveButton).should('be.enabled')
         //validate that 'Yes" radio button is selected / checked
         cy.contains('label', 'Yes')

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreLibraryIncludes.cy.ts
@@ -312,9 +312,9 @@ describe('Qi-Core Library Includes fields', () => {
         cy.get('[class="MuiTypography-root MuiTypography-h6 MuiDialogTitle-root css-7hqw69"]').should('contain.text', 'Details')
 
         //choose cancel
-        cy.get(CQLLibraryPage.savedLibrariesEditDetailsCancelBtn).scrollIntoView()
-        Utilities.waitForElementVisible(CQLLibraryPage.savedLibrariesEditDetailsCancelBtn, 5000)
-        cy.get(CQLLibraryPage.savedLibrariesEditDetailsCancelBtn).click()
+        cy.get(Global.DiscardCancelBtn).scrollIntoView()
+        Utilities.waitForElementVisible(Global.DiscardCancelBtn, 5000)
+        cy.get(Global.DiscardCancelBtn).click()
 
         //confirm that CQL value is the same as it was prior to change and the save button is not available
         cy.reload()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/QDMTestCaseAttributevalidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Attributes/QDMTestCaseAttributevalidations.cy.ts
@@ -167,7 +167,7 @@ describe('Remove Test case attribute', () => {
 
         //Commenting until feature flag for JSON tab is removed
         //Navigate to JSON tab and verify the attribute is deleted from tc Json
-        // cy.get(TestCasesPage.tcJsonTab).click()
+        // cy.get(TestCasesPage.jsonTab).click()
         // cy.get(TestCasesPage.qdmTCJson).should('not.contain.text', '"referenceRange"')
         // cy.get(TestCasesPage.qdmTCJson).should('not.contain.text', '"description": "Laboratory Test, Performed: Chlamydia Screening"')
     })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/QDMShiftTestCaseDatesValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/QDMShiftTestCaseDatesValidations.cy.ts
@@ -11,6 +11,7 @@ import { QDMElements } from "../../../../../Shared/QDMElements"
 import { Header } from "../../../../../Shared/Header"
 import { LandingPage } from "../../../../../Shared/LandingPage"
 import { umlsLoginForm } from "../../../../../Shared/umlsLoginForm"
+import { Global } from "../../../../../Shared/Global"
 
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 const now = Date.now()
@@ -206,11 +207,11 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         cy.get(TestCasesPage.shiftAllTestCaseDates).type('4')
 
         //confirm buttons that appear on page to either discard or save the shift dates
-        Utilities.waitForElementEnabled(TestCasesPage.shiftAllTestCasesDiscardBtn, 3500)
+        Utilities.waitForElementEnabled(Global.DiscardCancelBtn, 3500)
         Utilities.waitForElementEnabled(TestCasesPage.shftAllTestCasesSaveBtn, 3500)
 
         //discard shifting dates
-        cy.get(TestCasesPage.shiftAllTestCasesDiscardBtn).click()
+        cy.get(Global.DiscardCancelBtn).click()
 
         //confirm discarding change on page
         cy.get(TestCasesPage.continueDiscardChangesBtn).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/Qi-CoreShiftTestCaseDatesValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/Qi-CoreShiftTestCaseDatesValidations.cy.ts
@@ -7,6 +7,7 @@ import { TestCase, TestCasesPage } from "../../../../../Shared/TestCasesPage"
 import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
+import { Global } from "../../../../../Shared/Global"
 
 const now = Date.now()
 const measureName = 'QiCoreShiftDates' + now
@@ -60,30 +61,30 @@ describe('Shift Test Case Dates tests - Qi-Core Measure', () => {
         cy.get(TestCasesPage.testCaseDataSideLink).click()
         Utilities.waitForElementVisible(TestCasesPage.shiftAllTestCaseDates, 3500)
         cy.get(TestCasesPage.shiftAllTestCaseDates).type('4')
-   
+
         //confirm buttons that appear on page to either discard or save the shift dates
-        Utilities.waitForElementEnabled(TestCasesPage.shiftAllTestCasesDiscardBtn, 3500)
+        Utilities.waitForElementEnabled(Global.DiscardCancelBtn, 3500)
         Utilities.waitForElementEnabled(TestCasesPage.shftAllTestCasesSaveBtn, 3500)
-   
+
         //discard shifting dates
-        cy.get(TestCasesPage.shiftAllTestCasesDiscardBtn).click()
-   
+        cy.get(Global.DiscardCancelBtn).click()
+
         //confirm discarding change on page
         cy.get(TestCasesPage.continueDiscardChangesBtn).click()
         //confirm that shift test case text box is empty
         cy.get(TestCasesPage.shiftAllTestCaseDates).should('be.empty')
-   
+
         //enter new value in the shift test case text box
         cy.get(TestCasesPage.shiftAllTestCaseDates).type('3')
-   
+
         //save the shift test case
         Utilities.waitForElementEnabled(TestCasesPage.shftAllTestCasesSaveBtn, 3500)
         cy.get(TestCasesPage.shftAllTestCasesSaveBtn).click()
         Utilities.waitForElementVisible(TestCasesPage.tcSaveSuccessMsg, 3500)
-   
+
         //confirm success message
         cy.get(TestCasesPage.shiftAllTestCasesSuccessMsg).should('contain.text', 'All Test Case dates successfully shifted.')
-   
+
         //Validate if the Measurement period start date is updated for first Test case
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {


### PR DESCRIPTION
This PR is additional work on the effort to remove redundancies around variables that are used that point to the same page element. For the most part, this PR is concerning the variables that point to a page element that has a data testid for the cancel button.