### PR TITLE
MAT-8264 : user can no longer create a QI-Core 4.1.1 draft off a QI-Core 6.0.0 measure

### DIFF
--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
@@ -9,7 +9,7 @@ import { Header } from "../../../../Shared/Header"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import {LandingPage} from "../../../../Shared/LandingPage";
+import { LandingPage } from "../../../../Shared/LandingPage";
 
 let MeasuresPageOne = ''
 let updatedMeasuresPageName = ''
@@ -144,7 +144,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         })
     })
 
-    it('Change / update model from v4.1.1 - to - v6.0.0 and vice versa with versioning and drafting', () => {
+    it('Change / update model from v4.1.1 - to - v6.0.0 with versioning and drafting but cannot draft from 6.0.0 - to - 4.1.1', () => {
 
         let versionNumberFirst = '1.0.000'
         updatedMeasuresPageName = 'UpdatedTestMeasures1' + Date.now()
@@ -251,38 +251,121 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(MeasuresPage.createDraftContinueBtn).should('be.enabled')
 
         cy.get(MeasuresPage.draftModalSelectionBox).click()
-        Utilities.waitForElementVisible(MeasuresPage.draftModalVersionFourOneOne, 5000)
-        cy.get(MeasuresPage.draftModalVersionFourOneOne).click()
+        cy.get(MeasuresPage.draftModalSelectionBox).should('not.contain.text', 'QI-Core v4.1.1')
+        cy.get(MeasuresPage.draftModalSelectionBox).should('contain.text', 'QI-Core v6.0.0')
+    })
+})
+
+describe('Draft and Version Validations -- add and cannot create draft of a draft that already exists tests', () => {
+
+    beforeEach('Create Measure, add Cohort group and Login', () => {
+
+        newMeasureName = 'TestMeasure' + Date.now() + randValue
+        newCqlLibraryName = 'MeasureTypeTestLibrary' + Date.now() + randValue
+        //Create New Measure and Measure Group
+        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, cohortMeasureCQL)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI()
+
+        OktaLogin.Login()
+
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        cy.get(Header.mainMadiePageButton).click()
+        cy.get(LandingPage.newMeasureButton).should('be.visible')
+
+    })
+
+    afterEach('Logout', () => {
+
+        OktaLogin.UILogout()
+
+    })
+    it('Tooltip appears and user is unable to draft a 4.1.1 of a measure that has a 6.0.0 on measureSet', () => {
+
+        let filePath = 'cypress/fixtures/measureId'
+        let versionNumberFirst = '1.0.000'
+        updatedMeasuresPageName = 'UpdatedTestMeasures1' + Date.now()
+
+        let versionNumberSecond = '2.0.000'
+        updatedMeasuresPageNameSecond = 'UpdatedTestMeasures2' + Date.now()
+
+        MeasuresPage.actionCenter('version')
+
+        cy.get(MeasuresPage.measureVersionTypeDropdown).click()
+        cy.get(MeasuresPage.measureVersionMajor).click()
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type(versionNumberFirst)
+
+        cy.get('.MuiDialogContent-root').click()
+
+        cy.get(MeasuresPage.measureVersionContinueBtn).should('exist')
+        cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
+        cy.get(MeasuresPage.measureVersionContinueBtn).click()
+
+        cy.get(MeasuresPage.measureVersionSuccessMsg).should('contain.text', 'New version of measure is Successfully created')
+        MeasuresPage.validateVersionNumber(versionNumberFirst)
+        cy.log('Major Version Created Successfully')
+
+        //navigate back to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
+        cy.get(LandingPage.newMeasureButton).should('be.visible')
+
+        MeasuresPage.actionCenter('draft')
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).should('exist')
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).should('be.visible')
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).should('be.enabled')
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(updatedMeasuresPageName)
+
+        cy.get(MeasuresPage.createDraftContinueBtn).should('exist')
+        cy.get(MeasuresPage.createDraftContinueBtn).should('be.visible')
+        cy.get(MeasuresPage.createDraftContinueBtn).should('be.enabled')
+
+        cy.get(MeasuresPage.draftModalSelectionBox).click()
+        Utilities.waitForElementVisible(MeasuresPage.draftModalVersionSix, 5000)
+        cy.get(MeasuresPage.draftModalVersionSix).click()
 
         CreateMeasurePage.clickCreateDraftButton()
 
         cy.get(MeasuresPage.VersionDraftMsgs).should('contain.text', 'New draft created successfully.')
         cy.log('Draft Created Successfully')
+
         Utilities.waitForElementToNotExist(MeasuresPage.VersionDraftMsgs, 100000)
 
-        //verify CQL after draft
+        //navigate back to the main MADiE / measure list page
         cy.get(Header.mainMadiePageButton).click()
+        cy.get(LandingPage.newMeasureButton).should('be.visible')
+
         //Search for the Measure using Measure name
         cy.log('Search Measure with measure name')
-        cy.get(MeasuresPage.searchInputBox).type(updatedMeasuresPageNameSecond).type('{enter}')
-        cy.get(MeasuresPage.measureListTitles).should('contain', updatedMeasuresPageNameSecond)
-        MeasuresPage.actionCenter('edit')
+        cy.get(MeasuresPage.searchInputBox).type(updatedMeasuresPageName).type('{enter}')
+        cy.get(MeasuresPage.measureListTitles).should('contain', updatedMeasuresPageName)
 
-        //verify that the CQL to ELM version is not empty
-        cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
+        MeasuresPage.actionCenter('version')
 
-        //verify that the CQL to ELM version is not empty
-        cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
+        cy.get(MeasuresPage.measureVersionTypeDropdown).click()
+        cy.get(MeasuresPage.measureVersionMajor).click()
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type(versionNumberSecond)
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).should('contain.text', 'library ' + newCqlLibraryName)
-        cy.get(EditMeasurePage.cqlEditorTextBox).should('contain.text', 'using QICore version \'4.1.1\'')
-        cy.get(EditMeasurePage.cqlEditorTextBox).should('contain.text', 'include FHIRHelpers version \'4.1.000\' called FHIRHelpers')
+        cy.get('.MuiDialogContent-root').click()
 
+        cy.get(MeasuresPage.measureVersionContinueBtn).should('exist')
+        cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
+        cy.get(MeasuresPage.measureVersionContinueBtn).click()
+
+        cy.get(MeasuresPage.measureVersionSuccessMsg).should('contain.text', 'New version of measure is Successfully created')
+        MeasuresPage.validateVersionNumber(versionNumberSecond)
+        cy.log('Major Version Created Successfully')
+
+        //Search for the Measure using Measure name
+        cy.log('Search Measure with measure name')
+        cy.get(MeasuresPage.searchInputBox).type(newMeasureName).type('{enter}')
+        cy.get(MeasuresPage.measureListTitles).should('contain', newMeasureName)
+
+        cy.get('[class="px-1"]').find('[class=" cursor-pointer"]').eq(0).click()
+        cy.get('[data-testid="draft-action-tooltip"]').should('have.attr', 'aria-label', 'You cannot draft a 4.1.1 measure when a 6.0.0 version is available')
     })
 })
 


### PR DESCRIPTION
This PR is the updates to existing as well as new automated regression tests covering the new inability to revert a Qi Core measure's modal from version 6.0.0 to 4.1.1. Nor can a user draft a older 4.1.1 model version after a model version of 6.0.0 is on the measureSet.