### PR TITLE
feat: remove functions

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -95,8 +95,11 @@ export class CQLLibraryPage {
         cy.get(Header.cqlLibraryTab).should('be.visible')
         cy.get(Header.cqlLibraryTab).click()
 
-        this.validateCQlLibraryName(CQLLibraryName)
-        this.validateCQlLibraryModel('QI-Core')
+        cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((fileContents) => {
+
+            cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').should('contain', CQLLibraryName)
+            cy.get('[data-testid=cqlLibrary-button-' + fileContents + '-model' + ']').should('contain', 'QI-Core')
+        })
         cy.log('QI-Core CQL Library Created Successfully')
     }
 
@@ -144,24 +147,6 @@ export class CQLLibraryPage {
             })
         })
         return user
-    }
-
-    public static validateCQlLibraryName(expectedValue: string): void {
-        cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((fileContents) => {
-
-            let element = cy.get('[data-testid=cqlLibrary-button-' + fileContents + ']').parent()
-            element.parent().should('contain', expectedValue)
-
-        })
-    }
-
-    public static validateCQlLibraryModel(expectedValue: string): void {
-        cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((fileContents) => {
-
-            let element = cy.get('[data-testid=cqlLibrary-button-' + fileContents + '-model' + ']').parent()
-            element.parent().should('contain', expectedValue)
-
-        })
     }
 
     public static clickCreateLibraryButton(): void {

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts
@@ -2,6 +2,7 @@ import { OktaLogin } from "../../../Shared/OktaLogin"
 import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { Header } from "../../../Shared/Header"
 import { Utilities } from "../../../Shared/Utilities"
+import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 
 describe('Create CQL Library', () => {
 
@@ -51,8 +52,8 @@ describe('Create CQL Library', () => {
         cy.get(Header.cqlLibraryTab).should('be.visible')
         cy.get(Header.cqlLibraryTab).click()
 
-        CQLLibraryPage.validateCQlLibraryName(CQLLibraryName)
-        CQLLibraryPage.validateCQlLibraryModel('QDM v5.6')
+        CQLLibrariesPage.validateCQLLibraryName(CQLLibraryName)
+        CQLLibrariesPage.validateCQLLibraryName('QDM v5.6')
         cy.log('QDM CQL Library Created Successfully')
     })
 })


### PR DESCRIPTION
This change removes 2 functions from `CQLLibraryPage.ts` that I found very confusing.
They match the functionality of existing functions on `CQLLibrariesPage.ts` and almost exactly match these other functions names, only varying L to l.

This is essentially a "lift and shift" of the existing code. 1 in instance I swapped to the alternative functions & the other I simply eliminated the function calls and replaced with their respective code blocks (with a small change to consolidate them).