### PR TITLE
fix: fixes for 2 tests

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -117,7 +117,7 @@ export class MeasureGroupPage {
     public static readonly keepGroupModalbtn = '[data-testid="delete-measure-group-modal-cancel-btn"]'
     public static readonly deleteMeasureGroupConfirmationMsg = '.MuiDialogContent-root > div'
     //Reporting tab fields
-    public static readonly rateAggregation = '[data-testid="rateAggregationText"]'
+    public static readonly rateAggregation = '[data-testid="rate-aggregation-text"]'
     public static readonly improvementNotationSelect = '[id="improvement-notation-select"]'
     public static readonly improvementNotationDescText = '[data-testid="improvement-notation-description-input"]'
     // When the flag "EnhancedTextFormatting" is removed, replace the below variable's value with that wheich is commented out

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
@@ -66,8 +66,7 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(TestCasesPage.detailsTab).click()
-        TestCasesPage.checkToastMessageOK(TestCasesPage.successMsg)
-
+        cy.get(TestCasesPage.importTestCaseSuccessMsg, {timeout: 6500}).should('have.text', 'Test case updated successfully with warnings in JSONMADiE enforces a UTC (offset 0) timestamp format with mandatory millisecond precision. All timestamps with non-zero offsets have been overwritten to UTC, and missing milliseconds have been defaulted to \'000\'.')
         //Assert saved observation values
         cy.get(TestCasesPage.tctExpectedActualSubTab).click()
         cy.get(TestCasesPage.measureObservationRow).should('contain.value', '1.3')


### PR DESCRIPTION
Fixes for MeasureObservationExpectedValues.cy.ts  and PassingCodeCoverageTestCaseListPage.cy.ts   

Selector update & TZ offset fix.