### PR TITLE
Regression Failure Fixes: Webinterface tests: ExportMeasureWithInfo test file

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
@@ -83,7 +83,7 @@ describe('QI-Core Measure Export with Info', () => {
                 // assert details for the expected warning
                 expect(elm.library.annotation[1].errorSeverity).to.eq('warning')
                 expect(elm.library.annotation[1].type).to.eq('CqlToElmError')
-                expect(elm.library.annotation[1].message).to.eq('An alias identifier [IP] is hiding another identifier of the same name.')
+                expect(elm.library.annotation[1].message).to.eq('An alias identifier IP is hiding another identifier of the same name.')
             })
         })
     })


### PR DESCRIPTION
This PR resolves failure seen with the ExportMeasureWithInfo test file.