### PR TITLE
fix: add waits and selector change

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -314,7 +314,7 @@ export class TestCasesPage {
     public static readonly tcImportError = '[data-testid="test-case-import-error-div"]'
     public static readonly testCasesNonBonnieFileImportModal = '[data-testid="test-case-import-content-div"]'
     public static readonly testCasesNonBonnieFileImportFileLineAfterSelectingFile = '[data-testid="test-case-preview-header"]'
-    public static readonly importTestCaseSuccessMsg = '[data-testid="toast-success"]'
+    public static readonly importTestCaseSuccessMsg = '[data-testid="success-toast"]'
     public static readonly importTestCaseSuccessInfo = '[id="content"]'
 
     //Export Test Cases

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/EditTestCaseImportToEditor.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/EditTestCaseImportToEditor.cy.ts
@@ -16,11 +16,9 @@ describe('Import Test Case into the Test Case Editor', () => {
 
     beforeEach('Create Measure, Test case and Login', () => {
 
-        //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries)
         OktaLogin.Login()
-
     })
 
     afterEach('Clean up and Logout', () => {
@@ -30,7 +28,7 @@ describe('Import Test Case into the Test Case Editor', () => {
     })
 
     it('Successful Json file Import', () => {
-
+        const importTestCaseSuccessMsg = '[data-testid="success-toast"]'
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
 
@@ -40,11 +38,11 @@ describe('Import Test Case into the Test Case Editor', () => {
 
         //Upload valid Json file
         cy.get(TestCasesPage.testCaseFileImport).attachFile(fileToUpload)
-        cy.get(TestCasesPage.importTestCaseSuccessMsg).should('contain.text', 'Test Case JSON copied into editor. QI-Core Defaults have been added. Please review and save your Test Case.')
+        Utilities.waitForElementVisible(importTestCaseSuccessMsg, 15500)
+        cy.get(importTestCaseSuccessMsg).should('contain.text', 'Test Case JSON copied into editor. QI-Core Defaults have been added. Please review and save your Test Case.')
 
         //Save uploaded Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-
     })
 
     it('Verify error message when a Text file is imported', () => {
@@ -58,10 +56,9 @@ describe('Import Test Case into the Test Case Editor', () => {
 
         //Upload Text file
         cy.get(TestCasesPage.testCaseFileImport).attachFile('GenericCQLBoolean.txt')
-        cy.get(TestCasesPage.errorToastMsg).should('contain.text', 'An error occurred while reading the file. Please make sure the test case file is valid.')
+        cy.get(TestCasesPage.errorToastMsg, {timeout: 15500}).should('contain.text', 'An error occurred while importing the test case, please try again. If the error persists, please contact the help desk.')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-
     })
 
     it('Verify error message when an invalid Json file is imported', () => {
@@ -80,7 +77,6 @@ describe('Import Test Case into the Test Case Editor', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
     })
-
 
     it('Verify error message when bulk Json file is imported', () => {
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/EditTestCaseImportToEditor.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/EditTestCaseImportToEditor.cy.ts
@@ -28,7 +28,6 @@ describe('Import Test Case into the Test Case Editor', () => {
     })
 
     it('Successful Json file Import', () => {
-        const importTestCaseSuccessMsg = '[data-testid="success-toast"]'
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
 
@@ -38,8 +37,8 @@ describe('Import Test Case into the Test Case Editor', () => {
 
         //Upload valid Json file
         cy.get(TestCasesPage.testCaseFileImport).attachFile(fileToUpload)
-        Utilities.waitForElementVisible(importTestCaseSuccessMsg, 15500)
-        cy.get(importTestCaseSuccessMsg).should('contain.text', 'Test Case JSON copied into editor. QI-Core Defaults have been added. Please review and save your Test Case.')
+        Utilities.waitForElementVisible(TestCasesPage.importTestCaseSuccessMsg, 15500)
+        cy.get(TestCasesPage.importTestCaseSuccessMsg).should('contain.text', 'Test Case JSON copied into editor. QI-Core Defaults have been added. Please review and save your Test Case.')
 
         //Save uploaded Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()


### PR DESCRIPTION
Add waits/timeouts to allow for toasts to fire.

Restored selector `importTestCaseSuccessMsg` to an older value. Last update to it shouldn't have been done, the selector changed in specific circumstances, not in all uses.