### PR TITLE
Regression failure fixes: Webinterface tests: EditMeasureOwnershipValidations test file 2211

### DIFF
--- a/cypress/Shared/LandingPage.ts
+++ b/cypress/Shared/LandingPage.ts
@@ -3,7 +3,7 @@ export class LandingPage {
     public static readonly header = '#madie-header'
     public static readonly newMeasureButton = '[data-testid="create-new-measure-button"]'
     public static readonly allMeasuresTab = '[data-testid=all-measures-tab]'
-    public static readonly myMeasuresTab = '[data-testid=my-measures-tab]'
+    public static readonly myMeasuresTab = '[data-testid=owned-measures-tab]'
 
     public static readonly lowerLogo = '[data-testid="custom-madie-logo"]'
     public static readonly version = '.madie-version'


### PR DESCRIPTION
This PR contains update to the LandingPage support file for the purpose of resolving a failure seen while running the Regression EditMeasureOwnershipValidations test file, during the last regression test suite execution.