### PR TITLE
feat: corrections

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -199,19 +199,18 @@ export class EditMeasurePage {
 
             case EditMeasureActions.export: {
 
-                const exportWithInfo = options?.exportWithInfo
+                const exportForPublish = options?.exportForPublish
 
                 cy.get(this.editMeasureExportActionBtn).should('be.visible')
                 cy.get(this.editMeasureExportActionBtn).should('be.enabled')
                 cy.get(this.editMeasureExportActionBtn).click()
 
-                if (exportWithInfo) {
-                    Utilities.waitForElementVisible(MeasuresPage.exportNonPublishingOption, 50000)
-                    cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
-                }
-                else {
+                if (exportForPublish) {
                     Utilities.waitForElementVisible(MeasuresPage.exportPublishingOption, 50000)
                     cy.get(MeasuresPage.exportPublishingOption).should('contain.text', 'Export for Publishing').click()
+                } else {
+                    Utilities.waitForElementVisible(MeasuresPage.exportNonPublishingOption, 50000)
+                    cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
                 }
 
                 cy.get(MeasuresPage.exportingDialog).should('exist').should('be.visible')

--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -3,7 +3,7 @@ import { TestCasesPage } from "./TestCasesPage"
 import { EditMeasureActions } from "./EditMeasurePage"
 
 export type MeasureActionOptions = {
-    exportWithInfo?: boolean,
+    exportForPublish?: boolean,
     versionType?: string,
     updateModelVersion?: boolean
 }
@@ -108,19 +108,18 @@ export class MeasuresPage {
 
             case 'export': {
 
-                const exportWithInfo = options?.exportWithInfo
+                const exportForPublish = options?.exportForPublish
 
                 cy.get('[data-testid="export-action-btn"]').should('be.visible')
                 cy.get('[data-testid="export-action-btn"]').should('be.enabled')
                 cy.get('[data-testid="export-action-btn"]').click()
 
-                if (exportWithInfo) {
-                    Utilities.waitForElementVisible(MeasuresPage.exportNonPublishingOption, 50000)
-                    cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
-                }
-                else {
+                if (exportForPublish) {
                     Utilities.waitForElementVisible(MeasuresPage.exportPublishingOption, 50000)
                     cy.get(MeasuresPage.exportPublishingOption).should('contain.text', 'Export for Publishing').click()
+                } else {
+                    Utilities.waitForElementVisible(MeasuresPage.exportNonPublishingOption, 50000)
+                    cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
                 }
 
                 cy.get(MeasuresPage.exportingDialog).should('exist').should('be.visible')

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/ExportQDMMeasureWithInfo.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/ExportQDMMeasureWithInfo.cy.ts
@@ -11,15 +11,15 @@ import { Header } from "../../../../Shared/Header";
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
-
-const qdmMeasureName = 'QDMExportWithInfo' + Date.now()
-const qdmCqlLibraryName = 'QDMExportWithInfoLib' + Date.now()
 const qdmMeasureCQL = QdmCql.severeObstetricComplications
-const exportOptions: MeasureActionOptions = {
-    exportWithInfo: true
-} 
 
 describe('Successful QDM Measure Export with Info', () => {
+
+    const exportOptions: MeasureActionOptions = {
+        exportForPublish: false
+    }
+    const qdmMeasureName = 'QDMExportWithInfo' + Date.now()
+    const qdmCqlLibraryName = 'QDMExportWithInfoLib' + Date.now()
 
     deleteDownloadsFolderBeforeAll()
 
@@ -70,6 +70,68 @@ describe('Successful QDM Measure Export with Info', () => {
             })
             // assert exact number of warnings we expect
             expect(warnings).to.have.length(43)
+        })
+    })
+})
+
+describe('Successful QDM Measure Export for Publish', () => {
+
+    const exportOptions: MeasureActionOptions = {
+        exportForPublish: true
+    }
+    const qdmMeasureName = 'QDMExportWithInfo' + Date.now()
+    const qdmCqlLibraryName = 'QDMExportWithInfoLib' + Date.now()
+
+    deleteDownloadsFolderBeforeAll()
+
+    before('Create New Measure and Login', () => {
+
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasureName, qdmCqlLibraryName, 'Proportion',
+            false, qdmMeasureCQL, 0, false, '2026-01-01', '2026-12-31')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population',
+            '', '', 'Numerator 1 Delivery Encounters With Severe Obstetric Complications', '', 'Denominator')
+
+        OktaLogin.Login()
+
+        MeasuresPage.actionCenter("edit")
+
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 16500)
+
+        cy.get(Header.mainMadiePageButton).click()
+
+        MeasuresPage.actionCenter('export', null, exportOptions)
+        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', {timeout: 5500})
+        cy.log('Successfully verified zip file export')
+
+        cy.task('unzipFile', {zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder})
+            .then(results => {
+                cy.log('unzipFile Task finished')
+                cy.wait(1000)
+            })
+    })
+
+    after('Clean up and Logout', () => {
+
+        Utilities.deleteMeasure(qdmMeasureName, qdmCqlLibraryName)
+    })
+
+    it('Validate CQL info DOES NOT appear as annotations on the library JSON', () => {
+
+        const elmFile = path.join(downloadsFolder, 'resources', qdmCqlLibraryName + '-0.0.000.json')
+        
+        cy.readFile(elmFile).then(fileContents => {
+
+            expect(fileContents.library.annotation).to.have.length(2)
+            // remove other types of warnings/info
+            const warnings = fileContents.library.annotation.filter(obj => {
+                return obj.errorSeverity === 'warning' && obj.type === 'CqlToElmError'
+            })
+            // assert exact number of warnings we expect
+            expect(warnings).to.have.length(0)
         })
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
@@ -11,14 +11,6 @@ import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
-
-const measureName = 'ExportWithInfo' + Date.now()
-const CqlLibraryName = 'ExportWithInfoLib' + Date.now()
-const measureCQL = MeasureCQL.CQL_Multiple_Populations
-const exportOptions: MeasureActionOptions = {
-    exportWithInfo: true
-}
-
 const expCql = 'library FMPW version \'0.0.000\'\n' +
 'include FHIRHelpers version \'4.4.000\' called FHIRHelpers\n' +
 'using QICore version \'6.0.0\'\n' +
@@ -31,18 +23,20 @@ const expCql = 'library FMPW version \'0.0.000\'\n' +
 '  [Encounter] IP\n' +
 '  where IP.class is not null'
 
-describe('QI-Core Measure Export for Publish', () => {
+describe('QI-Core Measure Export with Info', () => {
+
+    const exportOptions: MeasureActionOptions = {
+        exportForPublish: false
+    }
+    const measureName = 'ExportWithInfo' + Date.now()
+    const CqlLibraryName = 'ExportWithInfoLib' + Date.now()
 
     deleteDownloadsFolderBeforeAll()
 
     before('Create New Measure and Login', () => {
 
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, {measureCql: expCql})
-      //  CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, expCql, null, false)
-      //  MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
-        // outcome boolean cohort "IP"
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'IP', 'boolean')
-
 
         OktaLogin.Login()
 
@@ -87,6 +81,70 @@ describe('QI-Core Measure Export for Publish', () => {
                 expect(elm.library.annotation[1].errorSeverity).to.eq('warning')
                 expect(elm.library.annotation[1].type).to.eq('CqlToElmError')
                 expect(elm.library.annotation[1].message).to.eq('An alias identifier [IP] is hiding another identifier of the same name.')
+            })
+        })
+    })
+})
+
+describe.only('QI-Core Measure Export for Publish', () => {
+
+    const exportOptions: MeasureActionOptions = {
+        exportForPublish: true
+    }
+    const measureName = 'ExportWithInfo' + Date.now()
+    const CqlLibraryName = 'ExportWithInfoLib' + Date.now()
+
+    deleteDownloadsFolderBeforeAll()
+
+    before('Create New Measure and Login', () => {
+
+        CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, {measureCql: expCql})
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'IP', 'boolean')
+
+        OktaLogin.Login()
+
+        MeasuresPage.actionCenter("edit")
+
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 16500)
+
+        cy.get(Header.mainMadiePageButton).click()
+
+        MeasuresPage.actionCenter('export', null, exportOptions)
+        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR6.zip', {timeout: 5500})
+        cy.log('Successfully verified zip file export')
+
+        cy.task('unzipFile', {zipFile: 'AutoTestTitle-v0.0.000-FHIR6.zip', path: downloadsFolder})
+            .then(results => {
+                cy.log('unzipFile Task finished')
+                cy.wait(1000)
+            })
+    })
+
+    after('Clean up and Logout', () => {
+
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+    })
+
+    it('Validate CQL info appears as annotations on the library JSON', () => {
+
+        const elmFile = path.join(downloadsFolder, 'resources', 'library-' + CqlLibraryName + '-0.0.000.json')
+        
+        cy.readFile(elmFile).then(fileContents => {
+
+            // the data we need is encoded - below will fetch, decode, and check for details
+            const encodedData = fileContents.content[2].data
+            Cypress.Blob.base64StringToBlob(encodedData).text().then(str => {
+                const elm = JSON.parse(str)
+
+                // assert we do not find specific details of the warning from scenario 1
+                expect(elm.library.annotation).to.have.length(2)
+                expect(elm.library.annotation[0].type).to.eq('CqlToElmInfo')
+                expect(elm.library.annotation[0]).to.not.have.key('message')
+                expect(elm.library.annotation[1]).to.not.have.key('message')
             })
         })
     })


### PR DESCRIPTION
Follow up to https://github.com/MeasureAuthoringTool/madie-cypress/pull/1917

I learned that my mental model was slightly off & I set things up somewhat backwards.
This PR corrects my mistake.

- Reversed logic on actionCenter functions to accurately reflect the situation.
- Added additional scenarios to cover "export for publish" that I mistakenly thought was already covered.