### PR TITLE
fix: add pretest cleanup, adjust test case creation

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseID/QiCoreTestCaseID.cy.ts
@@ -9,6 +9,7 @@ import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
 import { Header } from "../../../../../Shared/Header"
 import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
 import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
 
 const timestamp = Date.now()
 let measureName = 'QiCoreTestCaseId' + timestamp
@@ -118,6 +119,8 @@ describe('Test Case sorting by Test Case number', () => {
 })
 
 describe('Import Test cases onto an existing Qi Core measure via file and ensure test case ID / numbering appears', () => {
+
+    deleteDownloadsFolderBeforeAll()
 
     beforeEach('Create measure and login', () => {
 
@@ -291,7 +294,7 @@ describe('Qi Core Measure - Test case number on a Draft Measure', () => {
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCase2.description)
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-        cy.get(TestCasesPage.createTestCaseGroupInput).type(testCase2.group).type('{enter}')
+        cy.get(TestCasesPage.createTestCaseGroupInput).type(testCase2.group)
 
         cy.get(TestCasesPage.createTestCaseSaveButton).click()
 


### PR DESCRIPTION
Fixes QiCoreTestCaseID.cy.ts

1. Added a cleanup of /downloads folder before a test scenario involving test case import/export.
2. Adjusted test case creation to not hit the final {enter} as a keystroke & instead rely on button clicks.