### PR TITLE
Regression Failure Fixes: Webinterface tests: QDMPopulationCriteriaPage test file

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
@@ -356,7 +356,7 @@ describe('No values in QDM PC fields, when no CQL', () => {
         cy.get(MeasureGroupPage.initialPopulationSelect).scrollTo
         cy.get(MeasureGroupPage.initialPopulationSelect).click()
 
-        cy.get('[class="MuiList-root MuiList-padding MuiMenu-list css-1c1ttle"]').should('be.empty')
+        cy.get('[class="MuiList-root MuiList-padding MuiMenu-list css-ubifyk"]').should('be.empty')
 
         cy.get(MeasureGroupPage.QDMPopCriteria1IPDesc).should('be.visible')
     })


### PR DESCRIPTION
This PR contains fix to resolve the issue that was causing the QDMPopulationCriteriaPage test file fail, while running regression tests.