### PR TITLE
feat: move function to MeasureGroupPage, start transition of tests

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -813,4 +813,28 @@ export class MeasureGroupPage {
         })
         return user
     }
+
+    public static setMeasureGroupType(type?: MeasureType): void {
+
+        if (!type) {
+            type = MeasureType.process
+        }
+
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
+        cy.get(MeasureGroupPage.measureGroupTypeCheckbox).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeCheckbox).should('be.visible')
+        cy.get(MeasureGroupPage.measureGroupTypeCheckbox).each(($ele) => {
+            if ($ele.text() == "Text") {
+                cy.wrap($ele).should('exist')
+                cy.wrap($ele).focus()
+                cy.wrap($ele).click()
+            }
+        })
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).type(type).type('{downArrow}').type('{enter}')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
+    }
 }

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
@@ -58,7 +58,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
             cy.get(EditMeasurePage.measureGroupsTab).click()
 
-            Utilities.setMeasureGroupType()
+            MeasureGroupPage.setMeasureGroupType()
 
             cy.get(MeasureGroupPage.popBasis).should('exist')
             cy.get(MeasureGroupPage.popBasis).should('be.visible')
@@ -217,7 +217,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
             cy.get(EditMeasurePage.measureGroupsTab).click()
 
-            Utilities.setMeasureGroupType()
+            MeasureGroupPage.setMeasureGroupType()
 
             cy.get(MeasureGroupPage.popBasis).should('exist')
             cy.get(MeasureGroupPage.popBasis).should('be.visible')

--- a/cypress/e2e/WebInterface/Measure/Measure Group/AddMeasureGroup.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/AddMeasureGroup.cy.ts
@@ -53,7 +53,7 @@ describe('Validate Measure Group additions', () => {
             cy.url().should('contain', fileContents + '/edit/groups/2')
         })
 
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
         cy.get(MeasureGroupPage.popBasis).should('exist')

--- a/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureSharing/MeasureSharing.cy.ts
@@ -89,7 +89,7 @@ describe('Measure Sharing', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         cy.get(MeasureGroupPage.addMeasureGroupButton).click()
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
@@ -85,7 +85,7 @@ describe('Measure Transfer', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         cy.get(MeasureGroupPage.addMeasureGroupButton).click()
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeEncounter.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeEncounter.cy.ts
@@ -59,7 +59,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
         //Create Measure Group
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         cy.get(MeasureGroupPage.popBasis).should('exist')
         cy.get(MeasureGroupPage.popBasis).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
@@ -50,7 +50,7 @@ describe('Measure Creation and Testing: Cohort Episode w/ Stratification', () =>
         //Create Measure Group
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         cy.get(MeasureGroupPage.popBasis).should('exist')
         cy.get(MeasureGroupPage.popBasis).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
@@ -449,6 +449,7 @@ describe('JSON Resource ID tests', () => {
         Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
+        cy.wait(2000)
         cy.get(TestCasesPage.aceEditor).type(emptyResourceIDTCJson, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -542,6 +543,7 @@ describe('JSON Resource ID tests', () => {
         Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
+        cy.wait(2000)
         cy.get(TestCasesPage.aceEditor).type(missingResourceIDTCJsonButHasFullUrlExt, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -623,6 +625,7 @@ describe('JSON Resource ID tests', () => {
         Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
+        cy.wait(2000)
         cy.get(TestCasesPage.aceEditor).type(missingResourceIDTCJson, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -700,6 +703,7 @@ describe('JSON Resource ID tests', () => {
         cy.get(TestCasesPage.aceEditor).should('be.visible')
         Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
         cy.get(TestCasesPage.aceEditor).click()
+        cy.wait(2000)
         cy.get(TestCasesPage.aceEditor).type(dupResourceIDTCJson)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -755,6 +759,7 @@ describe('JSON Resource ID tests', () => {
         Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
         cy.get(TestCasesPage.aceEditor).should('exist')
         cy.get(TestCasesPage.aceEditor).should('be.visible')
+        cy.wait(2000)
         cy.get(TestCasesPage.aceEditor).type(missingMetaProfile, { parseSpecialCharSequences: false })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -820,7 +825,7 @@ describe('JSON Resource ID tests - Proportion Score Type', () => {
         //Add second Measure Group with return type as Boolean
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
         cy.get(MeasureGroupPage.popBasis).should('exist')
@@ -924,7 +929,7 @@ describe('JSON Resource ID tests -- CV', () => {
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
         cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
         cy.get(EditMeasurePage.measureGroupsTab).click()
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.setMeasureGroupType()
 
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCV)
 


### PR DESCRIPTION
Create a version of `setMeasureGroupType()` on MeasureGroupPage.

This functionality belongs on this page object instead of on the generic Utilities.

This PR transitions several tests to use this version.
There are about 30 tests that still use `Utilities.setMeasureGroupType()`
I will transition those tests in the future - I did not want to submit that many files all in 1 PR.