### PR TITLE
fix: scoping issue

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
@@ -17,10 +17,9 @@ let measureScoring = 'Cohort'
 let booleanPatientBasisQDM_CQL = MeasureCQL.returnBooleanPatientBasedQDM_CQL
 let simpleQDMMeasureCQL = MeasureCQL.simpleQDM_CQL
 
-const measureData: CreateMeasureOptions = {}
-
 describe('Validate QDM Population Criteria section -- scoring and populations', () => {
 
+    const measureData: CreateMeasureOptions = {}
     let randValue = (Math.floor((Math.random() * 1000) + 1))
     newMeasureName = measureName + randValue
     newCqlLibraryName = CqlLibraryName + randValue
@@ -330,6 +329,8 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
 })
 
 describe('No values in QDM PC fields, when no CQL', () => {
+    
+    const measureData: CreateMeasureOptions = {}
     let randValue = (Math.floor((Math.random() * 1000) + 1))
     newMeasureName = measureName + randValue
     newCqlLibraryName = CqlLibraryName + randValue
@@ -376,6 +377,8 @@ describe('No values in QDM PC fields, when no CQL', () => {
 })
 
 describe('Save Population Criteria on QDM measure', () => {
+    
+    const measureData: CreateMeasureOptions = {}
     let randValue = (Math.floor((Math.random() * 1000) + 1))
     newMeasureName = measureName + randValue
     newCqlLibraryName = CqlLibraryName + randValue
@@ -438,6 +441,7 @@ describe('Save Population Criteria on QDM measure', () => {
 
 describe('Validations: Population Criteria: Return Types -- Boolean', () => {
 
+    const measureData: CreateMeasureOptions = {}
     let randValue = (Math.floor((Math.random() * 1000) + 1))
     newMeasureName = measureName + randValue
     newCqlLibraryName = CqlLibraryName + randValue
@@ -503,6 +507,7 @@ describe('Validations: Population Criteria: Return Types -- Boolean', () => {
 
 describe('Validations: Population Criteria: Return Types -- Non-Boolean', () => {
 
+    const measureData: CreateMeasureOptions = {}
     let randValue = (Math.floor((Math.random() * 1000) + 1))
     newMeasureName = measureName + randValue
     newCqlLibraryName = CqlLibraryName + randValue


### PR DESCRIPTION
This should fix QDMPopulationCriteriaPage.cy.ts

I believe the previous version (before this PR) has some config values intended for 1 test scenario bleed into other scenarios.
Since the empty object {} was declared at the highest level, it was not being destroyed & recreated between scenarios.

The new version in this PR creates a brand new config object for each `describe` block & should eliminate this issue.