### PR TITLE
feat: remove method, update tests

### DIFF
--- a/cypress/Shared/CQLLibrariesPage.ts
+++ b/cypress/Shared/CQLLibrariesPage.ts
@@ -9,7 +9,7 @@ export class CQLLibrariesPage {
     public static readonly versionLibraryRadioButton = '[name="type"]'
     public static readonly createVersionContinueButton = '[data-testid="create-version-continue-button"] > :nth-child(1)'
     public static readonly VersionDraftMsgs = '.MuiAlert-message'
-    public static readonly cqlLibraryVersionList = '[data-testid="cqlLibrary-button-0_version"]' //':nth-child(1) > :nth-child(3) > p'
+    public static readonly cqlLibraryVersionList = '[data-testid="cqlLibrary-button-0_version"]'
     public static readonly updateDraftedLibraryTextBox = '[data-testid="cql-library-name-input"]'
     public static readonly createDraftContinueBtn = '[data-testid="create-draft-continue-button"]'
     public static readonly versionErrorMsg = '[data-testid=create-version-error-message]'
@@ -79,25 +79,8 @@ export class CQLLibrariesPage {
     public static validateCQLLibraryName(expectedValue: string): void {
 
         cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((fileContents) => {
-            let element = cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').parent()
-            element.parent().should('contain', expectedValue)
+            cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').should('contain', expectedValue)
 
-        })
-    }
-
-    public static clickVersionforCreatedLibrary(secondLibrary?: boolean): void {
-
-        let filePath = 'cypress/fixtures/cqlLibraryId'
-
-        if (secondLibrary === true) {
-            filePath = 'cypress/fixtures/cqlLibraryId2'
-        }
-
-        //Navigate to CQL Library Page
-        cy.get(Header.cqlLibraryTab).click()
-        cy.readFile(filePath).should('exist').then((fileContents) => {
-            cy.get('[data-testid="edit-cql-library-button-' + fileContents + '"]').click()
-            cy.get('[data-testid="create-new-version-' + fileContents + '-button"]').click()
         })
     }
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing/CQLLibrarySharing.cy.ts
@@ -90,6 +90,7 @@ describe('CQL Library Sharing - Multiple instances', () => {
         //set local user that does not own the Library
         cy.setAccessTokenCookie()
         OktaLogin.Login()
+        cy.get(Header.cqlLibraryTab).click()
     })
 
     afterEach('LogOut', () => {
@@ -100,7 +101,7 @@ describe('CQL Library Sharing - Multiple instances', () => {
     it('Verify all instances in the Library set (Version and Draft) are Shared to the new owner', () => {
 
         //Version the CQL Library
-        CQLLibrariesPage.clickVersionforCreatedLibrary()
+        CQLLibrariesPage.cqlLibraryActionCenter("version")
 
         cy.get(CQLLibrariesPage.versionLibraryRadioButton).should('exist')
         cy.get(CQLLibrariesPage.versionLibraryRadioButton).should('be.enabled')
@@ -114,7 +115,7 @@ describe('CQL Library Sharing - Multiple instances', () => {
         cy.log('Version Created Successfully')
 
         //Draft the Versioned CQL Library
-        CQLLibrariesPage.clickDraftforCreatedLibrary()
+        CQLLibrariesPage.cqlLibraryActionCenter('draft')
         cy.get(CQLLibrariesPage.updateDraftedLibraryTextBox).should('exist')
         cy.get(CQLLibrariesPage.updateDraftedLibraryTextBox).should('be.visible')
         cy.get(CQLLibrariesPage.updateDraftedLibraryTextBox).should('be.enabled')

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
@@ -84,6 +84,7 @@ describe('CQL Library Transfer - Multiple instances', () => {
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
         OktaLogin.Login()
+        cy.get(Header.cqlLibraryTab).click()
     })
 
     afterEach('LogOut', () => {
@@ -94,7 +95,7 @@ describe('CQL Library Transfer - Multiple instances', () => {
     it('Verify all instances in the Library set (Version and Draft) are Transferred to the new owner', () => {
 
         //Version the CQL Library
-        CQLLibrariesPage.clickVersionforCreatedLibrary()
+        CQLLibrariesPage.cqlLibraryActionCenter("version")
 
         cy.get(CQLLibrariesPage.versionLibraryRadioButton).should('exist')
         cy.get(CQLLibrariesPage.versionLibraryRadioButton).should('be.enabled')


### PR DESCRIPTION
Eliminate the old method `clickVersionforCreatedLibrary()` and all of it's uses.
Use `cqlLibraryActionCenter('version')` instead.