### PR TITLE
fix: update test

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/MeasureVersion.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/MeasureVersion.cy.ts
@@ -40,7 +40,6 @@ describe('QDM Measure Versioning', () => {
     beforeEach('Create Measure and Login', () => {
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureOpts)
-       // CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', true, QDMMeasureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
@@ -125,7 +124,6 @@ describe('QDM Measure Version for CMS Measure with huge included Library', () =>
     beforeEach('Create Measure and Login', () => {
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureOpts)
-      //  CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', false, qdmCMSMeasureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Qualifying Encounters')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()

--- a/cypress/e2e/WebInterface/Smoke Tests/MeasureVersion.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/MeasureVersion.cy.ts
@@ -1,6 +1,6 @@
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { TestCaseJson } from "../../../Shared/TestCaseJson"
-import { CreateMeasurePage } from "../../../Shared/CreateMeasurePage"
+import { CreateMeasureOptions, CreateMeasurePage } from "../../../Shared/CreateMeasurePage"
 import { OktaLogin } from "../../../Shared/OktaLogin"
 import { MeasuresPage } from "../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
@@ -8,7 +8,6 @@ import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
 import { MeasureGroupPage, MeasureGroups, MeasureScoring, MeasureType, PopulationBasis } from "../../../Shared/MeasureGroupPage"
 import { TestCasesPage } from "../../../Shared/TestCasesPage"
 import { Utilities } from "../../../Shared/Utilities"
-import {LandingPage} from "../../../Shared/LandingPage";
 import { Header } from "../../../Shared/Header"
 
 let measureName = 'TestMeasure' + Date.now()
@@ -24,14 +23,24 @@ let QiCoreMeasureCQL = MeasureCQL.SBTEST_CQL
 let QiCoreTestCaseJson = TestCaseJson.CohortEpisodeEncounter_PASS
 let qdmCMSMeasureCQL = MeasureCQL.QDM_CQL_withLargeIncludedLibrary
 
+
 describe('QDM Measure Versioning', () => {
 
     newMeasureName = measureName + randValue + 1
     newCQLLibraryName = cqlLibraryName + randValue + 1
 
+    const measureOpts: CreateMeasureOptions = {
+       ecqmTitle: newMeasureName, 
+       cqlLibraryName: newCQLLibraryName, 
+       measureScoring: 'Cohort', 
+       patientBasis: 'true', 
+       measureCql: QDMMeasureCQL
+    }
+
     beforeEach('Create Measure and Login', () => {
 
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', true, QDMMeasureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureOpts)
+       // CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', true, QDMMeasureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
@@ -105,9 +114,18 @@ describe('QDM Measure Version for CMS Measure with huge included Library', () =>
     newMeasureName = measureName + randValue + 2
     newCQLLibraryName = cqlLibraryName + randValue + 2
 
+    const measureOpts: CreateMeasureOptions = {
+        ecqmTitle: newMeasureName, 
+        cqlLibraryName: newCQLLibraryName, 
+        measureScoring: 'Cohort', 
+        patientBasis: 'false', 
+        measureCql: qdmCMSMeasureCQL
+     }
+
     beforeEach('Create Measure and Login', () => {
 
-        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', false, qdmCMSMeasureCQL)
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureOpts)
+      //  CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(newMeasureName, newCQLLibraryName, 'Cohort', false, qdmCMSMeasureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Qualifying Encounters')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()


### PR DESCRIPTION
Found this test was broken by https://github.com/MeasureAuthoringTool/madie-cypress/pull/2027
while working on MAT-8585.
Decided to fix it now, rather than wait.

No real changes, just updating for new object-based parameters.