### PR TITLE
Regression Failure fixes: WebInterface: AddVersionToCQLLibrary test file

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddVersionToCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddVersionToCQLLibrary.cy.ts
@@ -55,6 +55,7 @@ describe('Action Center Buttons - Add Version to CQL Library', () => {
 
     it('Non Measure owner unable to Version CQL Library using Action Center buttons', () => {
 
+        OktaLogin.UILogout()
         OktaLogin.AltLogin()
 
         cy.get(Header.cqlLibraryTab).click()


### PR DESCRIPTION
This PR contains fix for the AddVersionToCQLLibrary.cy.ts regression test file.