### PR TITLE
fix: change final assertions

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMRemoveValueSetVersion.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMRemoveValueSetVersion.cy.ts
@@ -46,8 +46,8 @@ describe('Validating that the valueset version is removed and message appears, o
         OktaLogin.Logout()
 
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-
     })
+
     it('Valueset version removed and user is informed', () => {
 
         OktaLogin.Login()
@@ -62,8 +62,8 @@ describe('Validating that the valueset version is removed and message appears, o
         cy.get(CQLEditorPage.saveAlertMessage).find('[class="madie-alert success"]').find(TestCasesPage.importTestCaseSuccessInfo).find('[data-testid="library-warning"]').should('contain.text', 'MADiE does not currently support use of value set version directly in measures at this time. Your value set versions have been removed. Please use the relevant manifest for value set expansion for testing.')
 
         //confirm that the CQL does not include the version
-        cy.get(EditMeasurePage.cqlEditorTextBox).should('include.text', 'library ' + CqlLibraryName + ' version \'0.0.000\'using QDM version \'5.6\'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Globalinclude TJCOverallQDM version \'8.0.000\' called TJCvalueset "Antithrombotic Therapy for Ischemic Stroke": \'urn:oid:2.16.840.1.113762.1.4    .1110.62\'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'valueset "Medical Reason For Not Providing Treatment": \'urn:oid:2.16.840.1.113883.3    .117.1.7.1.473\'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'valueset "Patient Refusal": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.93\'valueset "Adolescent depression screening assessment with version": \'urn:oid:2.16.840    .1.113762.1.4.1260.162\'valueset "Payer Type": \'urn:oid:2.16.840.1.114222.4.11.3591\'valueset "Pharmacological Contraindications For Antithrombotic Therapy": \'urn:oid:2.16    .840.1.113762.1.4.1110.52\'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'context Patientdefine "SDE Ethnicity":  ["Patient Characteristic Ethnicity": "Ethnicity"]define "SDE Payer":  ["Patient Characteristic Payer": "Payer Type"]define "SDE Race":  ["Patient Characteristic Race": "Race"]define "SDE Sex":  ["Patient Characteristic Sex": "ONC Administrative Sex"]define "Denominator Exclusions":  TJC."Ischemic Stroke Encounters with Discharge Disposition"    union TJC."Encounter with Comfort Measures during Hospitalization"define "Encounter with Pharmacological Contraindications for Antithrombotic Therapy at     Discharge":  TJC."Ischemic Stroke Encounter" IschemicStrokeEncounter    with ["Medication, Discharge": "Pharmacological Contraindications For         Antithrombotic Therapy"] Pharmacological\'')
-
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('include.text', 'Adolescent depression screening assessment with version')
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('not.include.text',  'version \'urn:hl7:version:20240307\'')
     })
 
 })


### PR DESCRIPTION
Fixes QDMRemoveValueSetVersion.cy.ts

This PR removes a validation of the whole CQL document, which is very difficult to maintain.
It replaces it with 2 very targeted assertions:
- does the CQL contain the name of the valueset added (Yes)
- does the CQL contain the specific version of said valueset (No)