### PR TITLE
fix: new selectors, switch to readonly

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -61,11 +61,14 @@ export class MeasureGroupPage {
     //QDM Supplemental Data Elements and Risk Adjustment variables
     public static readonly QDMSupplementalDataElementsTab = '[id="sideNavMeasurePopulationsSupplementalData"]'
     public static readonly QDMSupplementalDataDescriptionTextBox = '[data-testid=supplemental-data-description-text]'
+    public static readonly readOnlyQDMSDEDescription = 'supplementalDataDescription'
     public static readonly QDMSupplementalDataDefinitionSelect = '[data-testid=ArrowDropDownIcon]'
+    public static readonly readOnlyQDMSDEDefinition = '#supplemental-data'
     public static readonly QDMSupplementalDataElementsListBox = '[id="supplemental-data-listbox"]'
     public static readonly QDMSaveSupplementalDataElements = '[data-testid="measure-Supplemental Data-save"]'
     public static readonly QDMSupplementalDataDefinitionTextBox = '[id="supplemental-data"]'
     public static readonly QDMRiskAdjustmentDescriptionTextBox = '[data-testid=risk-adjustment-description-text]'
+    public static readonly readOnlyQDMRiskAdjDescription = '#riskAdjustmentDescription'
     public static readonly QDMRiskAdjustmentDefinitionTextBox = '[id="risk-adjustment"]'
 
     //mismatch CQL error
@@ -120,8 +123,10 @@ export class MeasureGroupPage {
     public static readonly deleteMeasureGroupConfirmationMsg = '.MuiDialogContent-root > div'
     //Reporting tab fields
     public static readonly rateAggregation = '[data-testid="rate-aggregation-text"]'
+    public static readonly readOnlyRateAggregation = '#rateAggregation'
     public static readonly improvementNotationSelect = '[id="improvement-notation-select"]'
     public static readonly improvementNotationDescText = '[data-testid="improvement-notation-description-text"]'
+    public static readonly readOnlyImpNotationDescription = '#improvementNotationDescription'
     // When the flag "EnhancedTextFormatting" is removed, replace the below variable's value with that wheich is commented out
     public static readonly improvementNotationDescQiCore = '[data-testid="improvement-notation-description-text"]'/*'[data-testid="improvement-notation-description-rich-text-editor"]'*/
     public static readonly improvementNotationValues = '[class="MuiList-root MuiList-padding MuiMenu-list css-ubifyk"]'

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMEditMeasureOwnershipValidation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMEditMeasureOwnershipValidation.cy.ts
@@ -26,7 +26,6 @@ describe('Measure Ownership Validations for QDM Measures', () => {
 
         cy.clearCookies()
         cy.clearLocalStorage()
-        // OktaLogin.AltLogin()
         cy.setAccessTokenCookieALT()
 
         measureData.ecqmTitle = altMeasureName
@@ -40,14 +39,12 @@ describe('Measure Ownership Validations for QDM Measures', () => {
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, true, 'ipp')
         OktaLogin.Login()
-
     })
 
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.UILogout()
         Utilities.deleteMeasure(altMeasureName, altCqlLibraryName, false, true)
-
     })
 
     it('Fields on Population criteria page are not editable by Non Measure Owner', () => {
@@ -71,23 +68,23 @@ describe('Measure Ownership Validations for QDM Measures', () => {
         //navigate to the criteria section of the PC
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
 
-        cy.get(MeasureGroupPage.ucumScoringUnitSelect).should('not.be.enabled')
-        cy.get(MeasureGroupPage.initialPopulationSelect).should('not.be.enabled')
+        cy.get(MeasureGroupPage.readOnlyScoringUnit).should('have.attr', 'readonly')
+        cy.get(MeasureGroupPage.initialPopulationSelect).should('have.attr', 'readonly')
 
         //Navigate to Supplemental data elements tab
         cy.get(MeasureGroupPage.QDMSupplementalDataElementsTab).click()
-        cy.get(MeasureGroupPage.QDMSupplementalDataDefinitionTextBox).should('not.be.enabled')
-        cy.get(MeasureGroupPage.QDMSupplementalDataDescriptionTextBox).should('not.be.enabled')
+        cy.get(MeasureGroupPage.QDMSupplementalDataDefinitionTextBox).should('have.attr', 'readonly')
+        cy.get(MeasureGroupPage.readOnlyQDMSDEDefinition).should('have.attr', 'readonly')
 
         //Navigate to Risk Adjustment Variables tab
         cy.get(MeasureGroupPage.leftPanelRiskAdjustmentTab).click()
-        cy.get(MeasureGroupPage.QDMRiskAdjustmentDefinitionTextBox).should('not.be.enabled')
-        cy.get(MeasureGroupPage.QDMRiskAdjustmentDescriptionTextBox).should('not.be.enabled')
+        cy.get(MeasureGroupPage.QDMRiskAdjustmentDefinitionTextBox).should('have.attr', 'readonly')
+        cy.get(MeasureGroupPage.readOnlyQDMRiskAdjDescription).should('have.attr', 'readonly')
 
         //Navigate to Reporting tab
         cy.get(MeasureGroupPage.qdmMeasureReportingTab).click()
-        cy.get(MeasureGroupPage.rateAggregation).should('not.be.enabled')
-        cy.get(MeasureGroupPage.improvementNotationSelect).should('not.be.enabled')
-
+        cy.get(MeasureGroupPage.readOnlyRateAggregation).should('have.attr', 'readonly')
+        cy.get(MeasureGroupPage.improvementNotationSelect).should('have.attr', 'readonly')
+        cy.get(MeasureGroupPage.readOnlyImpNotationDescription).should('have.attr', 'readonly')
     })
 })


### PR DESCRIPTION
Fixes QDMEditMeasureOwnershipValidations.cy.ts

Add new variant selectors for readonly text. Update checks to use these instead of standard textboxes, and change from disabled to readonly.