### PR TITLE
fix: details page updates

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -77,8 +77,8 @@ export class EditMeasurePage {
     public static readonly leftPanelPurpose = '[data-testid="leftPanelMeasurePurpose"]'
 
     //Measure Set
-    public static readonly measureSetText = '[data-testid="measureMeasure SetInput"]'
-    public static readonly measureSetSaveBtn = '[data-testid="measureMeasure SetSave"]'
+    public static readonly measureSetText = '[data-testid="measure-measure-set-input"]'
+    public static readonly measureSetSaveBtn = '[data-testid="measure-measure-set-save"]'
 
     //References page
     public static readonly addReferenceButton = '[data-testid="create-reference-button"]'

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
@@ -16,8 +16,8 @@ describe('QDM Measure Set', () => {
 
     beforeEach('Create Measure, add Cohort group and Login', () => {
 
-        newMeasureName = 'TestMeasure' + Date.now() + randValue
-        newCqlLibraryName = 'MeasureTypeTestLibrary' + Date.now() + randValue
+        newMeasureName = 'QDMMeasureSet' + Date.now() + randValue
+        newCqlLibraryName = 'QDMMeasureSetLib' + Date.now() + randValue
 
         measureData.ecqmTitle = newMeasureName
         measureData.cqlLibraryName = newCqlLibraryName
@@ -25,17 +25,14 @@ describe('QDM Measure Set', () => {
         measureData.patientBasis = 'true'
         measureData.measureCql = measureCQL
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         OktaLogin.Login()
-
     })
 
     afterEach('Logout and cleanup', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
     })
 
     it('Add QDM Measure Set', () => {
@@ -46,7 +43,6 @@ describe('QDM Measure Set', () => {
         cy.get(EditMeasurePage.measureSetSaveBtn).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure Measure Set Information Saved Successfully')
         cy.get(EditMeasurePage.measureSetText).should('contain.text', 'Measure Set')
-
     })
 
     it('Discard changes button', () => {
@@ -56,7 +52,7 @@ describe('QDM Measure Set', () => {
         //Navigate to Measure set page
         cy.get(EditMeasurePage.leftPanelMeasureSet).click()
         cy.get(EditMeasurePage.measureSetText).type('Measure Set')
-        cy.get(Utilities.DiscardCancelBtn).click()
+        cy.get(Utilities.DiscardButton).click()
         Utilities.clickOnDiscardChanges()
         cy.get(EditMeasurePage.measureSetText).should('be.empty')
     })
@@ -75,17 +71,14 @@ describe('QDM Measure Set - ownership validations', () => {
         measureData.patientBasis = 'true'
         measureData.measureCql = measureCQL
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         OktaLogin.AltLogin()
-
     })
 
     afterEach('Logout and cleanup', () => {
 
         OktaLogin.UILogout()
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
     })
 
     it('Non Measure owner unable to add Measure Set', () => {
@@ -96,7 +89,6 @@ describe('QDM Measure Set - ownership validations', () => {
 
         //Navigate to Measure set page
         cy.get(EditMeasurePage.leftPanelMeasureSet).click()
-        cy.get(EditMeasurePage.measureSetText).should('have.attr', 'readonly', 'readonly')
-
+        cy.get(EditMeasurePage.measureSetText).should('have.attr', 'disabled', 'disabled')
     })
 })


### PR DESCRIPTION
Fixes QDMMeasureSet.cy.ts

Similar to https://github.com/MeasureAuthoringTool/madie-cypress/pull/2161
selector updates for a details tab
