### PR TITLE
fix: restore test steps, add html to function

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -47,7 +47,8 @@ export type MeasureObservations = {
     aggregateMethod: string,
     criteriaReference?: uuidv4,
     definition: string,
-    id?: uuidv4
+    id?: uuidv4,
+    description?: string
 }
 
 export class MeasureGroupPage {
@@ -782,38 +783,44 @@ export class MeasureGroupPage {
             {
                 "id": uuidv4(),
                 "name": "initialPopulation",
-                "definition": populations.initialPopulation
+                "definition": populations.initialPopulation,
+                "description": "<p>initial pop</p>"
             },
             {
                 "id": denomUuid,
                 "name": "denominator",
-                "definition": populations.denominator
+                "definition": populations.denominator,
+                "description": "<p>denom</p>"
             },
             {
                 "id": numUuid,
                 "name": "numerator",
-                "definition": populations.numerator
+                "definition": populations.numerator,
+                "description": "<p>num</p>"
             },
         ]
         if (populations.denomExclusion) {
             popsArray.push({
                 "id": uuidv4(),
                 "name": "denominatorExclusion",
-                "definition": populations.denomExclusion
+                "definition": populations.denomExclusion,
+                "description": "<p>denom exc</p>"
             })
         }
         if (populations.numExclusion) {
             popsArray.push({
                 "id": uuidv4(),
                 "name": "numeratorExclusion",
-                "definition": populations.numExclusion
+                "definition": populations.numExclusion,
+                "description": "<p>num exc</p>"
             })
         }
         if (populations.denomException) {
             popsArray.push({
                 "id": uuidv4(),
                 "name": "denominatorException",
-                "definition": populations.denomException
+                "definition": populations.denomException,
+                "description": "<p>denom exception</p>"
             })
         }
         // need this bc CV populations structure is different
@@ -823,17 +830,20 @@ export class MeasureGroupPage {
             {
                 "id": uuidv4(),
                 "name": "initialPopulation",
-                "definition": cvPopulations.initialPopulation
+                "definition": cvPopulations.initialPopulation,
+                "description": "<p>initial pop</p>"
             },
             {
                 "id": measureUuid,
                 "name": "measurePopulation",
-                "definition": cvPopulations.measurePopulation
+                "definition": cvPopulations.measurePopulation,
+                "description": "<p>measure pop</p>"
             },
             {
                 "id": uuidv4(),
                 "name": "measurePopulationExclusion",
-                "definition": cvPopulations.measurePopExclusion ? cvPopulations.measurePopExclusion : '' 
+                "definition": cvPopulations.measurePopExclusion ? cvPopulations.measurePopExclusion : '',
+                "description": "<p>measure exclusion</p>"
             }
             ]
             if (cvPopulations.observation) {

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ExpectedValuesForObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ExpectedValuesForObservations.cy.ts
@@ -41,11 +41,13 @@ describe('Ratio based measure with measure observations', () => {
         // all these declared values need to match your CQL definitions and functions
         const obs1: MeasureObservations = {
             aggregateMethod: 'Count',
-            definition: 'daysObs'
+            definition: 'daysObs',
+            description: '<p>obs1</p>'
         }
         const obs2: MeasureObservations = {
             aggregateMethod: 'Count',
-            definition: 'daysObs'
+            definition: 'daysObs',
+            description: '<p>obs2</p>'
         }
         MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.outcome, PopulationBasis.encounter, MeasureScoring.Ratio, pops, false, obs1, obs2)
 
@@ -68,6 +70,13 @@ describe('Ratio based measure with measure observations', () => {
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        // verify populations
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        cy.contains('span', 'Outcome').should('have.class', 'MuiChip-label')
+        cy.get('#populationBasis').should('have.value', 'Encounter')
+        cy.get('#scoring-select').should('have.text', 'Ratio')
 
         // got to test case
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -149,7 +158,6 @@ describe('Proportion based measure with no observations', () => {
         OktaLogin.Logout()
         Utilities.deleteMeasure(measure.name, measure.libName)
     })
-
 
     it('Test Case Export & Import - Persist expected values through the process', () => {
 


### PR DESCRIPTION
Refines the fix from https://github.com/MeasureAuthoringTool/madie-cypress/pull/2348

Restores the skipped checks & instead supplies all the needed HTML elements to ensure no dirty check pops.