### PR TITLE
fix: update after login page changes

### DIFF
--- a/cypress/Shared/OktaLogin.ts
+++ b/cypress/Shared/OktaLogin.ts
@@ -14,11 +14,11 @@ export class OktaLogin {
 
     public static readonly needHelpButton = 'a[data-se="needhelp"]'
     public static readonly forgotPassword = '[data-se="forgot-password"]'
-    public static readonly helpLink = '[data-se="help-link"]'
+    public static readonly helpLink = '[data-se="help"]'
     public static readonly termsAndConditionsButton = '[data-testid="terms-and-conditions-button"]'
     public static readonly tcClose = '[data-testid="terms-and-conditions-close-button"]'
     public static readonly resetViaEmail = '[data-se="email-button"]'
-    public static readonly backFromReset = '[data-se="back-link"]'
+    public static readonly backFromReset = '[data-se="cancel"]'
 
     public static AltLogin() {
 

--- a/cypress/e2e/WebInterface/Smoke Tests/LoginPageLayout.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/LoginPageLayout.cy.ts
@@ -16,20 +16,13 @@ describe('Login page layout', () => {
 
     it('Login help links are correct', () => {
 
-        // expand
-        cy.get(OktaLogin.needHelpButton).click()
-
-        Utilities.waitForElementVisible(OktaLogin.forgotPassword, 3500)
         cy.get(OktaLogin.forgotPassword).click()
 
-      //  Utilities.waitForElementVisible(OktaLogin.resetViaEmail, 3500)
-        cy.get(OktaLogin.resetViaEmail).should('be.visible')
+        cy.contains('Reset your password').should('be.visible')
+        cy.contains('Email or Username ').should('be.visible')
 
         Utilities.waitForElementVisible(OktaLogin.backFromReset, 3500)
         cy.get(OktaLogin.backFromReset).should('have.text', 'Back to sign in').click()
-
-        // expand again
-        cy.get(OktaLogin.needHelpButton).click()
 
         cy.get(OktaLogin.helpLink).should('have.attr', 'href').and('contain', 'idm.cms.gov/help')
 
@@ -59,7 +52,7 @@ describe('Login page layout', () => {
         cy.contains('CMS/HHS Vulnerability Disclosure Policy').should('have.attr', 'href', 'https://www.cms.gov/about-cms/information-systems/privacy/vulnerability-disclosure-policy')
 
         cy.contains('CMS.gov').should('have.attr', 'href', 'https://www.cms.gov/')
-        })
+    })
 
     it('Footer displays all relevant info', () => {
 


### PR DESCRIPTION
Fixes for LoginPageLayout

These were expected, after the upgrade to the Okta-based login page.