### PR TITLE
fix: add waits to allow process to complete

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseExport.cy.ts
@@ -85,10 +85,10 @@ describe('QI-Core Single Test Case Export', () => {
     it('Non-owner of Measure: Export single QI-Core Test case', () => {
 
         OktaLogin.AltLogin()
-
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
         cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
         cy.get(MeasuresPage.allMeasuresTab).click()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
 
         MeasuresPage.actionCenter('edit')
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -122,10 +122,11 @@ describe('Test Case Import: functionality tests', () => {
         Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
         //Login as ALT User
         OktaLogin.AltLogin()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
 
         //navigating to the All Measures tab
-        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 35000)
         cy.get(MeasuresPage.allMeasuresTab).click()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')


### PR DESCRIPTION
Fixes TestCaseImportValidations.cy.ts & TestCaseExport.cy.ts

Both needed the same change - added waits for measure list page to fully load before advancing test steps.