### PR TITLE
fix: change disabled to readonly

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureDefinitions.cy.ts
@@ -88,7 +88,7 @@ describe('QDM Measure Definition ownership validation', () => {
 
         //Navigate to References page
         cy.get(EditMeasurePage.leftPanelDefinition).click()
-        cy.get(EditMeasurePage.definitionInputTextbox).should('have.attr', 'disabled')
+        cy.get(EditMeasurePage.definitionInputTextbox).should('have.attr', 'readonly')
     })
 })
 

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
@@ -89,6 +89,6 @@ describe('QDM Measure Set - ownership validations', () => {
 
         //Navigate to Measure set page
         cy.get(EditMeasurePage.leftPanelMeasureSet).click()
-        cy.get(EditMeasurePage.measureSetText).should('have.attr', 'disabled', 'disabled')
+        cy.get(EditMeasurePage.measureSetText).should('have.attr', 'readonly')
     })
 })


### PR DESCRIPTION
Fixes both
QDMMeasureDefinitions.cy.ts
QDMMeasureSet.cy.ts

Both had failing non-owner tests that were looking for the static text to be `disabled`. Updated them both to the newer `readonly`.