### PR TITLE
Regression failure fixes: Webinterface tests: EditMeasureAddMetaData test file

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -178,8 +178,8 @@ export class EditMeasurePage {
     public static readonly measureRationaleSuccessMessage = '[data-testid="measureRationaleSuccess"]'
 
     //Purpose
-    public static readonly measurePurposeTextBox = '[data-testid="measurePurposeInput"]'
-    public static readonly measurePurposeSaveBtn = '[data-testid="measurePurposeSave"]'
+    public static readonly measurePurposeTextBox = '[data-testid="measure-purpose-input"]'
+    public static readonly measurePurposeSaveBtn = '[data-testid="measure-purpose-save"]'
     public static readonly measurePurposeSavedMsg = '[data-testid="measurePurposeSuccess"]'
 
     //Guidance Page

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -821,7 +821,7 @@ export class MeasureGroupPage {
             type = MeasureType.process
         }
 
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).wait(1000).should('exist')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
         cy.get(MeasureGroupPage.measureGroupTypeCheckbox).should('exist')

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
@@ -269,7 +269,7 @@ describe('Edit Measure: Add Meta Data', () => {
 
 
         const expectedOrder = ['eight', 'eleven', 'five', 'four', 'nine', 'one', 'seven', 'six', 'ten', 'ThisIsTheDefinitionTermValue']
-        const pageTwoOrder = ['three','twelve', 'two']
+        const pageTwoOrder = ['three', 'twelve', 'two']
 
         cy.get(EditMeasurePage.definitionMetaTableBody).find('tr > td:first-child').each((el, index) => {
             cy.wrap(el).invoke('text').then(textValue => {


### PR DESCRIPTION
This PR contains the necessary updates / changes to resolve issues seen while executing the last regression suite run, with the EditMeasureAddMetaData test file.