### PR TITLE
fix: correct ordinals to match other files

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -376,7 +376,7 @@ export class CreateMeasurePage {
                 if (((twoMeasures === false) || (twoMeasures === undefined) || (twoMeasures === null)) && (measureNumber > 0)) {
                     cy.writeFile('cypress/fixtures/measureId' + measureNumber, response.body.id)
                     cy.writeFile('cypress/fixtures/measureSetId' + measureNumber, response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/versionId' + response.body.versionId, response.body.versionId)
+                    cy.writeFile('cypress/fixtures/versionId' + measureNumber, response.body.versionId)
                 }
                 else if (((twoMeasures === false) || (twoMeasures === undefined) || (twoMeasures === null)) && (measureNumber === 0)) {
                     cy.writeFile('cypress/fixtures/measureId', response.body.id)
@@ -485,7 +485,7 @@ export class CreateMeasurePage {
                 if (CreateMeasureOptions.measureNumber > 0) {
                     cy.writeFile('cypress/fixtures/measureId' + CreateMeasureOptions.measureNumber, response.body.id)
                     cy.writeFile('cypress/fixtures/measureSetId' + CreateMeasureOptions.measureNumber, response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/versionId' + response.body.versionId, response.body.versionId)
+                    cy.writeFile('cypress/fixtures/versionId' + CreateMeasureOptions.measureNumber, response.body.versionId)
 
                 }
                 else {


### PR DESCRIPTION
Minor fix, may not have even impacted any tests.

I found a confusing scenario in my local fixture files where some files were named `cypress/fixtures/versionId<UUID>`

I tracked it to these changes & corrected it to match the convention for other processing fixture files like measureId.