### PR TITLE
Regression failure fix: Webinterface tests: QDMLibraryIncludes and QiCoreLibraryIncludes files

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
@@ -73,7 +73,7 @@ describe('QDM Library Includes fields', () => {
         //Search for QDM Libraries
         cy.get(CQLEditorPage.librarySearchTextBox).clear().type('sdoh')
         cy.get(CQLEditorPage.librarySearchBtn).click()
-        cy.get('[data-testid="terminology-section-Library Results-sub-heading"]').find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable).find('[data-testid="library-results-tbl"]').find('[data-testid="library-results-table-body"]').should('include.text', 'SDOH3.2.000ltj7708SDOH3.1.000ltj7708SDOH3.0.000ltj7708SDOH2.0.000ltj7708SDOH1.0.000ltj7708')
+        cy.get('[data-testid="terminology-section-Library Results-sub-heading"]').find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable).find('[data-testid="library-results-tbl"]').find('[data-testid="library-results-table-body"]').should('include.text', 'SDOH3.2.000SDOH3.1.000SDOH3.0.000SDOH2.0.000SDOH1.0.000')
     })
 
     it('Apply QDM Included library to the CQL and save', () => {
@@ -84,7 +84,7 @@ describe('QDM Library Includes fields', () => {
         //Search for Library
         cy.get(CQLEditorPage.librarySearchTextBox).clear().type('vte')
         cy.get(CQLEditorPage.librarySearchBtn).click()
-        cy.get('[data-testid="terminology-section-Library Results-sub-heading"]').find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable).find('[data-testid="library-results-tbl"]').find('[data-testid="library-results-table-body"]').should('include.text', 'UATVTEQDM0.1.000YaHu1257VTEQDM9.0.000YaHu1257VTEQDM8.3.000YaHu1257VTEQDM8.2.000YaHu1257VTEQDM8.1.000YaHu1257')
+        cy.get('[data-testid="terminology-section-Library Results-sub-heading"]').find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable).find('[data-testid="library-results-tbl"]').find('[data-testid="library-results-table-body"]').should('include.text', 'UATVTEQDM0.1.000VTEQDM9.0.000VTEQDM8.3.000VTEQDM8.2.000VTEQDM8.1.000')
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()
@@ -105,7 +105,7 @@ describe('QDM Library Includes fields', () => {
         //Search for Library
         cy.get(CQLEditorPage.librarySearchTextBox).clear().type('VTE')
         cy.get(CQLEditorPage.librarySearchBtn).click()
-        cy.get('[data-testid="terminology-section-Library Results-sub-heading"]').find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable).find('[data-testid="library-results-tbl"]').find('[data-testid="library-results-table-body"]').should('include.text', 'UATVTEQDM0.1.000YaHu1257VTEQDM9.0.000YaHu1257VTEQDM8.3.000YaHu1257VTEQDM8.2.000YaHu1257VTEQDM8.1.000YaHu1257')
+        cy.get('[data-testid="terminology-section-Library Results-sub-heading"]').find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable).find('[data-testid="library-results-tbl"]').find('[data-testid="library-results-table-body"]').should('include.text', 'UATVTEQDM0.1.000VTEQDM9.0.000VTEQDM8.3.000VTEQDM8.2.000VTEQDM8.1.000')
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreLibraryIncludes.cy.ts
@@ -50,7 +50,7 @@ describe('Qi-Core Library Includes fields', () => {
         //Search for QDM Libraries
         cy.get(CQLEditorPage.librarySearchTextBox).clear().type('vte')
         cy.get(CQLEditorPage.librarySearchBtn).click()
-        cy.get(CQLEditorPage.librarySearchTable).should('contain', 'nameversionownerActionVTE8.10.000YaHu1257VTE8.9.000YaHu1257VTE8.8.000YaHu1257VTE8.7.000YaHu1257VTE8.6.000YaHu1257')
+        cy.get(CQLEditorPage.librarySearchTable).should('include.text', 'nameversionownerActionVTE8.10.000VTE8.9.000VTE8.8.000VTE8.7.000VTE8.6.000Items per page 5.Items per page5​1 - 5 of 181234')
     })
 
     it('Apply Qi-Core Included library to the CQL and save', () => {
@@ -61,7 +61,7 @@ describe('Qi-Core Library Includes fields', () => {
         //Search for Library
         cy.get(CQLEditorPage.librarySearchTextBox).clear().type('vte')
         cy.get(CQLEditorPage.librarySearchBtn).click()
-        cy.get(CQLEditorPage.librarySearchTable).should('contain', 'nameversionownerActionVTE8.10.000YaHu1257VTE8.9.000YaHu1257VTE8.8.000YaHu1257VTE8.7.000YaHu1257VTE8.6.000YaHu1257')
+        cy.get(CQLEditorPage.librarySearchTable).should('include.text', 'nameversionownerActionVTE8.10.000VTE8.9.000VTE8.8.000VTE8.7.000VTE8.6.000Items per page 5.Items per page5​1 - 5 of 181234')
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()
@@ -82,7 +82,7 @@ describe('Qi-Core Library Includes fields', () => {
         //Search for Library
         cy.get(CQLEditorPage.librarySearchTextBox).clear().type('vte')
         cy.get(CQLEditorPage.librarySearchBtn).click()
-        cy.get(CQLEditorPage.librarySearchTable).should('contain', 'nameversionownerActionVTE8.10.000YaHu1257VTE8.9.000YaHu1257VTE8.8.000YaHu1257VTE8.7.000YaHu1257VTE8.6.000YaHu1257')
+        cy.get(CQLEditorPage.librarySearchTable).should('include.text', 'nameversionownerActionVTE8.10.000VTE8.9.000VTE8.8.000VTE8.7.000VTE8.6.000Items per page 5.Items per page5​1 - 5 of 181234')
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()


### PR DESCRIPTION
This PR contains SOME changes for the following files:
-- QDMLibraryIncludes
-- QiCoreLibraryIncludes
This changes were included in the same PR, due
to the similarity of the tests and the changes.

These tests are still failing due to MAT-8569.