### PR TITLE
fix: updates for selector changes

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -98,8 +98,8 @@ export class EditMeasurePage {
     public static deleteQiCoreReference = '[aria-label="Delete"]'
 
     //Definition(Terms) page
-    public static readonly definitionInputTextbox = '[data-testid="measureDefinitionInput"]'
-    public static readonly saveMeasureDefinition = '[data-testid="measureDefinitionSave"]'
+    public static readonly definitionInputTextbox = '[data-testid="measure-definition-input"]'
+    public static readonly saveMeasureDefinition = '[data-testid="measure-definition-save"]'
     public static readonly createDefinitionBtn = '[data-testid="create-definition-button"]'
     public static readonly definitionTermInput = '[data-testid="measure-definition-term-input"]'
     public static readonly definitionInput = '[data-testid="measure-definition"]'

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureDefinitions.cy.ts
@@ -25,17 +25,14 @@ describe('QDM Measure Definition', () => {
         measureData.patientBasis = 'true'
         measureData.measureCql = measureCQL
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         OktaLogin.Login()
-
     })
 
     afterEach('Logout and cleanup', () => {
 
         OktaLogin.Logout()
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
     })
 
     it('Add QDM Measure Definitions', () => {
@@ -46,7 +43,6 @@ describe('QDM Measure Definition', () => {
         cy.get(EditMeasurePage.definitionInputTextbox).type('Measure Definition')
         cy.get(EditMeasurePage.saveMeasureDefinition).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure Definition Information Saved Successfully')
-
     })
 
     it('Discard changes button', () => {
@@ -56,9 +52,8 @@ describe('QDM Measure Definition', () => {
         //Navigate to References page
         cy.get(EditMeasurePage.leftPanelDefinition).click()
         cy.get(EditMeasurePage.definitionInputTextbox).type('Measure Definition')
-        cy.get(Utilities.DiscardCancelBtn).click()
+        cy.get(Utilities.DiscardButton).click()
         Utilities.clickOnDiscardChanges()
-
     })
 })
 
@@ -75,17 +70,14 @@ describe('QDM Measure Definition ownership validation', () => {
         measureData.patientBasis = 'true'
         measureData.measureCql = measureCQL
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         OktaLogin.AltLogin()
-
     })
 
     afterEach('Logout and cleanup', () => {
 
         OktaLogin.UILogout()
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
     })
 
     it('Non Measure owner unable to add Measure Definition', () => {
@@ -96,8 +88,7 @@ describe('QDM Measure Definition ownership validation', () => {
 
         //Navigate to References page
         cy.get(EditMeasurePage.leftPanelDefinition).click()
-        cy.get(EditMeasurePage.definitionInputTextbox).should('have.attr', 'readonly')
-
+        cy.get(EditMeasurePage.definitionInputTextbox).should('have.attr', 'disabled')
     })
 })
 


### PR DESCRIPTION
Fixes QDMMeasureDefinitions.cy.ts

1. Handful of changed selectors for objects used in these tests.
2. `readonly` to `disabled` attribute change that we have seen a few times.
3. Whitespace