### PR TITLE
Regression Failure Fixes: Webinterface tests: CreateMeasureValidations test file

### DIFF
--- a/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
@@ -253,8 +253,8 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //confirm dirty check window
-        cy.get(EditMeasurePage.dirtCheckModal).should('exist')
-        cy.get(EditMeasurePage.dirtCheckModal).should('be.visible')
+        cy.get(MeasureGroupPage.qdmDirtyCheckDiscardModal).should('exist')
+        cy.get(MeasureGroupPage.qdmDirtyCheckDiscardModal).should('be.visible')
 
     })
 


### PR DESCRIPTION
This PR contains fix for the failure that was seen during last regression run. The fix is for the CreateMeasureValidations test file.