### PR TITLE
Regression test failure fix: Webinterface tests: CreateCQLLibraryValidations test file

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -164,7 +164,6 @@ export class CQLEditorPage {
 
     public static validateSuccessfulCQLUpdate(): void {
 
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 60000)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).each($msg => {
             expect($msg).to.not.contain('Error')
             cy.wrap($msg)


### PR DESCRIPTION
This PR contains a change in the support file, CQLEditorPage, to resolve a failure that was being seen in the CreateCQLLibraryValidations test file.