### PR TITLE
fix: refactor, add Action header

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
@@ -21,7 +21,7 @@ const measureCQLPFTests = MeasureCQL.CQL_Populations
 const testCaseJson = TestCaseJson.TestCaseJson_CohortPatientBoolean_PASS
 const { deleteDownloadsFolderBeforeEach } = require('cypress-delete-downloads-folder')
 
-describe.skip('QI-Core: Export Bundle options for Non Measure Owner: Transaction or Collection', () => {
+describe('QI-Core: Export Bundle options for Non Measure Owner: Transaction or Collection', () => {
 
     deleteDownloadsFolderBeforeEach()
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExportBundleType.cy.ts
@@ -9,44 +9,34 @@ import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 import { Header } from "../../../../../Shared/Header"
 
+const timestamp = Date.now()
 const now = require('dayjs')
-let todaysDate = now().format('MM/DD/YYYY')
-let measureName = 'TestMeasure' + Date.now()
-let CqlLibraryName = 'TestLibrary' + Date.now()
-let randValue = (Math.floor((Math.random() * 1000) + 1))
-let testCaseTitle = 'Title for Auto Test'
-let measureCQLPFTests = MeasureCQL.CQL_Populations
-let testCaseDescription = 'DENOMFail' + Date.now()
-let testCaseSeries = 'SBTestSeries'
-let testCaseJson = TestCaseJson.TestCaseJson_CohortPatientBoolean_PASS
-let newMeasureName = measureName + randValue
-let newCqlLibraryName = CqlLibraryName + randValue
-const path = require('path')
-const downloadsFolder = Cypress.config('downloadsFolder')
-const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
-let validFileToUpload = downloadsFolder.toString()
+const todaysDate = now().format('MM/DD/YYYY')
+const measureName = 'ExportBundleType' + timestamp
+const CqlLibraryName = 'ExportBundleTypeLib' + timestamp
+const testCaseTitle = 'Title for Auto Test'
+const testCaseDescription = 'export test case scenarios'
+const testCaseSeries = 'SBTestSeries'
+const measureCQLPFTests = MeasureCQL.CQL_Populations
+const testCaseJson = TestCaseJson.TestCaseJson_CohortPatientBoolean_PASS
+const { deleteDownloadsFolderBeforeEach } = require('cypress-delete-downloads-folder')
 
-describe('QI-Core: Export Bundle options for Non Measure Owner: Transaction or Collection', () => {
+describe.skip('QI-Core: Export Bundle options for Non Measure Owner: Transaction or Collection', () => {
 
-    deleteDownloadsFolderBeforeAll()
+    deleteDownloadsFolderBeforeEach()
 
     beforeEach('Create measure, measure group, test case and login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
-
     })
 
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.Logout()
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        let newCqlLibraryName = CqlLibraryName + randValue
-
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
     })
+
     it('Export single QI-Core Test case by Non Measure Owner: Transaction', () => {
 
         OktaLogin.Login()
@@ -76,9 +66,8 @@ describe('QI-Core: Export Bundle options for Non Measure Owner: Transaction or C
         TestCasesPage.actionCenter(TestCaseAction.exportTransaction)
 
         //verify that the export occurred
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
+        cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('exist')
         cy.log('Successfully verified zip file export')
-
     })
 
     it('Export single QI-Core Test case by Non Measure Owner: Collection', () => {
@@ -108,33 +97,18 @@ describe('QI-Core: Export Bundle options for Non Measure Owner: Transaction or C
 
         TestCasesPage.checkTestCase(1)
         TestCasesPage.actionCenter(TestCaseAction.exportCollection)
-
     })
 })
 
-describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: Transaction', () => {
+describe('QI-Core: Single Test Case on Measure: Export / Import', () => {
 
-    deleteDownloadsFolderBeforeAll()
+    deleteDownloadsFolderBeforeEach()
 
     beforeEach('Create measure, measure group, test case and login', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
-
-    })
-
-    afterEach('Logout and Clean up Measures', () => {
-
-        OktaLogin.Logout()
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        let newCqlLibraryName = CqlLibraryName + randValue
-
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
-    })
-    it('Export single QI-Core Test case Transaction bundle and Import to the same Measure', () => {
 
         OktaLogin.Login()
 
@@ -156,13 +130,22 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
 
         //Navigate to Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()
+    })
+
+    afterEach('Logout and Clean up Measures', () => {
+
+        OktaLogin.Logout()
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+    })
+
+    it('Export single QI-Core Test case Transaction bundle and Import to the same Measure', () => {
 
         //export transaction
         TestCasesPage.checkTestCase(1)
         TestCasesPage.actionCenter(TestCaseAction.exportTransaction)
 
         //verify that the export occurred
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
+        cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('exist')
         cy.log('Successfully verified zip file export')
 
         Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
@@ -182,7 +165,7 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportModal, 35000)
 
         //Upload valid Json file via drag and drop
-        cy.get(TestCasesPage.filAttachDropBox).selectFile(path.join(validFileToUpload, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip'), { action: 'drag-drop', force: true })
+        cy.get(TestCasesPage.filAttachDropBox).selectFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip', { action: 'drag-drop', force: true })
 
         //verifies the section at the bottom of the modal, after file has been, successfully, dragged and dropped in modal
         Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile, 35000)
@@ -191,18 +174,62 @@ describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: 
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
-        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast Saved1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate)
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate)
 
         //navigate to test case edit / detail page
         TestCasesPage.clickEditforCreatedTestCase()
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
+    })
 
+    it('Export single QI-Core Test case Collection bundle and Import to the same Measure', () => {
+
+        //export transaction
+        TestCasesPage.checkTestCase(1)
+        TestCasesPage.actionCenter(TestCaseAction.exportCollection)
+
+        //verify that the export occurred
+        cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('exist')
+        cy.log('Successfully verified zip file export')
+
+        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
+
+        //Click on Edit Measure
+        MeasuresPage.actionCenter('edit')
+
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        //click on the Import Test Cases button
+        cy.get(TestCasesPage.importTestCasesBtn).click()
+
+        //wait until select / drag and drop modal window appears
+        Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportModal, 35000)
+
+        //Upload valid Json file via drag and drop
+        cy.get(TestCasesPage.filAttachDropBox).selectFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip', { action: 'drag-drop', force: true })
+
+        //verifies the section at the bottom of the modal, after file has been, successfully, dragged and dropped in modal
+        Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile, 35000)
+        cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
+
+        //import the tests cases from selected / dragged and dropped .zip file
+        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate)
+
+        //navigate to test case edit / detail page
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
     })
 })
-describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options: Transaction', () => {
 
-    deleteDownloadsFolderBeforeAll()
+describe('QI-Core: Multiple Test Case on Measure: Export / Import', () => {
+
+    deleteDownloadsFolderBeforeEach()
 
     beforeEach('Create measure, measure group, test case and login', () => {
 
@@ -210,20 +237,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'a', testCaseSeries + 'a', testCaseDescription + 'a', testCaseJson)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'b', testCaseSeries + 'b', testCaseDescription + 'b', testCaseJson, false, true)
-
-    })
-
-    afterEach('Logout and Clean up Measures', () => {
-
-        OktaLogin.Logout()
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        let newCqlLibraryName = CqlLibraryName + randValue
-
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
-    })
-    it('Export multiple QI-Core Test cases Transaction bundle and Import to the same Measure', () => {
+   
         OktaLogin.Login()
 
         Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
@@ -244,6 +258,15 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
 
         //Navigate to Test Case page
         cy.get(EditMeasurePage.testCasesTab).click()
+    })
+
+    afterEach('Logout and Clean up Measures', () => {
+
+        OktaLogin.Logout()
+        Utilities.deleteMeasure(measureName, CqlLibraryName)
+    })
+
+    it('Export multiple QI-Core Test cases Transaction bundle and Import to the same Measure', () => {
 
         //export both text cases
         TestCasesPage.checkTestCase(1)
@@ -251,7 +274,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         TestCasesPage.actionCenter(TestCaseAction.exportTransaction)
 
         //verify that the export occurred
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
+        cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('exist')
         cy.log('Successfully verified zip file export')
 
         cy.reload()
@@ -272,7 +295,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportModal, 35000)
 
         //Upload valid Json file via drag and drop
-        cy.get(TestCasesPage.filAttachDropBox).selectFile(path.join(validFileToUpload, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip'), { action: 'drag-drop', force: true })
+        cy.get(TestCasesPage.filAttachDropBox).selectFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip', { action: 'drag-drop', force: true })
 
         //verifies the section at the bottom of the modal, after file has been, successfully, dragged and dropped in modal
         Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile, 35000)
@@ -281,7 +304,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
-        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast Saved2N/A' + testCaseSeries + 'b' + 'Title for Auto Testb' + testCaseDescription + 'b' + todaysDate)
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/A' + testCaseSeries + 'b' + 'Title for Auto Testb' + testCaseDescription + 'b' + todaysDate)
         .should('contain.text', '1N/A' + testCaseSeries + 'a' + 'Title for Auto Testa' + testCaseDescription + 'a' + todaysDate)
 
         //navigate to test case edit / detail page for the first test case
@@ -296,144 +319,9 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         TestCasesPage.clickEditforCreatedTestCase(true)
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "transaction"')
-
-
-    })
-})
-
-describe('QI-Core: Single Test Case on Measure: Export / Import Bundle options: Collection', () => {
-
-    deleteDownloadsFolderBeforeAll()
-
-    beforeEach('Create measure, measure group, test case and login', () => {
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
-
     })
 
-    afterEach('Logout and Clean up Measures', () => {
-
-        OktaLogin.Logout()
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        let newCqlLibraryName = CqlLibraryName + randValue
-
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
-    })
-    it('Export single QI-Core Test case Collection bundle and Import to the same Measure', () => {
-
-        OktaLogin.Login()
-
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
-        cy.get(MeasuresPage.allMeasuresTab).click()
-
-        Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.get(Header.cqlLibraryTab).click()
-
-        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible')
-        cy.get(Header.mainMadiePageButton).click()
-
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-
-        MeasuresPage.actionCenter('edit')
-
-        //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
-
-        //export transaction
-        TestCasesPage.checkTestCase(1)
-        TestCasesPage.actionCenter(TestCaseAction.exportCollection)
-
-        //verify that the export occurred
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
-        cy.log('Successfully verified zip file export')
-
-        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible')
-        cy.get(Header.mainMadiePageButton).click()
-
-        //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
-
-        //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
-
-        //click on the Import Test Cases button
-        cy.get(TestCasesPage.importTestCasesBtn).click()
-
-        //wait until select / drag and drop modal window appears
-        Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportModal, 35000)
-
-        //Upload valid Json file via drag and drop
-        cy.get(TestCasesPage.filAttachDropBox).selectFile(path.join(validFileToUpload, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip'), { action: 'drag-drop', force: true })
-
-        //verifies the section at the bottom of the modal, after file has been, successfully, dragged and dropped in modal
-        Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile, 35000)
-        cy.get(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile).should('contain.text', 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')
-
-        //import the tests cases from selected / dragged and dropped .zip file
-        cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
-
-        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast Saved1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription + todaysDate)
-
-        //navigate to test case edit / detail page
-        TestCasesPage.clickEditforCreatedTestCase()
-
-        cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
-
-    })
-})
-describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options: Collection', () => {
-
-    deleteDownloadsFolderBeforeAll()
-
-    beforeEach('Create measure, measure group, test case and login', () => {
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean')
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'a', testCaseSeries + 'a', testCaseDescription + 'a', testCaseJson)
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle + 'b', testCaseSeries + 'b', testCaseDescription + 'b', testCaseJson, false, true)
-
-    })
-
-    afterEach('Logout and Clean up Measures', () => {
-
-        OktaLogin.Logout()
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        let newCqlLibraryName = CqlLibraryName + randValue
-
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-
-    })
     it('Export multiple QI-Core Test cases Collection bundle and Import to the same Measure', () => {
-
-        OktaLogin.Login()
-
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-        cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
-        cy.get(MeasuresPage.allMeasuresTab).click()
-
-        Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-        cy.get(Header.cqlLibraryTab).should('be.visible')
-        cy.get(Header.cqlLibraryTab).click()
-
-        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-        cy.get(Header.mainMadiePageButton).should('be.visible')
-        cy.get(Header.mainMadiePageButton).click()
-
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
-
-        MeasuresPage.actionCenter('edit')
-
-        //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
 
         //export both text cases
         TestCasesPage.checkTestCase(1)
@@ -441,7 +329,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         TestCasesPage.actionCenter(TestCaseAction.exportCollection)
 
         //verify that the export occurred
-        cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip')).should('exist')
+        cy.readFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip').should('exist')
         cy.log('Successfully verified zip file export')
 
         cy.reload()
@@ -462,7 +350,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportModal, 35000)
 
         //Upload valid Json file via drag and drop
-        cy.get(TestCasesPage.filAttachDropBox).selectFile(path.join(validFileToUpload, 'eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip'), { action: 'drag-drop', force: true })
+        cy.get(TestCasesPage.filAttachDropBox).selectFile('cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR4-TestCases.zip', { action: 'drag-drop', force: true })
 
         //verifies the section at the bottom of the modal, after file has been, successfully, dragged and dropped in modal
         Utilities.waitForElementVisible(TestCasesPage.testCasesNonBonnieFileImportFileLineAfterSelectingFile, 35000)
@@ -471,7 +359,7 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         //import the tests cases from selected / dragged and dropped .zip file
         cy.get(TestCasesPage.importTestCaseBtnOnModal).click()
 
-        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast Saved2N/ASBTestSeriesbTitle for Auto Testb' + testCaseDescription + 'b' + todaysDate)
+        cy.get(TestCasesPage.testCaseListTable).should('contain.text', 'Case #StatusGroupTitleDescriptionLast SavedAction2N/ASBTestSeriesbTitle for Auto Testb' + testCaseDescription + 'b' + todaysDate)
             .should('contain.text', '1N/ASBTestSeriesaTitle for Auto Testa' + testCaseDescription + 'a' + todaysDate)
 
         //navigate to test case edit / detail page for the first test case
@@ -486,7 +374,5 @@ describe('QI-Core: Multiple Test Case on Measure: Export / Import Bundle options
         TestCasesPage.clickEditforCreatedTestCase(true)
 
         cy.get(TestCasesPage.aceEditor).should('include.text', '"type": "collection"')
-
-
     })
 })


### PR DESCRIPTION
Fixes and refactors TestCaseExportBundleType.cy.ts

Summary of changes
1. Consolidate scenario structures - there were 4 `describes` with 1 `it` each. Re-worked tests to be 2 `describes` with 2 `its` and more shared code in the `beforeEach` hooks. This also meant switching to the plugin `deleteDownloadsFolderBeforeEach`.
2. Removed use of `path` and the randomization scheme. Changed names to be unique to this file.
3. (Actual fix) Added new header "Action" into expected text checks.