### PR TITLE
Regression failure fixes: Webinterface tests: TestCaseImportValidations test file

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -236,11 +236,12 @@ describe('Test Case Import validations for versioned Measures', () => {
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        OktaLogin.UILogout()
-        OktaLogin.Login()
     })
 
     it('Measure is in VERSIONED status: user is owner: import button is not available', () => {
+
+        //navigate to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Version Measure
         MeasuresPage.actionCenter('version')
@@ -270,6 +271,9 @@ describe('Test Case Import validations for versioned Measures', () => {
     })
 
     it('Measure is in VERSIONED status: measure has been shared with user: import button is not available', () => {
+
+        //navigate to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Version Measure
         MeasuresPage.actionCenter('version')
@@ -347,9 +351,7 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        OktaLogin.UILogout()
 
-        OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -360,6 +362,9 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
     })
 
     it('Importing: not a .zip file', () => {
+
+        //navigate to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -382,6 +387,9 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
     })
 
     it('Importing: .zip\'s test case folder does not contain a json file', () => {
+
+        //navigate to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -408,6 +416,9 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
 
     it('Importing: .zip\'s test case folder contains multiple json files', () => {
 
+        //navigate to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
+
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -432,6 +443,9 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
     })
 
     it('Importing: .zip\'s test case folder contains malformed json file', () => {
+
+        //navigate to the main MADiE / measure list page
+        cy.get(Header.mainMadiePageButton).click()
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -49,6 +49,15 @@ describe('Test Case Import: functionality tests', () => {
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJsonLizzy)
         TestCasesPage.CreateTestCaseAPI(secondTestCaseTitle, secondTestCaseSeries, secondTestCaseDescription, validTestCaseJsonBobby, false, true)
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout()
 
         cy.clearCookies()
         cy.clearLocalStorage()
@@ -220,6 +229,15 @@ describe('Test Case Import validations for versioned Measures', () => {
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJsonLizzy)
         TestCasesPage.CreateTestCaseAPI(secondTestCaseTitle, secondTestCaseSeries, secondTestCaseDescription, validTestCaseJsonBobby, false, true)
         OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout()
+        OktaLogin.Login()
     })
 
     it('Measure is in VERSIONED status: user is owner: import button is not available', () => {
@@ -321,6 +339,15 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
         MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJsonLizzy)
         TestCasesPage.CreateTestCaseAPI(secondTestCaseTitle, secondTestCaseSeries, secondTestCaseDescription, validTestCaseJsonBobby, false, true)
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout()
 
         OktaLogin.Login()
     })
@@ -440,6 +467,15 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
 
         CreateMeasurePage.CreateQICoreMeasureAPI(firstMeasureName, updatedCQLLibraryName, measureCQLPFTests)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout()
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -556,6 +592,15 @@ describe('Test case uniqueness error validation', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(firstMeasureName, updatedCQLLibraryName, measureCQLPFTests)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout()
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -673,6 +718,15 @@ describe('Test Case Import: New Test cases on measure validations: PC does not m
 
         CreateMeasurePage.CreateQICoreMeasureAPI(firstMeasureName, updatedCQLLibraryName, measureCQLPFTests)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        OktaLogin.UILogout()
     })
 
     afterEach('Logout and Clean up Measures', () => {


### PR DESCRIPTION
This PR updates / makes changes to the TestCaseImportValidations regression test file to resolve the failure seen during last regression test suite execution.