### PR TITLE
fix: return tests to passing for regression

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -50,7 +50,7 @@ export class MeasureGroupPage {
     public static readonly QDMPopulationCriteria1 = '[data-testid="leftPanelMeasureInformation-MeasureGroup1"]'
     public static readonly QDMPopulationCriteria2 = '[data-testid="leftPanelMeasureInformation-MeasureGroup2"]'
     //when the "EnhancedTextFormatting" flag has been removed, switch this variable to point to the commented out value
-    public static readonly QDMPopCriteria1Desc = /*'[data-testid="population-criteria-1-description-rich-text-editor"]'*/'[data-testid="groupDescriptionInput"]'
+    public static readonly QDMPopCriteria1Desc = /*'[data-testid="population-criteria-1-description-rich-text-editor"]'*/'[data-testid="group-description-text"]'
     public static readonly QDMPopCriteria2IP = '[id="population-select-initial-population-select"]'
     public static readonly QDMPopCriteria1IPDesc = '[data-testid="populations[0].description-description"]'
     public static readonly QDMAddPopCriteriaBtn = '[data-testid="add-measure-group-button"]'

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -125,9 +125,8 @@ describe('Test Case Import: functionality tests', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
-        Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 9500)
-
-        cy.get(TestCasesPage.successMsg).should('have.text', 'Test case updated successfully with warnings in JSONMADiE only supports a timezone offset of 0. MADiE has overwritten any timezone offsets that are not zero.')
+        cy.get(TestCasesPage.successMsg).should('have.text', 'Test case updated successfully with warnings in JSONMADiE enforces a UTC (offset 0) timestamp format with mandatory millisecond precision. All timestamps with non-zero offsets have been overwritten to UTC, and missing milliseconds have been defaulted to \'000\'.')
+        Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
 
         OktaLogin.UILogout()
 
@@ -545,7 +544,7 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         cy.get(EditMeasurePage.testCasesTab).click()
 
         //export test case
-        cy.get(TestCasesPage.testCaseListTable).find('[class="TestCaseTable___StyledThead-sc-1faw1su-0 dGIzIy"]').find('[class="header-button"]').eq(0).scrollIntoView().click()
+        cy.get(TestCasesPage.testCaseListTable).find('[class="TestCaseTable___StyledThead-sc-1faw1su-0 dGIzIy"]').find('[class="header-button"]').eq(0).click()
         cy.get(TestCasesPage.testcaseQRDAExportBtn).click()
         Utilities.waitForElementVisible(TestCasesPage.exportCollectionTypeOption, 35000)
         cy.get(TestCasesPage.exportCollectionTypeOption).scrollIntoView().click({ force: true })


### PR DESCRIPTION
Fixes TestCaseImportValidations.cy.ts

1. Update selector
2. Update toast message for TZ offset after ms change
3. Remove scroll action