### PR TITLE
fix: update for changes with RTE

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -83,7 +83,7 @@ export class EditMeasurePage {
     public static readonly leftPanelPurpose = '[data-testid="leftPanelMeasurePurpose"]'
 
     //Measure Set
-    public static readonly measureSetText = '[data-testid="measure-measure-set-input"]'
+    public static readonly measureSetText = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureSetSaveBtn = '[data-testid="measure-measure-set-save"]'
 
     //References page
@@ -127,7 +127,7 @@ export class EditMeasurePage {
     public static readonly acceptBtn = '[data-testid="share-confirmation-dialog-accept-button"]'
 
     //Transmission Format page
-    public static readonly transmissionFormatDescription = '[data-testid="transmission-format-text"]'
+    public static readonly transmissionFormatDescription = '[data-testid="transmission-format-rich-text-editor"]'
     public static readonly readOnlyTFDesc = '#transmissionFormat'
 
     //Measure CQL Page

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureSet.cy.ts
@@ -54,7 +54,7 @@ describe('QDM Measure Set', () => {
         cy.get(EditMeasurePage.measureSetText).type('Measure Set')
         cy.get(Utilities.DiscardButton).click()
         Utilities.clickOnDiscardChanges()
-        cy.get(EditMeasurePage.measureSetText).should('be.empty')
+        cy.get(EditMeasurePage.measureSetText).should('not.contain.text')
     })
 })
 
@@ -84,11 +84,10 @@ describe('QDM Measure Set - ownership validations', () => {
     it('Non Measure owner unable to add Measure Set', () => {
 
         cy.get(MeasuresPage.allMeasuresTab).click()
-        cy.reload()
         MeasuresPage.actionCenter('edit')
 
         //Navigate to Measure set page
         cy.get(EditMeasurePage.leftPanelMeasureSet).click()
-        cy.get(EditMeasurePage.measureSetText).should('have.attr', 'readonly')
+        cy.get(EditMeasurePage.measureSetText).find('p').should('have.class', 'rich-text-editor_read_only')
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureTransmissionFormat.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM EditMeasure/QDMMeasureTransmissionFormat.cy.ts
@@ -55,7 +55,7 @@ describe('QDM Measure: Transmission Format', () => {
         cy.get(EditMeasurePage.transmissionFormatDescription).type('Test Transmission format')
         cy.get(Utilities.DiscardCancelBtn).click()
         Utilities.clickOnDiscardChanges()
-        cy.get(EditMeasurePage.transmissionFormatDescription).should('be.empty')
+        cy.get(EditMeasurePage.transmissionFormatDescription).should('not.contain.text')
     })
 })
 
@@ -90,7 +90,7 @@ describe('QDM Measure: Transmission format ownership validation', () => {
 
         //Navigate to References page
         cy.get(EditMeasurePage.leftPanelTransmissionFormat).click()
-        cy.get(EditMeasurePage.readOnlyTFDesc).should('have.attr', 'readonly')
+        cy.get(EditMeasurePage.transmissionFormatDescription).find('p').should('have.class', 'rich-text-editor_read_only')
     })
 })
 


### PR DESCRIPTION
Fixes both of these tests:
QDMMeasureTransmissionFormat.cy.ts
QDMMeasureSet.cy.ts

Summary
1. Update selectors
2. Change old `.should('be.empty')` to new `.should('not.contain.text')`
3. Update readonly checks to look for controlling class instead of attr