### PR TITLE
feat: refactor for consolidated versionLibraryAPI function

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -13,6 +13,7 @@ export enum EditLibraryActions {
     share
 }
 
+const filePath = 'cypress/fixtures/cqlLibraryId'
 
 export class CQLLibraryPage {
     public static readonly measureCQLGenericErrorsList = '[data-testid="generic-errors-text-list"]'
@@ -414,6 +415,26 @@ export class CQLLibraryPage {
             .parent('tr')
             .find('input[type="checkbox"]')
             .check()
+    }
+
+    public static versionLibraryAPI(expectedVersionNumber: string) {
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile(filePath).should('exist').then((cqlLibraryId) => {
+                cy.request({
+                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
+                    method: 'PUT',
+                    headers: {
+                        authorization: 'Bearer ' + accessToken.value
+                    }
+
+                }).then((response) => {
+                    expect(response.status).to.eql(200)
+                    expect(response.body.version).to.eql(expectedVersionNumber)
+
+                })
+            })
+        })
     }
 
     public static actionCenter(action: EditLibraryActions): void {

--- a/cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts
@@ -8,6 +8,7 @@ let harpUserALT = Environment.credentials().harpUserALT
 let measureCQLAlt = MeasureCQL.ICFCleanTestQICore
 let harpUser = Environment.credentials().harpUser
 const adminApiKey = Environment.credentials().adminApiKey
+const versionNumber = '1.0.000'
 
 describe('Delete CQL Library: Tests covering Libraries that are in draft and versioned states as well as when user is the owner, when user has had Library transferred to them, and when the user is neither the owner nor has had the Library transferred to them', () => {
 
@@ -106,23 +107,8 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookie()
-            cy.getCookie('accessToken').then((accessToken) => {
-                cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                    cy.request({
-                        url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                        method: 'PUT',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        }
+            CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql("1.0.000")
-
-                    })
-
-                })
-            })
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookieALT()
@@ -146,23 +132,8 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookie()
-            cy.getCookie('accessToken').then((accessToken) => {
-                cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                    cy.request({
-                        url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                        method: 'PUT',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        }
+           CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql("1.0.000")
-
-                    })
-
-                })
-            })
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookie()
@@ -204,23 +175,8 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
                 cy.clearAllCookies()
                 cy.clearLocalStorage()
                 cy.setAccessTokenCookieALT()
-                cy.getCookie('accessToken').then((accessToken) => {
-                    cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                        cy.request({
-                            url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                            method: 'PUT',
-                            headers: {
-                                authorization: 'Bearer ' + accessToken.value
-                            }
+               CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                        }).then((response) => {
-                            expect(response.status).to.eql(200)
-                            expect(response.body.version).to.eql("1.0.000")
-
-                        })
-
-                    })
-                })
                 cy.clearAllCookies()
                 cy.clearLocalStorage()
                 cy.setAccessTokenCookieALT()
@@ -246,22 +202,8 @@ describe('Delete CQL Library: Tests covering Libraries that are in draft and ver
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookie()
-            cy.getCookie('accessToken').then((accessToken) => {
-                cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                    cy.request({
-                        url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                        method: 'PUT',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        }
+            CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql("1.0.000")
-
-                    })
-                })
-            })
             //Draft Versioned Library
             cy.getCookie('accessToken').then((accessToken) => {
                 cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {

--- a/cypress/e2e/Services/CQL Library Service/VersionAndDraftCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/VersionAndDraftCQL-Library.cy.ts
@@ -5,10 +5,11 @@ import { v4 as uuidv4 } from 'uuid'
 let CqlLibraryOne = ''
 let CqlLibraryTwo = ''
 let updatedCqlLibraryName = 'UpdatedTestLibrary' + Date.now()
-let harpUser = Environment.credentials().harpUser
-let harpUserALT = Environment.credentials().harpUserALT
-let model = 'QI-Core v4.1.1'
-let CQLLibraryPublisher = 'SemanticBits'
+const harpUser = Environment.credentials().harpUser
+const harpUserALT = Environment.credentials().harpUserALT
+const model = 'QI-Core v4.1.1'
+const CQLLibraryPublisher = 'SemanticBits'
+const versionNumber = '1.0.000'
 
 describe('Version and Draft CQL Library', () => {
 
@@ -31,23 +32,7 @@ describe('Version and Draft CQL Library', () => {
 
     it('Add Version to the CQL Library', () => {
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
     })
 
     it('User can not draft CQL Library if the CQL Library naming validations fail', () => {
@@ -165,23 +150,7 @@ describe('Draft and Version Validations', () => {
     it('Verify the CQL Library updates are restricted after Version is created', () => {
 
         //Add Version to the CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
         //Edit Library Name after versioned
         cy.getCookie('accessToken').then((accessToken) => {
@@ -210,23 +179,8 @@ describe('Draft and Version Validations', () => {
 
     it('Elm data is generated on the fly per GET versioned library request', () => {
         //Add Version to the CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //hit the cql-library-service versioned end point and validate that elm data is returned / generated
         cy.getCookie('accessToken').then((accessToken) => {
             cy.request({
@@ -246,8 +200,6 @@ describe('Draft and Version Validations', () => {
 })
 
 describe('Version CQL Library without CQL', () => {
-
-    let CQLLibraryPublisher = 'SemanticBits'
 
     before('Set Access Token and create CQL Library', () => {
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibraryUnsharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibraryUnsharing.cy.ts
@@ -114,24 +114,10 @@ describe('Un Share CQL Library using Action Center buttons - Multiple instances'
 
     it('Verify all instances of the CQL Library (Version and Draft) are shared to the user', () => {
 
+        const versionNumber = '1.0.000'
         //Version CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Draft Library
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {

--- a/cypress/e2e/WebInterface/CQL Library/DeleteCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/DeleteCQLLibraryValidations.cy.ts
@@ -1,18 +1,19 @@
-import {CQLLibraryPage, EditLibraryActions} from "../../../Shared/CQLLibraryPage"
+import { CQLLibraryPage, EditLibraryActions } from "../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 import { Environment } from "../../../Shared/Environment"
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { Header } from "../../../Shared/Header"
-import {MadieObject, PermissionActions, Utilities} from "../../../Shared/Utilities"
+import { MadieObject, PermissionActions, Utilities } from "../../../Shared/Utilities"
 import { OktaLogin } from "../../../Shared/OktaLogin"
 import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
 
-let filePath = 'cypress/fixtures/cqlLibraryId'
 let CQLLibraryName = ''
-let CQLLibraryPublisher = 'SemanticBits'
-let harpUserALT = Environment.credentials().harpUserALT
-let measureCQLAlt = MeasureCQL.ICFCleanTestQICore
+const CQLLibraryPublisher = 'SemanticBits'
+const harpUserALT = Environment.credentials().harpUserALT
+const measureCQLAlt = MeasureCQL.ICFCleanTestQICore
 const adminApiKey = Environment.credentials().adminApiKey
+const versionNumber = '1.0.000'
+const filePath = 'cypress/fixtures/cqlLibraryId'
 
 describe('Delete CQL Library Validations - Library List page', () => {
 
@@ -98,23 +99,8 @@ describe('Delete CQL Library Validations - Library List page', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Login as Regular User
         cy.clearCookies()
         cy.clearLocalStorage()
@@ -130,23 +116,8 @@ describe('Delete CQL Library Validations - Library List page', () => {
     it('Delete CQL Library - Versioned Library - user has had the Library transferred to them', () => {
         //Version Library
         cy.setAccessTokenCookie()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Transfer Library to ALT User
         cy.clearCookies()
         cy.clearLocalStorage()
@@ -179,23 +150,8 @@ describe('Delete CQL Library Validations - Library List page', () => {
     it('Delete CQL Library - Versioned Library - user has had the Library shared with them', () => {
         //Version Library
         cy.setAccessTokenCookie()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Share Library with ALT User
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
         //Login as ALT User
@@ -295,23 +251,8 @@ describe('Delete CQL Library Validations - Edit Library page', () => {
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Login as Regular User
         cy.clearCookies()
         cy.clearLocalStorage()
@@ -327,23 +268,8 @@ describe('Delete CQL Library Validations - Edit Library page', () => {
     it('Delete CQL Library - Versioned Library - user has had the Library transferred to them', () => {
         //Version Library
         cy.setAccessTokenCookie()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Transfer Library to ALT User
         cy.clearCookies()
         cy.clearLocalStorage()
@@ -375,23 +301,8 @@ describe('Delete CQL Library Validations - Edit Library page', () => {
     it('Delete CQL Library - Versioned Library - user has had the Library shared with them', () => {
         //Version Library
         cy.setAccessTokenCookie()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql("1.0.000")
-
-                })
-
-            })
-        })
         //Share Library with ALT User
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
         //Login as ALT User

--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
@@ -11,32 +11,13 @@ const versionNumber = '1.0.000'
 const filePath = 'cypress/fixtures/cqlLibraryId'
 const filePath2 = 'cypress/fixtures/cqlLibraryId2'
 
-
-
-
 describe('Action Center Buttons - Add Draft to CQL Library', () => {
 
     beforeEach('Create CQL Library and Login', () => {
 
         CqlLibraryOne = 'DraftingLibrary' + Date.now()
         CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(filePath).should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql(versionNumber)
-
-                })
-            })
-        })
+        CQLLibraryPage.versionLibraryAPI(versionNumber)
     })
 
     afterEach('Logout', () => {
@@ -44,14 +25,11 @@ describe('Action Center Buttons - Add Draft to CQL Library', () => {
         OktaLogin.Logout()
     })
 
+    // just this 1st test has been prepped for when FF LibrarySearch = true, see references to MAT-5119
+    // as of right now, this version should fail in DEV but pass in TEST
     it('Add Draft to the versioned Library from My Libraries', () => {
 
         //Add Draft to Versioned Library
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.clearAllSessionStorage({ log: true })
-
-        cy.setAccessTokenCookie()
         OktaLogin.Login()
         cy.get(Header.cqlLibraryTab).click()
         CQLLibrariesPage.cqlLibraryActionCenter('draft')


### PR DESCRIPTION
Added function `versionLibraryAPI()` and updated all tests possible that used the raw version of the API call to instead use the function call.

Remaining uses of the raw call are for error cases & do not fit the standard success use-case.