### PR TITLE
Regression failure fixes: Webinterface tests: TestCaseButtons test file

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseButtons.cy.ts
@@ -74,9 +74,9 @@ describe('Test case list page - Action Center icons for measure owner', () => {
     it('Clone icon is present and enables correctly', () => {
 
         cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
-        TestCasesPage.checkTestCase(1)
-        cy.get(TestCasesPage.actionCenterClone).should('be.enabled')
         TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterClone).should('be.enabled')
+        TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
 
         cy.get('tr > :nth-child(1) > input').check()


### PR DESCRIPTION
This PR resolves test failure seen while running general regression on 2.2.8, for the TestCaseButtons test file.