### PR TITLE
fix: post-regression updates

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -25,6 +25,7 @@ export class CQLLibraryPage {
     public static readonly cqlLibSearchResultsTable = '[data-testid="table-body"]'
     public static readonly createCQLLibraryBtn = '[data-testid="create-new-cql-library-button"]'
     public static readonly cqlLibraryNameTextbox = '[data-testid="cql-library-name-text-field-input"]'
+    public static readonly readOnlyCqlLibraryName = '[data-testid="cql-library-name-text-field"]'
     public static readonly cqlLibraryModelDropdown = '[data-testid="cql-library-model-select"]'
     public static readonly cqlLibraryStickySave = '[data-testid="cql-library-save-button"]'
     public static readonly libraryListTitles = '[data-testid="cqlLibrary-list"]'

--- a/cypress/e2e/WebInterface/CQL Library/DeleteCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/DeleteCQLLibraryValidations.cy.ts
@@ -191,8 +191,9 @@ describe('Delete CQL Library Validations - Edit Library page', () => {
 
         CQLLibrariesPage.clickViewforCreatedLibrary()
 
-        Utilities.waitForElementVisible(CQLLibraryPage.cqlLibraryNameTextbox, 11500)
+        Utilities.waitForElementVisible(CQLLibraryPage.readOnlyCqlLibraryName, 11500)
 
+        cy.contains('You are not the owner of the CQL Library. Only owner can edit it.').should('be.visible')
         cy.get(CQLLibraryPage.actionCenterButton).should('not.exist')
     })
 

--- a/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
@@ -85,7 +85,6 @@ describe('Edit CQL Library validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryDesc).click()
         cy.get(CQLLibraryPage.cqlLibPubHelperText).should('contain.text', 'Publisher is required.')
         cy.get(CQLLibraryPage.cqlLibraryStickySave).should('be.disabled')
-
     })
 
     it('CQL Library Edit page validation that the "Experimental" check box can be checked or unchecked -- not required', () => {
@@ -138,23 +137,22 @@ describe('Edit CQL Library validations', () => {
         cy.get(CQLLibraryPage.cqlLibraryStickySave).should('exist')
         cy.get(CQLLibraryPage.cqlLibraryStickySave).should('be.visible')
         cy.get(CQLLibraryPage.cqlLibraryStickySave).should('be.enabled')
-
     })
 })
+
 describe('CQL Library Validations -- User ownership', () => {
 
     beforeEach('Login', () => {
         var randValue = (Math.floor((Math.random() * 1000) + 1))
         CQLLibraryNameAlt = 'TestLibrary' + Date.now() + randValue
         CQLLibraryPage.createCQLLibraryAPI(CQLLibraryNameAlt, CQLLibraryPublisherAlt, false, true)
-
-
     })
+
     afterEach('Logout', () => {
 
         OktaLogin.Logout()
-
     })
+
     it('Owner is the same as current user, library will appear in, both, "All Libraries" and "My Libraries" default / stand-alone lists', () => {
         //log in as user that does not own the Library
         OktaLogin.AltLogin()
@@ -178,8 +176,8 @@ describe('CQL Library Validations -- User ownership', () => {
         cy.get(CQLLibraryPage.allLibrariesBtn).click()
 
         CQLLibrariesPage.validateCQLLibraryName(CQLLibraryNameAlt)
-
     })
+
     it('Owner is not the user and the library details are viewed via a View button and Library cannot be edited', () => {
         //log in as user that does not own the Library
         OktaLogin.Login()
@@ -206,8 +204,7 @@ describe('CQL Library Validations -- User ownership', () => {
 
         })
 
-        cy.get(CQLLibraryPage.cqlLibraryDesc).should('be.disabled')
-
+        cy.contains('You are not the owner of the CQL Library. Only owner can edit it.').should('be.visible')
+        cy.get(CQLLibraryPage.cqlLibraryDesc).should('have.attr', 'readonly')
     })
-
 })

--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
@@ -145,9 +145,6 @@ describe('Action Center Buttons - Add Draft to CQL Library', () => {
 
         OktaLogin.AltLogin()
         cy.get(Header.cqlLibraryTab).click().wait(1000)
-        cy.get(Header.mainMadiePageButton).click().wait(1000)
-        cy.get(Header.cqlLibraryTab).click().wait(1000)
-        cy.reload()
         cy.get(CQLLibraryPage.allLibrariesBtn).wait(2000).click()
 
         Utilities.waitForElementVisible('[data-testid="cqlLibrary-button-0_select"]', 600000)
@@ -159,8 +156,8 @@ describe('Action Center Buttons - Add Draft to CQL Library', () => {
         //Verify that Non Measure owner unable to edit Library
         CQLLibrariesPage.clickViewforCreatedLibrary(null, true)
         cy.get(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'You are not the owner of the CQL Library. Only owner can edit it.')
-        cy.get(CQLLibraryPage.cqlLibraryNameTextbox).should('have.attr', 'disabled', 'disabled')
-        cy.get(CQLLibraryPage.cqlLibraryDesc).should('have.attr', 'disabled', 'disabled')
+        cy.get(CQLLibraryPage.readOnlyCqlLibraryName).should('have.attr', 'readonly')
+        cy.get(CQLLibraryPage.cqlLibraryDesc).should('have.attr', 'readonly')
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.disabled')
 
         OktaLogin.UILogout()


### PR DESCRIPTION
Fixes these tests that we skipped during regression due to interference from https://jira.cms.gov/browse/MAT-8895

Fixes include our recent standards:
- switch disabled to readonly
- add a readOnly version of selectors

I also added new checks to non-owner Library tests for the specific message shown in that scenario.