### PR TITLE
fix: added helper and new TZ warning message

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -905,4 +905,11 @@ export class TestCasesPage {
         }
 
     }
+
+    public static checkToastMessageOK(element: string) {
+
+        cy.get(element).each(msg => {
+            expect(msg.text()).to.be.oneOf(['Test case updated successfully!', 'Test case updated successfully with warnings in JSON', 'Test case updated successfully with warnings in JSONMADiE only supports a timezone offset of 0. MADiE has overwritten any timezone offsets that are not zero.'])
+        })
+    }
 }

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExpectedValues.cy.ts
@@ -53,9 +53,7 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         //Save edited / updated to test case
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.successMsg).each(msg => {
-            expect(msg.text()).to.be.oneOf(['Test case updated successfully!', 'Test case updated successfully with warnings in JSON'])
-        })
+        TestCasesPage.checkToastMessageOK(TestCasesPage.successMsg)
 
         //Navigate to Measure group page and update scoring type
         cy.get(EditMeasurePage.measureGroupsTab).click()
@@ -102,9 +100,7 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         //Save edited / updated to test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.detailsTab).click()
-        cy.get(TestCasesPage.successMsg).each(msg => {
-            expect(msg.text()).to.be.oneOf(['Test case updated successfully!', 'Test case updated successfully with warnings in JSON'])
-        })
+        TestCasesPage.checkToastMessageOK(TestCasesPage.successMsg)
 
         //Navigate to Measure group page and update scoring type
         cy.get(EditMeasurePage.measureGroupsTab).click()
@@ -236,9 +232,7 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('not.exist')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.detailsTab).click()
-        cy.get(TestCasesPage.successMsg).each(msg => {
-            expect(msg.text()).to.be.oneOf(['Test case updated successfully!', 'Test case updated successfully with warnings in JSON'])
-        })
+        TestCasesPage.checkToastMessageOK(TestCasesPage.successMsg)
 
         //Navigate to Measure Group page and add Numerator Exclusion & delete Denominator Exclusion
         cy.get(EditMeasurePage.measureGroupsTab).click()
@@ -425,8 +419,6 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         //Save edited / updated to test case
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.successMsg).each(msg => {
-            expect(msg.text()).to.be.oneOf(['Test case updated successfully!', 'Test case updated successfully with warnings in JSON'])
-        })
+        TestCasesPage.checkToastMessageOK(TestCasesPage.successMsg)
     })
 })


### PR DESCRIPTION
Fixes TestCaseExpectedValues.cy.ts

Updated several scenarios to account for the new warning message re: TZ offset in test cases.

Added a helper function `TestCasesPage.checkToastMessageOK()` to make it easier for these same updates.