### PR TITLE
feat: add new step to capture and check api call

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMRAVSubTabValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMRAVSubTabValidations.cy.ts
@@ -67,7 +67,6 @@ describe('QDM Test Cases : RAV Sub tab validations', () => {
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).find('[aria-label="option Denominator not selected"]').click()
         cy.get(MeasureGroupPage.riskAdjustmentDefinitionDropdown).find('[aria-label="option Initial Population not selected"]').click()
 
-
         //Save RAV data
         cy.get(MeasureGroupPage.saveRiskAdjustments).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure Risk Adjustments have been Saved Successfully')
@@ -99,14 +98,29 @@ describe('QDM Test Cases : RAV Sub tab validations', () => {
         cy.get(TestCasesPage.saveRAVOption).should('be.disabled')
         cy.get(TestCasesPage.discardRavChangesOption).should('be.disabled')
 
+        cy.intercept('**/cqmmeasure').as('cqm')
+
+        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        //return to test case list page
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        // rav's declared here will match selections from MeasureGroupPage.leftPanelRiskAdjustmentTab
+        cy.wait('@cqm').then(cqmMeasure => {
+            const body = cqmMeasure.response.body.population_sets[0]
+            expect(body.risk_adjustment_variables.length).eq(2)
+            // no guarantee - but seems like statement_name sorts by alphatical order
+            expect(body.risk_adjustment_variables[0].statement_name).eq('Denominator')
+            expect(body.risk_adjustment_variables[1].statement_name).eq('Initial Population')
+        })
 
     /*  
         this is all from the SDESubTabValidations test
         everything below will be useful after https://jira.cms.gov/browse/MAT-8630    
 
         //Add Elements to the test case
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
         //Navigate to Edit Test Case page
         TestCasesPage.clickEditforCreatedTestCase()
 


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-8690
https://jira.cms.gov/browse/MAT-8691

This adds 1 more step to the existing sequence on QDMRAVSubTabValidations.cy.ts
It is still not a complete e2e of the feature, but this moves us 1 step closer.

Adds an intercept & checks for data of the populations declared earlier in the test to be affected by RAV.