### PR TITLE
fix: correct list tabs to new style

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
@@ -6,7 +6,6 @@ import { Utilities } from "../../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { Header } from "../../../../Shared/Header"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { LandingPage } from "../../../../Shared/LandingPage"
 
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
@@ -51,7 +50,7 @@ describe('QI-Core Measure Export with Info', () => {
         cy.get(Header.mainMadiePageButton).click()
 
         //wait until page / tabs loads
-        Utilities.waitForElementVisible(LandingPage.myMeasuresTab, 60000)
+        Utilities.waitForElementVisible(MeasuresPage.ownedMeasures, 60000)
 
         MeasuresPage.actionCenter('export', null, exportOptions)
         cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR6.zip', { timeout: 5500 })
@@ -117,7 +116,7 @@ describe('QI-Core Measure Export for Publish', () => {
         cy.get(Header.mainMadiePageButton).click()
 
         //wait until page / tabs loads
-        Utilities.waitForElementVisible(LandingPage.myMeasuresTab, 60000)
+        Utilities.waitForElementVisible(MeasuresPage.ownedMeasures, 60000)
 
         MeasuresPage.actionCenter('export', null, exportOptions)
         cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR6.zip', { timeout: 5500 })


### PR DESCRIPTION
Fixes ExportMeasureWithInfo.cy.ts

Updated waits to look for "Owned Measures" instead of "My Measures"