### PR TITLE
fix: resolve editor errors

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
@@ -51,7 +51,7 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
         const measureOptions: CreateMeasureOptions = {
             measureCql: qdmMeasureCQL,
             measureScoring: 'Cohort',
-            patientBasis: 'false',
+            patientBasis: false,
             blankMetadata: true
         }
         CreateMeasurePage.CreateMeasureAPI(newMeasureName, newCqlLibraryName, SupportedModels.QDM, measureOptions)

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
@@ -113,8 +113,9 @@ describe('FHIR Measure Export, Not the Owner', () => {
             })
 
         //Verify all files exist in exported zip file
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4.zip')).should('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.html' &&
-            'eCQMTitle4QICore-v0.0.000-FHIR.xml' && 'eCQMTitle4QICore-v0.0.000-FHIR.json')
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4.zip')).should('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.html')
+            .and('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.xml')
+            .and('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.json')
 
         // cy.readFile(path.join(downloadsFolder, 'eCQMTitle-v1.0.000-FHIR4.zip')).should('contain', 'eCQMTitle-v1.0.000-FHIR.html' &&
         //     'eCQMTitle-v1.0.000-FHIR.xml' && 'eCQMTitle-v1.0.000-FHIR.json' && 'FHIRHelpers-4.1.000.cql' && 'CQMCommon-1.0.000.cql' && 'FHIRCommon-4.1.000.cql'

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
@@ -136,8 +136,8 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
             })
 
         //Verify all files exist in exported zip file
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v1.0.000-FHIR4.zip')).should('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.html' &&
-            'eCQMTitle4QICore-v1.0.000-FHIR.xml' && 'eCQMTitle4QICore-v1.0.000-FHIR.json', { timeout: 500000 })
-
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v1.0.000-FHIR4.zip')).should('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.html')
+            .and('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.xml')
+            .and('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.json')
     })
 })

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
@@ -71,7 +71,10 @@ describe('QI-Core Measure Export', () => {
         //'Include in Report Type' field added for Initial Population when Risk adjustment variable is added
         cy.get(MeasureGroupPage.ippIncludeInReportTypeField).should('exist')
         cy.get('[data-testid=ArrowDropDownIcon]').eq(1).click()
-        cy.get(MeasureGroupPage.ippIncludeInReportTypeDropdownList).should('contain.text', 'Individual' && 'Subject List' && 'Summary' && 'Data Collection')
+        cy.get(MeasureGroupPage.ippIncludeInReportTypeDropdownList).should('contain.text', 'Individual')
+            .and('contain.text', 'Subject List')
+            .and('contain.text', 'Summary')
+            .and('cotain.text', 'Data Collection')
         cy.get('[data-testid=ArrowDropDownIcon]').eq(1).click()
 
         cy.get(MeasureGroupPage.saveRiskAdjustments).click()
@@ -91,7 +94,10 @@ describe('QI-Core Measure Export', () => {
         //'Include in Report Type' field added when Supplemental data element is added
         cy.get(MeasureGroupPage.ippIncludeInReportTypeField).should('exist')
         cy.get('[data-testid=ArrowDropDownIcon]').eq(1).click()
-        cy.get(MeasureGroupPage.ippIncludeInReportTypeDropdownList).should('contain.text', 'Individual' && 'Subject List' && 'Summary' && 'Data Collection')
+        cy.get(MeasureGroupPage.ippIncludeInReportTypeDropdownList).should('contain.text', 'Individual')
+            .and('contain.text', 'Subject List')
+            .and('contain.text', 'Summary')
+            .and('cotain.text', 'Data Collection')
         cy.get('[data-testid=ArrowDropDownIcon]').eq(1).click()
 
         //Save Supplemental data

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExport.cy.ts
@@ -67,8 +67,8 @@ describe('QI-Core Single Test Case Export', () => {
             })
         cy.readFile(testCasePIdPath).should('exist').then((patientId) => {
             //Verify all files exist in exported zip file
-            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json' &&
-                patientId, 'README.txt')
+            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json')
+                .and('contain',patientId, 'README.txt')
         })
     })
 
@@ -100,8 +100,8 @@ describe('QI-Core Single Test Case Export', () => {
             })
         cy.readFile(testCasePIdPath).should('exist').then((patientId) => {
             //Verify all files exist in exported zip file
-            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json' &&
-                patientId, 'README.txt')
+            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json')
+                .and('contain', patientId, 'README.txt')
         })
     })
 })
@@ -158,13 +158,13 @@ describe('QI-Core Test Case Export for all test cases', () => {
             })
         cy.readFile(testCasePIdPath).should('exist').then((patientId) => {
             //Verify all files exist in exported zip file
-            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json' &&
-                patientId, 'README.txt')
+            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json')
+                .and('contain', patientId, 'README.txt')
         })
         cy.readFile(testCasePIdPathSecnD).should('exist').then((patientId2) => {
             //Verify all files exist in exported zip file
-            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries2-Title for Auto Test2.json' &&
-                patientId2)
+            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries2-TitleforAutoTest2.json')
+                .and('contain', patientId2)
         })
     })
 
@@ -200,13 +200,13 @@ describe('QI-Core Test Case Export for all test cases', () => {
             })
         cy.readFile(testCasePIdPath).should('exist').then((patientId) => {
             //Verify all files exist in exported zip file
-            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-Title for Auto Test.json' &&
-                patientId, 'README.txt')
+            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries-TitleforAutoTest.json')
+                .and('contain', patientId, 'README.txt')
         })
         cy.readFile(testCasePIdPathSecnD).should('exist').then((patientId2) => {
             //Verify all files exist in exported zip file
-            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries2-Title for Auto Test2.json' &&
-                patientId2)
+            cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('contain', 'eCQMTitle4QICore-v0.0.000-SBTestSeries2-TitleforAutoTest2.json')
+                .and('contain', patientId2)
         })
         cy.reload()
         Utilities.waitForElementVisible('[data-testid="user-profile-select"]', 60000)


### PR DESCRIPTION
The changes below all resolve errors within the editor, present whenever the individual file is opened.
Based off the last regression cycle, these may not have been causing test failures, but even so, I feel these changes increase the tests stability & our trust in them.