### PR TITLE
feat: add tests for minimize alerts on measures

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -18,6 +18,12 @@ export class CQLEditorPage {
     //error tooltip container
     public static readonly errorContainer = '#ace-editor-wrapper > div.ace_tooltip'
     public static readonly errorMsg = '[data-testid="generic-errors-text-list"]'
+    public static readonly warningMsg = '[data-testid="generic-warnings-text-list"]'
+    public static readonly minimizeButton = '[data-testid="minimize-button-0"]'
+    public static readonly greenMessageBox = '.madie-alert.success'
+    public static readonly orangeWarningBox = '[data-testid="generic-warning-text-header"]'
+
+    public static readonly minimizedAlertsTab = '[data-testid="minimized-alert"]'
 
     //success save message without errors
     public static readonly successfulCQLSaveNoErrors = '.madie-alert'

--- a/cypress/Shared/FHIRMeasuresCQL.ts
+++ b/cypress/Shared/FHIRMeasuresCQL.ts
@@ -843,6 +843,21 @@ public static readonly ICFCleanTestQICore = 'library SimpleFhirLibrary version \
     '        union ["Encounter": "Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal."]\n' +
     '        ) ValidEncounters\n' +
     '        where QICoreCommon."ToInterval"(ValidEncounters.period) during day of "Measurement Period"'
+
+    public static intentionalErrorCql = 'library TestLibrary16969620425371870 version \'0.0.000\'\n\n' +
+    'using QICore version \'4.1.1\'\n\n' +
+    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
+    'include CQMCommon version \'1.0.000\' called CQMCommon\n' +
+    'include SupplementalDataElements version \'3.1.000\' called SDE\n' +
+    'include QICoreCommon version \'1.2.000\' called QICoreCommon\n' +
+    'include Hospice version \'6.1.000\' called Hospice\n' +
+    'include Status version \'1.1.000\' called Status\n\n' +
+    'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n\n' +
+    'codesystem "CPT": \'http://www.ama-assn.org/go/cpt\'\n\n' +
+    'code "Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal.": \'99211\' from "CPT" display \'Office or other outpatient visit for the evaluation and management of an established patient, that may not require the presence of a physician or other qualified health care professional. Usually, the presenting problem(s) are minimal.\'\n\n' +
+    'parameter "Measurement Period" Interval<DateTime>\n\n' +
+    'context Patient\n\n' +
+    'define "IP":'
 }
 
 export class QiCore6Cql {

--- a/cypress/e2e/WebInterface/Measure/MinimizeAlerts.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MinimizeAlerts.cy.ts
@@ -1,0 +1,150 @@
+import { CreateMeasurePage, SupportedModels } from "../../../Shared/CreateMeasurePage"
+import { OktaLogin } from "../../../Shared/OktaLogin"
+import { Utilities } from "../../../Shared/Utilities"
+import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
+import { MeasuresPage } from "../../../Shared/MeasuresPage"
+import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
+import { QiCore4Cql } from "../../../Shared/FHIRMeasuresCQL"
+
+const now = Date.now()
+const measureName = 'MinimizeAlerts' + now
+const CqlLibraryName = 'MinimizeAlertsLib' + now
+const errorCql = QiCore4Cql.intentionalErrorCql.replace('TestLibrary16969620425371870', CqlLibraryName)
+
+describe('Minimize Alerts - Measure with a CQL error', () => {
+
+    beforeEach('Create Measure and Login', () => {
+
+        CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore4, {measureCql: errorCql})
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+
+        //Save CQL
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 25000)
+    })
+
+    afterEach('Clean up and Logout', () => {
+
+        OktaLogin.Logout()
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+    })
+
+    it('On CQL Editor, user can minimize and then maximize the error list', () => {
+
+        // CQL save successful, orange box shows with 1 issue
+        cy.get(CQLEditorPage.orangeWarningBox).should('have.length', 1)
+
+        cy.get(CQLEditorPage.minimizeButton).click()
+
+        // Orange box is gone, alerts tab shows on right side
+        cy.get(CQLEditorPage.orangeWarningBox).should('not.exist')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
+
+        // Click on the Alerts tab
+        cy.get(CQLEditorPage.minimizedAlertsTab).click()
+
+        // Alerts tab is gone, orange box shows again
+        cy.get(CQLEditorPage.orangeWarningBox).should('be.visible')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('not.exist')
+    })
+
+    it('On CQL Editor, after minimzing errors and navigating away; when user returns, the original error list shows', () => {
+    
+        // CQL save successful, orange box shows with 1 issue
+        cy.get(CQLEditorPage.orangeWarningBox).should('have.length', 1)
+
+        cy.get(CQLEditorPage.minimizeButton).click()
+
+        // Orange box is gone, alerts tab shows on right side
+        cy.get(CQLEditorPage.orangeWarningBox).should('not.exist')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
+
+        // nav away - go to details tab
+        cy.get(EditMeasurePage.measureDetailsTab).click()
+        cy.wait(500)
+
+        // come back to cql editor
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+
+        // Alerts tab is gone, main box now shows as red
+        cy.get(CQLEditorPage.errorMsg).should('be.visible')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('not.exist')
+    })
+
+    it('On Populations page, user can minimize and then maximize the error list', () => {
+
+        // verify error box
+        cy.get(CQLEditorPage.errorMsg).should('have.length', 1)
+
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+            // click minimize
+        cy.get(CQLEditorPage.minimizeButton).click()
+        cy.wait(2500) // change to wait for alert to disappear
+
+        // verify box gone & label shows on right side
+        cy.get('[data-testid="error-alerts"]').should('not.exist')
+        cy.get('[data-testid="minimized-alert"]').should('be.visible')
+
+        // click label
+        cy.contains('Display Alerts').click()
+        cy.wait(2500)
+
+        // verify label gone & error box re-appears
+        cy.get('[data-testid="error-alerts"]').should('be.visible') 
+            .and('have.text', 'Please complete the CQL Editor process before continuing')
+        cy.get('[data-testid="minimized-alert"]').should('not.exist')
+
+        cy.wait(2500)
+    })
+})
+
+describe('Minimize Alerts - Non-owner can also minimize to review the measure', () => {
+
+    beforeEach('Create Measure and Login', () => {
+
+        CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore4, {measureCql: errorCql})
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+
+        //Save CQL
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 18500)
+        OktaLogin.Logout()
+
+        OktaLogin.AltLogin()
+        cy.get(MeasuresPage.allMeasuresTab).click()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+    })
+
+    afterEach('Clean up and Logout', () => {
+
+        OktaLogin.Logout()
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+    })
+
+    it('Verify Non Measure owner can perform minimize action', () => {
+
+        // CQL save successful, red box shows with 1 issue
+        cy.get(CQLEditorPage.errorMsg).should('have.length', 1)
+
+        cy.get(CQLEditorPage.minimizeButton).click()
+
+        // Red box is gone, alerts tab shows on right side
+        cy.get(CQLEditorPage.errorMsg).should('not.exist')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
+
+        // Click on the Alerts tab
+        cy.get(CQLEditorPage.minimizedAlertsTab).click()
+
+        // Alerts tab is gone, red box shows again
+        cy.get(CQLEditorPage.errorMsg).should('be.visible')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('not.exist')
+    })
+})


### PR DESCRIPTION
e2e ticket: https://jira.cms.gov/browse/MAT-8417

Added new tests for feature "Minimize Alerts" scoped to Measures.
Coverage focuses on CQL editor and measure groups tab.

I will have another PR (or 2) next week for coverage of CQL Libraries and test cases.