### PR TITLE
fix: handle prod test data update

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportValidations.cy.ts
@@ -355,14 +355,13 @@ describe('Error Message on Measure Export for Publish when measure was versioned
 
         // navigate to the all measures tab
         Utilities.waitForElementVisible(LandingPage.allMeasuresTab, 30000)
-        cy.get(LandingPage.allMeasuresTab).should('be.visible')
-        Utilities.waitForElementEnabled(LandingPage.allMeasuresTab, 30000)
-        cy.get(LandingPage.allMeasuresTab).should('be.enabled')
         cy.get(LandingPage.allMeasuresTab).click()
 
-        // search for specific measure - it should be 1st on the search result
+        Utilities.waitForElementVisible('.measures-list', 15500)
+
+        // search for specific measure - last on the list
         cy.get(MeasuresPage.searchInputBox).clear().type(specialMeasureName).type('{enter}')
-        cy.contains('View').click()
+        cy.get('[data-testid="row-item"]').last().contains('View').click()
 
         // perform export for publish
         cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()


### PR DESCRIPTION
Fixes MeasureExportValidations.cy.ts

This update resolves a failure stemming from PROD data being updated.
In the old version of the test, after the search action there was only 1 measure showing.
After the data update, now there are multiple.

This PR changes the selection from the 1st measure shown to the last measure shown.
It should remain correct (and the test passing) until this measure paginates.