### PR TITLE
fix: restore regression test

### DIFF
--- a/cypress/Shared/TestCaseJson.ts
+++ b/cypress/Shared/TestCaseJson.ts
@@ -7,7 +7,7 @@ export class TestCaseJson {
         '9th 2021 for Asthma<a name=\\"mm\\"/></div>" }, "status": "in-progress", "class": { "system": "http://terminology.hl7.org/' +
         'CodeSystem/v3-ActCode", "code": "IMP", "display": "inpatient encounter" }, "type": [ { "text": "OutPatient" } ], "subject": ' +
         '{ "reference": "Patient/1" }, "participant": [ { "individual": { "reference": "Practitioner/30164", "display": "Dr John Doe" ' +
-        '} } ], "period": { "start": "2022-05-13T03:34:10.054Z" } } }, { "fullUrl": "http://local/Patient", "resource": { "id": "2", ' +
+        '} } ], "period": { "start": "2022-05-13T03:34:10.054+00:00" } } }, { "fullUrl": "http://local/Patient", "resource": { "id": "2", ' +
         '"resourceType": "Patient", "text": { "status": "generated", "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">Lizzy Health' +
         '</div>" }, "meta": { "profile": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" }, "identifier": [ { ' +
         '"system": "http://clinfhir.com/fhir/NamingSystem/identifier", "value": "20181011LizzyHealth" } ], "name": [ { "use": "official", ' +
@@ -528,7 +528,7 @@ export class TestCaseJson {
         '9th 2021 for Asthma<a name=\\"mm\\"/></div>" }, "status": "in-progress", "class": { "system": "http://terminology.hl7.org/' +
         'CodeSystem/v3-ActCode", "code": "IMP", "display": "inpatient encounter" }, "type": [ { "text": "OutPatient" } ], "subject": ' +
         '{ "reference": "Patient/1" }, "participant": [ { "individual": { "reference": "Practitioner/30164", "display": "Dr John Doe" ' +
-        '} } ], "period": { "start": "2022-05-13T03:34:10.054Z" } } }, { "fullUrl": "http://local/Patient", "resource": { "id": "2", ' +
+        '} } ], "period": { "start": "2022-05-13T03:34:10.054+00:00" } } }, { "fullUrl": "http://local/Patient", "resource": { "id": "2", ' +
         '"resourceType": "Patient", "text": { "status": "generated", "div": "<div xmlns=\\"http://www.w3.org/1999/xhtml\\">Builder Bobby' +
         '</div>" }, "meta": { "profile": "http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient" }, "identifier": [ { ' +
         '"system": "http://clinfhir.com/fhir/NamingSystem/identifier", "value": "20181011LizzyHealth" } ], "name": [ { "use": "official", ' +

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -110,15 +110,15 @@ describe('Test Case Import: functionality tests', () => {
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).check()
+        cy.get(TestCasesPage.testCaseIPPExpected).click()
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
-        cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
+        Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 9500)
 
-        cy.get(TestCasesPage.successMsg).should('have.text', 'Test case updated successfully with warnings in JSON')
+        cy.get(TestCasesPage.successMsg).should('have.text', 'Test case updated successfully with warnings in JSONMADiE only supports a timezone offset of 0. MADiE has overwritten any timezone offsets that are not zero.')
 
         OktaLogin.UILogout()
 


### PR DESCRIPTION
Change summary:

1. Test case JSONs used by these scenarios are now standardized on timestamps `+00.00`. This seems to remove complicated toast messages.
2. Added an explicit wait as part of the test case save process. Previously the scenario was performing another action instead of waiting, and sometimes that action completed too fast.
3. Changed a `.check()` that did not actually tick the checkbox into a `.click()` that does properly tick.