### PR TITLE
feat: remove duplicated cql from several tests

### DIFF
--- a/cypress/Shared/MeasureCQL.ts
+++ b/cypress/Shared/MeasureCQL.ts
@@ -39,18 +39,14 @@ export class MeasureCQL {
         'define "Initial PopulationOne":\n' +
         'true\n'
 
-    public static readonly zipfileExportQICore = 'library TestLibrary1678378360032 version \'0.0.000\'\n' +
-        '\n' +
-        'using QICore version \'4.1.1\'\n' +
-        '\n' +
+    public static readonly zipfileExportQICore = 'library TestLibrary1678378360032 version \'0.0.000\'\n\n' +
+        'using QICore version \'4.1.1\'\n\n' +
         'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
         'include SupplementalDataElements version \'3.5.000\' called SDE\n' +
-        'include CQMCommon version \'1.0.000\' called CQMCommon \n' +
-        'include FHIRCommon version \'4.1.000\' called FHIRCommon\n' +
-        '\n' + '\n' +
-        'codesystem "SNOMEDCT": \'http://snomed.info/sct\' \n' +
-        'codesystem "ActCode": \'http://terminology.hl7.org/CodeSystem/v3-ActCode\'  \n' +
-        '\n' + '\n' + '\n' +
+        'include CQMCommon version \'1.0.000\' called CQMCommon\n' +
+        'include FHIRCommon version \'4.1.000\' called FHIRCommon\n\n' +
+        'codesystem "SNOMEDCT": \'http://snomed.info/sct\'\n' +
+        'codesystem "ActCode": \'http://terminology.hl7.org/CodeSystem/v3-ActCode\'\n\n' +
         'valueset "Care Services in Long-Term Residential Facility": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014\' \n' +
         'valueset "Diabetic Retinopathy": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327\' \n' +
         'valueset "Level of Severity of Retinopathy Findings": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283\' \n' +
@@ -60,8 +56,7 @@ export class MeasureCQL {
         'valueset "Nursing Facility Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012\' \n' +
         'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\' \n' +
         'valueset "Ophthalmological Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285\' \n' +
-        'valueset "Patient Reason": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008\' \n' +
-        '\n' +
+        'valueset "Patient Reason": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008\'\n\n' +
         'code "Healthcare professional (occupation)": \'223366009\' from "SNOMEDCT" display \'Healthcare professional (occupation)\'\n' +
         'code "Medical practitioner (occupation)": \'158965000\' from "SNOMEDCT" display \'Medical practitioner (occupation)\'\n' +
         'code "Ophthalmologist (occupation)": \'422234006\' from "SNOMEDCT" display \'Ophthalmologist (occupation)\'\n' +
@@ -69,30 +64,21 @@ export class MeasureCQL {
         'code "Physician (occupation)": \'309343006\' from "SNOMEDCT" display \'Physician (occupation)\'\n' +
         'code "virtual": \'VR\' from "ActCode" display \'virtual\'\n' +
         'code "Macular edema absent (situation)": \'428341000124108\' from "SNOMEDCT" display \'Macular edema absent (situation)\'\n' +
-        'code "AMB" : \'AMB\' from "ActCode" display \'Ambulatory\'\n' +
-        '\n' +
-        'parameter "Measurement Period" Interval<DateTime>\n' +
-        '\n' +
-        'context Patient\n' +
-        '\n' +
+        'code "AMB" : \'AMB\' from "ActCode" display \'Ambulatory\'\n\n' +
+        'parameter "Measurement Period" Interval<DateTime>\n\n' +
+        'context Patient\n\n' +
         'define "SDE Ethnicity":\n' +
-        '  SDE."SDE Ethnicity"\n' +
-        '\n' +
+        '  SDE."SDE Ethnicity"\n\n' +
         'define "SDE Payer":\n' +
-        '  SDE."SDE Payer"\n' +
-        '\n' +
+        '  SDE."SDE Payer"\n\n' +
         'define "SDE Race":\n' +
-        '  SDE."SDE Race"\n' +
-        '\n' +
+        '  SDE."SDE Race"\n\n' +
         'define "SDE Sex":\n' +
-        '  SDE."SDE Sex"\n' +
-        '\n' + '\n' + '\n' +
+        '  SDE."SDE Sex"\n\n' +
         'define "ipp":\n' +
-        'true\n' +
-        '\n' +
+        'true\n\n' +
         'define "num":\n' +
-        'true\n' +
-        '\n' +
+        'true\n\n' +
         'define "denom":\n' +
         'true'
 

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureRiskAdjustmentsValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureRiskAdjustmentsValidations.cy.ts
@@ -6,60 +6,12 @@ import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { Header } from "../../../../Shared/Header"
+import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 
 let measureNameTimeStamp = 'TestMeasure' + Date.now()
 let measureName = measureNameTimeStamp
 let CqlLibraryName = 'TestLibrary' + Date.now()
-
-let measureCQL = 'library TestLibrary1678378360032 version \'0.0.000\'\n' +
-    '\n' +
-    'using QICore version \'4.1.1\'\n' +
-    '\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.1.000\' called SDE\n' +
-    'include CQMCommon version \'1.0.000\' called CQMCommon \n' +
-    'include FHIRCommon version \'4.1.000\' called FHIRCommon\n' +
-    '\n' +
-    '\n' +
-    'codesystem "SNOMEDCT": \'http://snomed.info/sct\' \n' +
-    'codesystem "ActCode": \'http://terminology.hl7.org/CodeSystem/v3-ActCode\'  \n' +
-    '\n' +
-    '\n' +
-    'code "Healthcare professional (occupation)": \'223366009\' from "SNOMEDCT" display \'Healthcare professional (occupation)\'\n' +
-    'code "Medical practitioner (occupation)": \'158965000\' from "SNOMEDCT" display \'Medical practitioner (occupation)\'\n' +
-    'code "Ophthalmologist (occupation)": \'422234006\' from "SNOMEDCT" display \'Ophthalmologist (occupation)\'\n' +
-    'code "Optometrist (occupation)": \'28229004\' from "SNOMEDCT" display \'Optometrist (occupation)\'\n' +
-    'code "Physician (occupation)": \'309343006\' from "SNOMEDCT" display \'Physician (occupation)\'\n' +
-    'code "virtual": \'VR\' from "ActCode" display \'virtual\'\n' +
-    'code "Macular edema absent (situation)": \'428341000124108\' from "SNOMEDCT" display \'Macular edema absent (situation)\'\n' +
-    'code "AMB" : \'AMB\' from "ActCode" display \'Ambulatory\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "SDE Ethnicity":\n' +
-    '  SDE."SDE Ethnicity"\n' +
-    '\n' +
-    'define "SDE Payer":\n' +
-    '  SDE."SDE Payer"\n' +
-    '\n' +
-    'define "SDE Race":\n' +
-    '  SDE."SDE Race"\n' +
-    '\n' +
-    'define "SDE Sex":\n' +
-    '  SDE."SDE Sex"\n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    'true\n' +
-    '\n' +
-    'define "Num":\n' +
-    'true\n' +
-    '\n' +
-    'define "Denom":\n' +
-    'true'
+let measureCQL = MeasureCQL.zipfileExportQICore
 
 describe('Validations between Risk Adjustments with the CQL definitions', () => {
 
@@ -69,14 +21,11 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
 
     beforeEach('Create New Measure and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-        //create Measure Group
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '',
-            'Num', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'ipp', '', '',
+            'num', '', 'ipp', 'boolean')
 
         OktaLogin.Login()
-
     })
 
     afterEach('Log out', () => {
@@ -84,6 +33,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         OktaLogin.Logout()
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
     })
+
     it('Removing definition related to the RA alerts user.', () => {
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
@@ -94,7 +44,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
 
         //select a definition and enter a description for denom
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).click()
-        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox)
             .first() // select the first element
@@ -128,6 +78,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         cy.get('[data-testid="test-case-list-error"]').should('contain.text', 'Supplemental Data Elements or Risk Adjustment Variables in the Population Criteria section are invalid. Please check and update these values. Test cases will not execute until this issue is resolved.')
 
     })
+
     it('Fixing RA to point to something that is, now, in CQL, resolves alert.', () => {
 
         cy.get(Header.measures).click()
@@ -139,7 +90,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
 
         //select a definition and enter a description for denom
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).click()
-        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox)
             .first() // select the first element
@@ -187,7 +138,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
 
         //select a definition and enter a description for Initial Population
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).click()
-        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('Initial Population').click()
+        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('ipp').click()
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox)
             .first() // select the first element
@@ -205,6 +156,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         Utilities.waitForElementToNotExist(MeasureGroupPage.pcErrorAlertToast, 75)
 
     })
+
     it('Placing definition back into CQL and saving resolves the alert.', () => {
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
@@ -214,7 +166,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         cy.get(MeasureGroupPage.leftPanelRiskAdjustmentTab).click()
         //select a definition and enter a description for denom
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).click()
-        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox)
             .first() // select the first element
@@ -256,7 +208,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
             '{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}' +
             '\n' +
             '\n' +
-            'define "Denom":\n' +
+            'define "denom":\n' +
             ' true')
         //save updated CQL
         cy.get(CQLEditorPage.saveCQLButton).click()
@@ -270,6 +222,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         cy.get(EditMeasurePage.measureGroupsTab).click()
         Utilities.waitForElementToNotExist(MeasureGroupPage.pcErrorAlertToast, 75)
     })
+
     // user is able to create, add, and save RAs on a group
     it('QI Core: User able to create, add, and save RA and RA description', () => {
         cy.get(Header.measures).click()
@@ -281,13 +234,13 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
 
         //select a definition and enter a description for denom
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).click()
-        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox)
             .first() // select the first element
             .type('Initial Population Description')
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).eq(0).click()
-        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('Num').click()
+        cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).contains('num').click()
 
         //save the Risk Adjustment data
         cy.get(MeasureGroupPage.saveRiskAdjustments).click().click()
@@ -302,7 +255,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         cy.get(MeasureGroupPage.leftPanelRiskAdjustmentTab).click()
 
         //confirm the values in the RA fields
-        cy.get(MeasureGroupPage.riskAdjDropDown).should('contain.text', 'DefinitionDenom+1')
+        cy.get(MeasureGroupPage.riskAdjDropDown).should('contain.text', 'Definitiondenom+1')
         cy.get(MeasureGroupPage.riskAdjustmentDescriptionTextBox).should('contain.text', 'Initial Population Description')
 
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionSelect).eq(0).click()
@@ -319,7 +272,7 @@ describe('Validations between Risk Adjustments with the CQL definitions', () => 
         cy.get(MeasureGroupPage.leftPanelRiskAdjustmentTab).click()
 
         //confirm the values in the RA fields
-        cy.get(MeasureGroupPage.riskAdjDropDown).should('contain.text', 'DefinitionNum')
+        cy.get(MeasureGroupPage.riskAdjDropDown).should('contain.text', 'Definitionnum')
 
     })
 })

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureSupplementalDataValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureSupplementalDataValidations.cy.ts
@@ -6,72 +6,21 @@ import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { Header } from "../../../../Shared/Header"
+import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 
-let measureNameTimeStamp = 'TestMeasure' + Date.now()
-let measureName = measureNameTimeStamp
+let measureName = 'TestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
+let measureCQL = MeasureCQL.zipfileExportQICore
 
-let measureCQL = 'library TestLibrary1678378360032 version \'0.0.000\'\n' +
-    '\n' +
-    'using QICore version \'4.1.1\'\n' +
-    '\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.1.000\' called SDE\n' +
-    'include CQMCommon version \'1.0.000\' called CQMCommon \n' +
-    'include FHIRCommon version \'4.1.000\' called FHIRCommon\n' +
-    '\n' +
-    '\n' +
-    'codesystem "SNOMEDCT": \'http://snomed.info/sct\' \n' +
-    'codesystem "ActCode": \'http://terminology.hl7.org/CodeSystem/v3-ActCode\'  \n' +
-    '\n' +
-    '\n' +
-    'code "Healthcare professional (occupation)": \'223366009\' from "SNOMEDCT" display \'Healthcare professional (occupation)\'\n' +
-    'code "Medical practitioner (occupation)": \'158965000\' from "SNOMEDCT" display \'Medical practitioner (occupation)\'\n' +
-    'code "Ophthalmologist (occupation)": \'422234006\' from "SNOMEDCT" display \'Ophthalmologist (occupation)\'\n' +
-    'code "Optometrist (occupation)": \'28229004\' from "SNOMEDCT" display \'Optometrist (occupation)\'\n' +
-    'code "Physician (occupation)": \'309343006\' from "SNOMEDCT" display \'Physician (occupation)\'\n' +
-    'code "virtual": \'VR\' from "ActCode" display \'virtual\'\n' +
-    'code "Macular edema absent (situation)": \'428341000124108\' from "SNOMEDCT" display \'Macular edema absent (situation)\'\n' +
-    'code "AMB" : \'AMB\' from "ActCode" display \'Ambulatory\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "SDE Ethnicity":\n' +
-    '  SDE."SDE Ethnicity"\n' +
-    '\n' +
-    'define "SDE Payer":\n' +
-    '  SDE."SDE Payer"\n' +
-    '\n' +
-    'define "SDE Race":\n' +
-    '  SDE."SDE Race"\n' +
-    '\n' +
-    'define "SDE Sex":\n' +
-    '  SDE."SDE Sex"\n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    'true\n' +
-    '\n' +
-    'define "Num":\n' +
-    'true\n' +
-    '\n' +
-    'define "Denom":\n' +
-    'true'
 
 describe('Validations between Supplemental Data Elements with the CQL definitions', () => {
 
     beforeEach('Create New Measure and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        //create Measure Group
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '',
-            'Num', '', 'Initial Population', 'boolean')
-
-
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'ipp', '', '', 'num', '', 'ipp', 'boolean')
+        
+        OktaLogin.Login()
     })
 
     afterEach('Log out', () => {
@@ -82,7 +31,6 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
     it('Removing definition related to the SD alerts user.', () => {
 
-        OktaLogin.Login()
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
         //navigate to the PC page / tab
@@ -92,7 +40,7 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
         //set supplemental data definition to e Denom
         cy.get(MeasureGroupPage.supplementalDataDefinitionSelect).click()
-        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox)
             .first() // select the first element
@@ -128,7 +76,6 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
     it('Fixing SD to point to something that is, now, in CQL, resolves alert.', () => {
 
-        OktaLogin.Login()
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
         //navigate to the PC page / tab
@@ -138,7 +85,7 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
         //set supplemental data definition to e Denom
         cy.get(MeasureGroupPage.supplementalDataDefinitionSelect).click()
-        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox)
             .first() // select the first element
@@ -186,7 +133,7 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
         //set supplemental data definition to e Denom
         cy.get(MeasureGroupPage.supplementalDataDefinitionSelect).click()
-        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('Initial Population').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('ipp').click()
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox)
             .first() // select the first element
@@ -207,7 +154,6 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
     it('Placing definition back into CQL and saving resolves the alert.', () => {
 
-        OktaLogin.Login()
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
         //navigate to the PC page / tab
@@ -217,7 +163,7 @@ describe('Validations between Supplemental Data Elements with the CQL definition
 
         //set supplemental data definition to e Denom
         cy.get(MeasureGroupPage.supplementalDataDefinitionSelect).click()
-        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('Denom').click()
+        cy.get(MeasureGroupPage.supplementalDataDefinitionDropdown).contains('denom').click()
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox).should('exist')
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox)
             .first() // select the first element
@@ -259,7 +205,7 @@ describe('Validations between Supplemental Data Elements with the CQL definition
             '{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}' +
             '\n' +
             '\n' +
-            'define "Denom":\n' +
+            'define "denom":\n' +
             ' true')
         //save updated CQL
         cy.get(CQLEditorPage.saveCQLButton).click()

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
@@ -2,76 +2,18 @@ import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
 import { OktaLogin } from "../../../../Shared/OktaLogin"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
+import { MeasureCQL } from "../../../../Shared/MeasureCQL"
+import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { Utilities } from "../../../../Shared/Utilities"
 
-let measureNameTimeStamp = 'TestMeasure' + Date.now()
-let measureName = measureNameTimeStamp
+let measureName = 'TestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
 
-let measureCQL = 'library TestLibrary1678378360032 version \'0.0.000\'\n' +
-    '\n' +
-    'using QICore version \'4.1.1\'\n' +
-    '\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.1.000\' called SDE\n' +
-    'include CQMCommon version \'1.0.000\' called CQMCommon \n' +
-    'include FHIRCommon version \'4.1.000\' called FHIRCommon\n' +
-    '\n' +
-    '\n' +
-    'codesystem "SNOMEDCT": \'http://snomed.info/sct\' \n' +
-    'codesystem "ActCode": \'http://terminology.hl7.org/CodeSystem/v3-ActCode\'  \n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'valueset "Care Services in Long-Term Residential Facility": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014\' \n' +
-    'valueset "Diabetic Retinopathy": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327\' \n' +
-    'valueset "Level of Severity of Retinopathy Findings": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283\' \n' +
-    'valueset "Macular Edema Findings Present": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320\' \n' +
-    'valueset "Macular Exam": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251\' \n' +
-    'valueset "Medical Reason": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007\' \n' +
-    'valueset "Nursing Facility Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012\' \n' +
-    'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\' \n' +
-    'valueset "Ophthalmological Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285\' \n' +
-    'valueset "Patient Reason": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008\' \n' +
-    '\n' +
-    'code "Healthcare professional (occupation)": \'223366009\' from "SNOMEDCT" display \'Healthcare professional (occupation)\'\n' +
-    'code "Medical practitioner (occupation)": \'158965000\' from "SNOMEDCT" display \'Medical practitioner (occupation)\'\n' +
-    'code "Ophthalmologist (occupation)": \'422234006\' from "SNOMEDCT" display \'Ophthalmologist (occupation)\'\n' +
-    'code "Optometrist (occupation)": \'28229004\' from "SNOMEDCT" display \'Optometrist (occupation)\'\n' +
-    'code "Physician (occupation)": \'309343006\' from "SNOMEDCT" display \'Physician (occupation)\'\n' +
-    'code "virtual": \'VR\' from "ActCode" display \'virtual\'\n' +
-    'code "Macular edema absent (situation)": \'428341000124108\' from "SNOMEDCT" display \'Macular edema absent (situation)\'\n' +
-    'code "AMB" : \'AMB\' from "ActCode" display \'Ambulatory\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "SDE Ethnicity":\n' +
-    '  SDE."SDE Ethnicity"\n' +
-    '\n' +
-    'define "SDE Payer":\n' +
-    '  SDE."SDE Payer"\n' +
-    '\n' +
-    'define "SDE Race":\n' +
-    '  SDE."SDE Race"\n' +
-    '\n' +
-    'define "SDE Sex":\n' +
-    '  SDE."SDE Sex"\n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    'true\n' +
-    '\n' +
-    'define "Num":\n' +
-    'true\n' +
-    '\n' +
-    'define "Denom":\n' +
-    'true'
-
+let measureCQL = MeasureCQL.zipfileExportQICore
 
 describe('FHIR Measure Export, Not the Owner', () => {
 
@@ -79,14 +21,18 @@ describe('FHIR Measure Export, Not the Owner', () => {
 
     before('Create New Measure and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        //create Measure Group
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '',
-            'Num', '', 'Denom', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'ipp', '', '', 'num', '', 'denom', 'boolean')
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 16500)
+        OktaLogin.Logout()
 
         OktaLogin.AltLogin()
-
     })
 
     it('Validate the zip file Export is downloaded for FHIR Measure', () => {
@@ -101,7 +47,6 @@ describe('FHIR Measure Export, Not the Owner', () => {
         cy.log('Successfully verified zip file export')
 
         OktaLogin.Logout()
-
     })
 
     it('Unzip the downloaded file and verify file types for FHIR Measure', () => {
@@ -113,10 +58,10 @@ describe('FHIR Measure Export, Not the Owner', () => {
             })
 
         //Verify all files exist in exported zip file
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4.zip')).should('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.html')
+        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4.zip'))
+            .should('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.html')
             .and('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.xml')
             .and('contain', 'eCQMTitle4QICore-v0.0.000-FHIR.json')
-
     })
 })
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
@@ -48,68 +48,8 @@ let CQLForCVMeasure = 'library SimpleFhirMeasure version \'0.0.001\'\n' +
     'define function "booleanFunction"():\n' +
     '  true'
 
-// same as zipfileExportQICore
-let measureCQLCardTests = 'library TestLibrary1678378360032 version \'0.0.000\'\n' +
-    '\n' +
-    'using QICore version \'4.1.1\'\n' +
-    '\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.1.000\' called SDE\n' +
-    'include CQMCommon version \'1.0.000\' called CQMCommon \n' +
-    'include FHIRCommon version \'4.1.000\' called FHIRCommon\n' +
-    '\n' +
-    '\n' +
-    'codesystem "SNOMEDCT": \'http://snomed.info/sct\' \n' +
-    'codesystem "ActCode": \'http://terminology.hl7.org/CodeSystem/v3-ActCode\'  \n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'valueset "Care Services in Long-Term Residential Facility": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1014\' \n' +
-    'valueset "Diabetic Retinopathy": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.327\' \n' +
-    'valueset "Level of Severity of Retinopathy Findings": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1283\' \n' +
-    'valueset "Macular Edema Findings Present": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1320\' \n' +
-    'valueset "Macular Exam": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1251\' \n' +
-    'valueset "Medical Reason": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1007\' \n' +
-    'valueset "Nursing Facility Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1012\' \n' +
-    'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\' \n' +
-    'valueset "Ophthalmological Services": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1285\' \n' +
-    'valueset "Patient Reason": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1008\' \n' +
-    '\n' +
-    'code "Healthcare professional (occupation)": \'223366009\' from "SNOMEDCT" display \'Healthcare professional (occupation)\'\n' +
-    'code "Medical practitioner (occupation)": \'158965000\' from "SNOMEDCT" display \'Medical practitioner (occupation)\'\n' +
-    'code "Ophthalmologist (occupation)": \'422234006\' from "SNOMEDCT" display \'Ophthalmologist (occupation)\'\n' +
-    'code "Optometrist (occupation)": \'28229004\' from "SNOMEDCT" display \'Optometrist (occupation)\'\n' +
-    'code "Physician (occupation)": \'309343006\' from "SNOMEDCT" display \'Physician (occupation)\'\n' +
-    'code "virtual": \'VR\' from "ActCode" display \'virtual\'\n' +
-    'code "Macular edema absent (situation)": \'428341000124108\' from "SNOMEDCT" display \'Macular edema absent (situation)\'\n' +
-    'code "AMB" : \'AMB\' from "ActCode" display \'Ambulatory\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
-    'define "SDE Ethnicity":\n' +
-    '  SDE."SDE Ethnicity"\n' +
-    '\n' +
-    'define "SDE Payer":\n' +
-    '  SDE."SDE Payer"\n' +
-    '\n' +
-    'define "SDE Race":\n' +
-    '  SDE."SDE Race"\n' +
-    '\n' +
-    'define "SDE Sex":\n' +
-    '  SDE."SDE Sex"\n' +
-    '\n' +
-    '\n' +
-    '\n' +
-    'define "Initial Population":\n' +
-    'true\n' +
-    '\n' +
-    'define "Num":\n' +
-    'true\n' +
-    '\n' +
-    'define "Denom":\n' +
-    'true'
+let measureCQLCardTests = MeasureCQL.zipfileExportQICore
+
 let dupResourceIDTCJson = '{\n' +
     '  "resourceType": "Bundle",\n' +
     '  "id": "ip-pass-InpatientEncounter",\n' +
@@ -998,7 +938,6 @@ describe('Tests around cardinality violations', () => {
 
     beforeEach('Create New Measure and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLCardTests)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
@@ -1009,8 +948,8 @@ describe('Tests around cardinality violations', () => {
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.Logout()
-        //create Measure Group
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Num', '', 'Initial Population', 'boolean')
+
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'ipp', '', '', 'num', '', 'denom', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, cardInvalidTCJson)
         OktaLogin.Login()
     })


### PR DESCRIPTION
This PR shifts the CQL usage in several tests from local copies (or near copies) to the referenced `MeasureCQL.zipfileExportQICore` for consistency.

Other supporting changes:
- Tests have updated config to adjust for the CQL change e.g. numerator populatiion name `Num` in some tests becomes `num`
- CQL block itself adjusted to reduce lines
- moved Login into `beforeEach` in 1 test
- formatting in many places