### PR TITLE
feat: same as previous

### DIFF
--- a/cypress/Shared/CQLLibrariesPage.ts
+++ b/cypress/Shared/CQLLibrariesPage.ts
@@ -92,18 +92,6 @@ export class CQLLibrariesPage {
         })
     }
 
-    public static clickDraftforCreatedLibrary(): void {
-
-        //Navigate to CQL Library Page
-        cy.get(Header.cqlLibraryTab).should('exist')
-        cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.get(Header.cqlLibraryTab).click()
-        cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="edit-cql-library-button-' + fileContents + '"]').click()
-            cy.get('[data-testid="create-new-draft-' + fileContents + '-button"]').click()
-        })
-    }
-
     public static cqlLibraryAction(action: string, secondTestCase?: boolean): void {
         let filePath = 'cypress/fixtures/cqlLibraryId'
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
@@ -109,7 +109,8 @@ describe('CQL Library Transfer - Multiple instances', () => {
         cy.log('Version Created Successfully')
 
         //Draft the Versioned CQL Library
-        CQLLibrariesPage.clickDraftforCreatedLibrary()
+        CQLLibrariesPage.cqlLibraryActionCenter('draft')
+
         cy.get(CQLLibrariesPage.updateDraftedLibraryTextBox).should('exist')
         cy.get(CQLLibrariesPage.updateDraftedLibraryTextBox).should('be.visible')
         cy.get(CQLLibrariesPage.updateDraftedLibraryTextBox).should('be.enabled')


### PR DESCRIPTION
Same operation for function `clickDraftforCreatedLibrary()`

Removed it and its only use. Replaced with `cqlLibraryActionCenter('draft')`