### PR TITLE
Added versioned Measure check

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/ProportionBoolean600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/ProportionBoolean600.cy.ts
@@ -3,7 +3,7 @@ import { CreateMeasurePage, SupportedModels } from "../../../../Shared/CreateMea
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { Utilities } from "../../../../Shared/Utilities"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import {EditMeasureActions, EditMeasurePage} from "../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
@@ -103,6 +103,31 @@ describe('Measure Creation and Testing: Proportion Episode Measure', () => {
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('exist')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '99%')
+
+
+        //after versioning, there should be no change to test results or coverage
+
+        //commenting this out until it works, the following stories need to be completed
+        //https://jira.cms.gov/browse/MAT-8585
+        //https://jira.cms.gov/browse/MAT-8586
+        //https://jira.cms.gov/browse/MAT-8587
+
+        // EditMeasurePage.actionCenter(EditMeasureActions.version)
+        //
+        // Utilities.waitForElementVisible(TestCasesPage.executeTestCaseButton, 65000)
+        // Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 65000)
+        // cy.get(TestCasesPage.executeTestCaseButton).click()
+        //
+        // //verify Passing Tab's text after Versioning
+        // cy.get(TestCasesPage.testCaseListPassingPercTab).should('exist')
+        // cy.get(TestCasesPage.testCaseListPassingPercTab).should('be.visible')
+        // cy.get(TestCasesPage.testCaseListPassingPercTab).should('contain.text', '100%')
+        // cy.get(TestCasesPage.testCaseListPassingPercTab).should('contain.text', '(49/49)')
+        //
+        // //Verify Coverage percentage after versioning
+        // cy.get(TestCasesPage.testCaseListCoveragePercTab).should('exist')
+        // cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
+        // cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '99%')
 
     })
 })


### PR DESCRIPTION
added check for running test cases against versioned measure, this check is commented out for now until https://jira.cms.gov/browse/MAT-8585, https://jira.cms.gov/browse/MAT-8586 and https://jira.cms.gov/browse/MAT-8587 are finished and deployed