### PR TITLE
fix: update test after refactor

### DIFF
--- a/cypress/e2e/Services/Measure Service/MeasureTranslatorVersion.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureTranslatorVersion.cy.ts
@@ -1,7 +1,6 @@
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { CreateMeasurePage, CreateMeasureOptions } from "../../../Shared/CreateMeasurePage"
 import { Utilities } from "../../../Shared/Utilities"
-import { v4 as uuidv4 } from 'uuid'
 import { OktaLogin } from "../../../Shared/OktaLogin"
 import { MeasuresPage } from "../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
@@ -24,7 +23,6 @@ const expectedQdmVersion = '3.27.0'
 const measureData: CreateMeasureOptions = {}
 
 describe('Measure Service: Translator Version for QI-Core Measure', () => {
-
 
     beforeEach('Create QI-Core Measure and Set Access Token', () => {
 
@@ -52,7 +50,6 @@ describe('Measure Service: Translator Version for QI-Core Measure', () => {
         cy.clearAllLocalStorage()
         cy.clearAllSessionStorage()
         cy.setAccessTokenCookie()
-
     })
 
     after('Delete Versioned Measure', () => {
@@ -60,78 +57,50 @@ describe('Measure Service: Translator Version for QI-Core Measure', () => {
         Utilities.deleteVersionedMeasure(qicoreCqlLibraryName, qicoreCqlLibraryName)
     })
 
-
     it('Get Translator version for QI-Core Measure', () => {
 
         //Get Translator Version for Draft Measure
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/fhir/translator-version?draft=true',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'GET',
-                    body: {
-                        "id": id,
-                        "measureName": qicoreMeasureName,
-                        "cqlLibraryName": qicoreCqlLibraryName,
-                        "model": 'QI-Core v4.1.1',
-                        "version": "0.0.000",
-                        "measureScoring": "Ratio",
-                        "measureMetaData": { "experimental": false, "draft": true },
-                        "measureSetId": uuidv4(),
-                        "ecqmTitle": "ecqmTitle",
-                        "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
-                        "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z"
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(expectedQiCoreVersion)
-                })
-            })
-        })
+                cy.readFile('cypress/fixtures/measureSetId').should('exist').then((measureSetId) => {
+           
+                    cy.request({
+                        url: '/api/fhir/translator-version?draft=true',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+                        body: {
+                            "id": id,
+                            "measureName": qicoreMeasureName,
+                            "cqlLibraryName": qicoreCqlLibraryName,
+                            "model": 'QI-Core v4.1.1',
+                            "version": "0.0.000",
+                            "measureScoring": "Ratio",
+                            "measureMetaData": { "experimental": false, "draft": true },
+                            "measureSetId": measureSetId,
+                            "ecqmTitle": "ecqmTitle",
+                            "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
+                            "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z"
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body).to.eql(expectedQiCoreVersion)
+                    })
 
-        //Version QI Core Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.include('1.0.000')
-                })
-            })
-        })
-        //Verify Translator version for Versioned Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/fhir/translator-version?draft=false',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'GET',
-                    body: {
-                        "id": id,
-                        "measureName": qicoreMeasureName,
-                        "cqlLibraryName": qicoreCqlLibraryName,
-                        "model": 'QI-Core v4.1.1',
-                        "version": "1.0.000",
-                        "measureScoring": "Ratio",
-                        "measureMetaData": { "experimental": false, "draft": false },
-                        "measureSetId": uuidv4(),
-                        "ecqmTitle": "ecqmTitle",
-                        "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
-                        "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z"
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(expectedQiCoreVersion)
+                    //Version QI Core Measure
+                    cy.request({
+                        url: '/api/measures/' + id + '/version?versionType=major',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'PUT'
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body.version).to.include('1.0.000')
+                        // versioned measures read translator version from ELM
+                        expect(response.body.elmJson).to.include('"translatorVersion" : "' + expectedQiCoreVersion + '"')
+                    })
                 })
             })
         })
@@ -169,7 +138,6 @@ describe('Measure Service: Translator Version for QDM Measure', () => {
         cy.clearAllLocalStorage()
         cy.clearAllSessionStorage()
         cy.setAccessTokenCookie()
-
     })
 
     after('Delete Versioned Measure', () => {
@@ -177,79 +145,50 @@ describe('Measure Service: Translator Version for QDM Measure', () => {
         Utilities.deleteVersionedMeasure(qdmMeasureName, qdmCqlLibraryName)
     })
 
-
     it('Get Translator version for QDM Measure', () => {
 
         //Get Translator Version for Draft Measure
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/qdm/translator-version?draft=true',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'GET',
-                    body: {
-                        "id": id,
-                        "measureName": qdmMeasureName,
-                        "cqlLibraryName": qdmCqlLibraryName,
-                        "model": 'QDM v5.6',
-                        "version": "0.0.000",
-                        "measureScoring": "Cohort",
-                        "measureMetaData": { "experimental": false, "draft": true },
-                        "measureSetId": uuidv4(),
-                        "ecqmTitle": "ecqmTitle",
-                        "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
-                        "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z"
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(expectedQdmVersion)
-                })
-            })
-        })
+                cy.readFile('cypress/fixtures/measureSetId').should('exist').then((measureSetId) => {
+          
+                    cy.request({
+                        url: '/api/qdm/translator-version?draft=true',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'GET',
+                        body: {
+                            "id": id,
+                            "measureName": qdmMeasureName,
+                            "cqlLibraryName": qdmCqlLibraryName,
+                            "model": 'QDM v5.6',
+                            "version": "0.0.000",
+                            "measureScoring": "Cohort",
+                            "measureMetaData": { "experimental": false, "draft": true },
+                            "measureSetId": measureSetId,
+                            "ecqmTitle": "ecqmTitle",
+                            "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
+                            "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z"
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body).to.eql(expectedQdmVersion)
+                    })
 
-        //Version QDM Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.include('1.0.000')
-                })
-            })
-        })
-
-        //Verify Translator version for Versioned Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/qdm/translator-version?draft=false',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken.value
-                    },
-                    method: 'GET',
-                    body: {
-                        "id": id,
-                        "measureName": qdmMeasureName,
-                        "cqlLibraryName": qdmCqlLibraryName,
-                        "model": 'QDM v5.6',
-                        "version": "1.0.000",
-                        "measureScoring": "Cohort",
-                        "measureMetaData": { "experimental": false, "draft": false },
-                        "measureSetId": uuidv4(),
-                        "ecqmTitle": "ecqmTitle",
-                        "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
-                        "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z"
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(expectedQdmVersion)
+                    //Version QDM Measure
+                    cy.request({
+                        url: '/api/measures/' + id + '/version?versionType=major',
+                        headers: {
+                            authorization: 'Bearer ' + accessToken.value
+                        },
+                        method: 'PUT'
+                    }).then((response) => {
+                        expect(response.status).to.eql(200)
+                        expect(response.body.version).to.include('1.0.000')
+                        // versioned measures read translator version from ELM
+                        expect(response.body.elmJson).to.include('"translatorVersion" : "' + expectedQdmVersion + '"')
+                    })
                 })
             })
         })


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-8696

Updates MeasureTranslatorVersion.cy.ts to account for changes from this refactor.

The API call ......draft=false was removed - the old implementation for this was an approximation & not always accurate. Now, all versioned measures will have translator version specced in their ELM.