### PR TITLE
Regression failure fixes: Webinterface tests: MeasureObservations test file

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -44,6 +44,8 @@ export type MeasureObservations = {
 }
 
 export class MeasureGroupPage {
+
+    public static readonly popBasisField = '[id="populationBasis"]'
     public static readonly pcErrorAlertToast = '[data-testid="population-criteria-error"]'
 
     //QDM population criteria
@@ -331,6 +333,8 @@ export class MeasureGroupPage {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         Utilities.setMeasureGroupType()
+
+        cy.get(MeasureGroupPage.popBasisField).focus()
 
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringRatio)
 

--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -399,8 +399,8 @@ export class Utilities {
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).type('Process').type('{downArrow}').type('{enter}')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).wait(100).type('Process').wait(100).type('{downArrow}').wait(100).type('{enter}')
+
     }
 
     public static validateErrors(errorElementObject: string, errorContainer: string, errorMsg1: string, errorMsg2?: string): void {

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
@@ -25,6 +25,13 @@ describe('Measure Observations', () => {
         //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        cy.get(Header.mainMadiePageButton).click()
 
     })
 
@@ -309,6 +316,13 @@ describe('Measure Observations and Stratification -- non-owner tests', () => {
         //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        cy.get(Header.mainMadiePageButton).click()
 
     })
 
@@ -555,6 +569,13 @@ describe('Measure Observation - Expected Values', () => {
         //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(' Clean up and Logout', () => {
@@ -660,7 +681,7 @@ describe('Measure Observation - Expected Values', () => {
         cy.get(TestCasesPage.measureObservationRow).should('exist')
     })
 
-    it('Verify Expected values for Boolean Type Ratio Measure Observations', () => {
+    it.only('Verify Expected values for Boolean Type Ratio Measure Observations', () => {
 
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
         //navigate away from measure group page
@@ -776,6 +797,13 @@ describe('Validate Measure Observation Parameters', () => {
         //Create New Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(' Clean up and Logout', () => {

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
@@ -681,7 +681,7 @@ describe('Measure Observation - Expected Values', () => {
         cy.get(TestCasesPage.measureObservationRow).should('exist')
     })
 
-    it.only('Verify Expected values for Boolean Type Ratio Measure Observations', () => {
+    it('Verify Expected values for Boolean Type Ratio Measure Observations', () => {
 
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
         //navigate away from measure group page


### PR DESCRIPTION
This PR contains the necessary fixes to resolve the failures seen while trying to run the MeasureObservations test file during the last regression suite execution.