### PR TITLE
feat: handle new export dropdown, ensure backwards compatibility

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -1,4 +1,4 @@
-import { MeasuresPage } from "./MeasuresPage"
+import { MeasureActionOptions, MeasuresPage } from "./MeasuresPage"
 import { Utilities } from "./Utilities"
 import { TestCasesPage } from "./TestCasesPage"
 
@@ -27,6 +27,8 @@ export class EditMeasurePage {
     public static readonly editMeasureVersionActionBtn = '[data-testid="VersionMeasure"]'
     public static readonly editMeasureDraftActionBtn = '[data-testid="DraftMeasure"]'
     public static readonly editMeasureExportActionBtn = '[data-testid="ExportMeasure"]'
+    public static readonly editMeasureExportStandard = '[data-testid="export-option"]'
+    public static readonly editMeasureExportForPublish = '[data-testid=""export-publishing-option""]'
     public static readonly viewHRActionBtn = '[data-testid="Viewhumanreadable"]'
     public static readonly shareMeasureActionBtn = '[data-testid="Share/Unshare"]'
     public static readonly editPageVersionDraftMsg = '[data-testid="edit-measure-information-success-text"]'
@@ -187,7 +189,7 @@ export class EditMeasurePage {
     public static readonly measureClinicalRecommendationSaveButton = '[data-testid="measureClinical Recommendation StatementSave"]'
     public static readonly measureClinicalRecommendationSuccessMessage = '[data-testid="measureClinical Recommendation StatementSuccess"]'
 
-    public static actionCenter(action: EditMeasureActions): void {
+    public static actionCenter(action: EditMeasureActions, options?: MeasureActionOptions): void {
 
         cy.get(this.editMeasureButtonActionBtn).click()
 
@@ -195,9 +197,18 @@ export class EditMeasurePage {
 
             case EditMeasureActions.export: {
 
+                const exportWithInfo = options?.exportWithInfo
+
                 cy.get(this.editMeasureExportActionBtn).should('be.visible')
                 cy.get(this.editMeasureExportActionBtn).should('be.enabled')
                 cy.get(this.editMeasureExportActionBtn).click()
+
+                if (exportWithInfo) {
+                    cy.get(this.editMeasureExportStandard).click()
+                }
+                else {
+                    cy.get(this.editMeasureExportForPublish).click()
+                }
 
                 cy.get(MeasuresPage.exportingDialog).should('exist').should('be.visible')
                 cy.get(MeasuresPage.exportingSpinner).should('exist').should('be.visible')

--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -1,6 +1,12 @@
 import { Utilities } from "./Utilities"
 import { TestCasesPage } from "./TestCasesPage"
 
+export type MeasureActionOptions = {
+    exportWithInfo: boolean,
+    versionType: string,
+    updateModelVersion: boolean
+}
+
 export class MeasuresPage {
 
     public static readonly measureListTitles = '[data-testid="measure-list-tbl"]'
@@ -55,7 +61,7 @@ export class MeasuresPage {
         })
     }
 
-    public static actionCenter(action: string, measureNumber?: number): void {
+    public static actionCenter(action: string, measureNumber?: number, options?: MeasureActionOptions): void {
 
         //There is a prerequsite that you have a measure created and measure ID stored to a file
 
@@ -99,9 +105,18 @@ export class MeasuresPage {
 
             case 'export': {
 
+                const exportWithInfo = options?.exportWithInfo
+
                 cy.get('[data-testid="export-action-btn"]').should('be.visible')
                 cy.get('[data-testid="export-action-btn"]').should('be.enabled')
                 cy.get('[data-testid="export-action-btn"]').click()
+
+                if (exportWithInfo) {
+                    cy.get('[data-testid="export-option"]').click()
+                }
+                else {
+                    cy.get('[data-testid="export-publishing-option]').click()
+                }
 
                 cy.get(MeasuresPage.exportingDialog).should('exist').should('be.visible')
                 cy.get(MeasuresPage.exportingSpinner).should('exist').should('be.visible')


### PR DESCRIPTION
Do not merge this until after 2.2.0 regression cycle completes.

This code change will fix tests that currently fail in DEV but these same tests are passing in TEST.
A merge would reverse this, due to the new behavior the story https://jira.cms.gov/browse/MAT-8164 introduces.