### PR TITLE
Regression Failure Fixes: Webinterface tests: MeasureWithVeryLongName test file

### DIFF
--- a/cypress/e2e/WebInterface/Measure/CreateMeasure/MeasureWithVeryLongName.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/CreateMeasure/MeasureWithVeryLongName.cy.ts
@@ -1,5 +1,5 @@
 import { OktaLogin } from "../../../../Shared/OktaLogin"
-import {CreateMeasurePage, SupportedModels} from "../../../../Shared/CreateMeasurePage"
+import { CreateMeasurePage, SupportedModels } from "../../../../Shared/CreateMeasurePage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { Utilities } from "../../../../Shared/Utilities"
@@ -20,18 +20,18 @@ describe('Create New Measure with very long name', () => {
 
     afterEach('Cleanup and Logout', () => {
 
-        Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 5000)
+        Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 90000)
         cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
-        Utilities.waitForElementVisible(EditMeasurePage.editMeasureDeleteActionBtn, 5000)
+        Utilities.waitForElementVisible(EditMeasurePage.editMeasureDeleteActionBtn, 90000)
         cy.get(EditMeasurePage.editMeasureDeleteActionBtn).click()
-        Utilities.waitForElementVisible(EditMeasurePage.deleteMeasureConfirmationButton, 5000)
+        Utilities.waitForElementVisible(EditMeasurePage.deleteMeasureConfirmationButton, 90000)
         cy.get(EditMeasurePage.deleteMeasureConfirmationButton).click()
-        Utilities.waitForElementVisible(EditMeasurePage.successMessage, 5000)
+        Utilities.waitForElementVisible(EditMeasurePage.successMessage, 90000)
         cy.get(EditMeasurePage.successMessage).should('contain.text', "Measure successfully deleted")
 
         //Verify the deleted measure on My Measures page list
         cy.get(Header.measures).click()
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 90000)
         cy.get(MeasuresPage.measureListTitles).should('not.contain', measureName)
 
         OktaLogin.Logout()
@@ -43,11 +43,11 @@ describe('Create New Measure with very long name', () => {
         cy.get(Header.mainMadiePageButton).click()
 
         cy.readFile('cypress/fixtures/measureId').should('exist').then((fileContents) => {
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_measureName"]', 5000)
-            cy.get('[data-testid="measure-name-' + fileContents + '_measureName"]').should('have.text', measureName.slice(0,120) + 'Show more')
-            
+            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_measureName"]', 90000)
+            cy.get('[data-testid="measure-name-' + fileContents + '_measureName"]').should('have.text', measureName.slice(0, 120) + 'Show more')
+
             cy.get('[data-testid="measure-name-' + fileContents + '_measureName"]').find('button').click()
-     
+
             cy.get('[data-testid="measure-name-' + fileContents + '_measureName"]').should('have.text', measureName + 'Show less')
         })
 


### PR DESCRIPTION
This PR contains fix to resolve issue with the MeasureWithVeryLongName test file.