### PR TITLE
fix: update library under test

### DIFF
--- a/cypress/e2e/Services/CQL Library Service/LibraryUsageAndDeleteUnusedLibrary.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/LibraryUsageAndDeleteUnusedLibrary.cy.ts
@@ -61,14 +61,14 @@ describe('Verify Library usage and Delete Library', () => {
 
         cy.getCookie('accessToken').then((accessToken) => {
             cy.request({
-                url: '/api/measures/library/usage?libraryName=MATGlobalCommonFunctionsQDM',
+                url: '/api/measures/library/usage?libraryName=AlaraCommonFunctions',
                 method: 'GET',
                 headers: {
                     authorization: 'Bearer ' + accessToken.value
                 }
             }).then((response) => {
                 expect(response.status).to.eql(200)
-                expect(response.body[0].name).to.eql('MyCMS826')
+                expect(response.body[0].name).to.include('Excessive Radiation Dose or Inadequate Image Quality for Diagnostic Computed Tomography in Adults')
             })
         })
     })


### PR DESCRIPTION
Fixes LibraryUsageAndDeleteUnusedLbrary.cy.ts

Changed the Library used as part of this test to be much more specific.
MATGlobalCommonFunctionsQDM is used in ~900 different measures, which makes verifying this check moderately difficult.
AlaraCommonFunctions is only used in ~30 & they are all variations of the same name.