### PR TITLE
fix: add extra click for group

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecuteTestCasesByNonMeasureOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecuteTestCasesByNonMeasureOwner.cy.ts
@@ -94,6 +94,7 @@ describe('Ability to run valid test cases whether or not the user is the owner o
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
         cy.get(TestCasesPage.createTestCaseGroupInput).type(testCaseSeries, { delay: 50 })
+        cy.contains(testCaseSeries).click()
 
         TestCasesPage.clickCreateTestCaseButton()
 


### PR DESCRIPTION
Fixes ExecuteTestCasesByNonMeasureOwner.cy.ts

Add an extra click to select the test case group. Without this the group would be empty.