### PR TITLE
MAT-8370 measureDefinitions object values on exported HR file

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -187,6 +187,13 @@ export class CreateMeasurePage {
                         "guidance": "this is a meta guidance (usage) value -- for the 'Clinical Usage' field",
                         "description": "SemanticBits",
                         "purpose": "this is a meta purpose value",
+                        "measureDefinitions": [
+                            {
+                                "id": "e764840c-d859-40b2-b701-6f114e5c8bb9",
+                                "term": "ThisIsTheDefinitionTermValue",
+                                "definition": "ThisIsTheDefinitionDefValue"
+                            }
+                        ],
                         "endorsements": [
                             {
                                 "endorser": "CMS Consensus Based Entity",

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
@@ -242,6 +242,10 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
             expect(bodyText).to.include(
                 'Identifier\t3502'
             )
+            //measureDefinitions value
+            expect(bodyText).to.include(
+                'ThisIsTheDefinitionTermValue Definition\tThisIsTheDefinitionDefValue'
+            )
 
             //Measure Population Criteria
             expect(bodyText).to.include('Measure Population Criteria (ID: Group_1)\n' +
@@ -476,6 +480,11 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
 
             //Version Number
             expect(bodyText).to.include('Version Number\t1.0.000')
+
+            //measureDefinitions value
+            expect(bodyText).to.include(
+                'ThisIsTheDefinitionTermValue Definition\tThisIsTheDefinitionDefValue'
+            )
 
             //Measure Population Criteria
             expect(bodyText).to.include('Measure Population Criteria (ID: Group_1)\n' +


### PR DESCRIPTION
This PR contains changes that verifies that values that appear in the measureDefinitions object, on the measure meta fields, now appear on an exported HR file, for Qi Core measures.