### PR TITLE
fix: add steps for test req or stability

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/QDMShiftTestCaseDatesValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/ShiftTestCaseDates/QDMShiftTestCaseDatesValidations.cy.ts
@@ -35,6 +35,22 @@ describe('MADiE Shift Test Case Dates tests for QDM Measure', () => {
         Utilities.waitForElementEnabled(EditMeasurePage.cqlEditorSaveButton, 3500)
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        // add SDE to test case coverage
+        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        cy.get(MeasureGroupPage.leftPanelSupplementalDataTab).click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionSelect).click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('SDE Ethnicity').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('SDE Payer').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('SDE Race').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).scrollIntoView().contains('SDE Sex').click()
+
+        //Save Supplemental data
+        cy.get('[data-testid="measure-Supplemental Data-save"]').click({ force: true })
+        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure Supplemental Data have been Saved Successfully')
+
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
@@ -171,6 +171,7 @@ describe('Import Test cases onto an existing Qi Core measure via file and ensure
 
         cy.reload()
 
+        Utilities.waitForElementVisible(Header.mainMadiePageButton, 45500)
         cy.get(Header.mainMadiePageButton).click()
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit', 2)


### PR DESCRIPTION
Small changes:
1. Added an extra wait step in QiCoreTestCaseID to ensure the page load completes before trying to continue.
2. Added the extra step to "include SDE data" for QDMShiftTestCaseDatesValidations. This will now be a requirement for any test that uses demographic data (SDE) as part of its testcases.