### PR TITLE
fix: restore qdm testcasecopytonewmeasure

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -559,10 +559,12 @@ export class CreateMeasurePage {
                 if (measureNumber > 0) {
                     cy.writeFile('cypress/fixtures/measureId' + measureNumber, response.body.id)
                     cy.writeFile('cypress/fixtures/measureSetId' + measureNumber, response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/versionId' + measureNumber, response.body.versionId)
                 }
                 else {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
                     cy.writeFile('cypress/fixtures/measureSetId', response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/versionId', response.body.versionId)
                 }
             })
         })

--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -321,7 +321,9 @@ export class Utilities {
             cy.get(dropdownDataElement).wait(2000).click()
             cy.get(valueDataElement).wait(2000).click()
         }
-        else if (dropdownDataElement == '[id="improvement-notation-select"]') {
+        else if (dropdownDataElement == '[id="improvement-notation-select"]' ||
+            dropdownDataElement == MeasureGroupPage.initialPopulationSelect
+        ) {
             cy.get(dropdownDataElement)
                 .wait(2000)
                 .click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CloneAndCopyTo/QDMTestCaseCopyToNewMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CloneAndCopyTo/QDMTestCaseCopyToNewMeasure.cy.ts
@@ -235,7 +235,7 @@ describe('Copy to new measure - partial success case', () => {
     it('All test cases copy - even new, "empty", or "invalid"', () => {
 
         // go to measure 2, test cases tab
-        MeasuresPage.actionCenter('edit', 2)
+        MeasuresPage.actionCenter('edit', 1)
 
         cy.get(EditMeasurePage.testCasesTab).click()
 


### PR DESCRIPTION
Expanded on Brandon's change in https://github.com/MeasureAuthoringTool/madie-cypress/pull/1840 as part of this.
We may need to reset the default to the current "else if".

Otherwise needed to re-align numbered measures to match other changes.