### PR TITLE
Regression failure fixes: Webinterface tests: QDMTestCaseCreation test file

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseCreation.cy.ts
@@ -463,7 +463,8 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.executeTestCaseButton).click()
 
         //verify the results row
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '1PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate + 'Edit')
+        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '1PassQDMManifestTCGroupQDMManifestTCQDMManifestTC')
+            .should('contain.text', '(UTC)Edit')
 
         //navigate to the test case list Expansion page
         cy.get(TestCasesPage.qdmExpansionSubTab).click()
@@ -497,7 +498,8 @@ describe('Validating Expansion -> Manifest selections / navigation functionality
         cy.get(TestCasesPage.executeTestCaseButton).click()
 
         //verify the results row
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '1FailQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate + 'Edit')
+        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '1FailQDMManifestTCGroupQDMManifestTCQDMManifestTC')
+            .should('contain.text', '(UTC)Edit')
     })
 
 })


### PR DESCRIPTION
This PR contains the necessary update to resolve the failure that was seen with the QDMTestCaseCreation regression test file, during last regression test suite execution.