### PR TITLE
fix: revert type change, specify basis

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -17,7 +17,7 @@ export type CreateMeasureOptions = {
     elmJson?: string,
     measureNumber?: number,
     measureScoring?: string,
-    patientBasis?: boolean,
+    patientBasis?: string,
     altUser?: boolean,
     mpStartDate?: string,
     mpEndDate?: string,
@@ -442,7 +442,7 @@ export class CreateMeasurePage {
             ecqmTitle = 'AutoTestTitle',
             measureCql,
             elmJson,
-            patientBasis: boolean,
+            patientBasis,
             measureScoring,
             measureMetadata
 

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
@@ -51,12 +51,11 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
         const measureOptions: CreateMeasureOptions = {
             measureCql: qdmMeasureCQL,
             measureScoring: 'Cohort',
-            patientBasis: false,
+            patientBasis: 'false',
             blankMetadata: true
         }
         CreateMeasurePage.CreateMeasureAPI(newMeasureName, newCqlLibraryName, SupportedModels.QDM, measureOptions)
-
-        MeasureGroupPage.CreateCohortMeasureGroupWithoutTypeAPI(false, false, 'Initial Population')
+        MeasureGroupPage.CreateCohortMeasureGroupWithoutTypeAPI(false, false, 'Initial Population', 'Encounter')
         OktaLogin.Login()
     })
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CloneAndCopyTo/QDMTestCaseCopyToNewMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CloneAndCopyTo/QDMTestCaseCopyToNewMeasure.cy.ts
@@ -33,7 +33,7 @@ describe('Copy test cases from existing measure into new measure', () => {
     const measureOptions: CreateMeasureOptions = {
         measureCql: existingMeasureCql,
         measureScoring: 'Proportion',
-        patientBasis: true
+        patientBasis: 'true'
     }
     const populations: MeasureGroups = {
         initialPopulation: 'Initial Population',
@@ -201,13 +201,13 @@ describe('Copy to new measure - partial success case', () => {
     const measure1Options: CreateMeasureOptions = {
         measureCql: basicCql,
         measureScoring: 'Cohort',
-        patientBasis: true
+        patientBasis: 'true'
     }
     const measure2Options: CreateMeasureOptions = {
         measureCql: basicCql,
         measureNumber: 1,
         measureScoring: 'Cohort',
-        patientBasis: true
+        patientBasis: 'true'
     }
     const secondTestCaseTitle = 'valid test case'
 


### PR DESCRIPTION
This PR fixes QDMMeasureExportValidations.cy.ts

1. It reverts a previous change I made & restores the type of `CreateMeasureOptions.patientBasis` to string. Booleans worked with QiCore measures but it seems like QDM requires this as a string.
2. It removes a /groups error by specifying that the Measure is scored by Encounter, not the default boolean.