### PR TITLE
fix: wait for initial load

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/ExcelTestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/ExcelTestCaseExport.cy.ts
@@ -7,7 +7,6 @@ import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
 import { QDMElements } from "../../../../../Shared/QDMElements"
-import { CQLLibraryPage } from "../../../../../Shared/CQLLibraryPage"
 import { QdmCql } from "../../../../../Shared/QDMMeasuresCQL"
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
 
@@ -39,6 +38,8 @@ describe('QDM Test Case Excel Export', () => {
     })
 
     it('Successful Excel Export for QDM Test Cases', () => {
+
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
 
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')


### PR DESCRIPTION
Fixes ExcelTestCaseExport.cy.ts

This scenario was correct, but I was seeing flaky failures of the initial load of the measure list after. logging in.
Added a wait to account for some delay there.