### PR TITLE
Regression Failure fixes: Webinterface tests: files for the CQL Editor Builder: Definitions tab, Functions tab, and the Parameters tab

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -80,6 +80,7 @@ export class CQLEditorPage {
 
     //CQL Builder Sub tabs
     public static readonly expandCQLBuilder = '[data-testid="KeyboardTabOutlinedIcon"]'
+    public static readonly collapseCQLBuilder = '[data-testid="collapsed-button"]'
 
     //Includes page
     public static readonly editLibraryAliasInput = '[data-testid="library-alias-input"]'

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLDefinitions.cy.ts
@@ -459,12 +459,16 @@ describe('QDM CQL Definitions - Expression Editor Name Option Validations', () =
         cy.get(CQLEditorPage.savedDefinitionsTab).should('contain.text', 'Saved Definitions (7)')
 
         //Add errors to CQL
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}define "test":')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}{enter}define \"test\":{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).wait(700).click()
 
         //Navigate to Definitions tab
         cy.get(CQLEditorPage.expandCQLBuilder).click()
-        cy.get(CQLEditorPage.definitionsTab).click()
+        cy.get(CQLEditorPage.collapseCQLBuilder).wait(1000).click()
+        cy.get(CQLEditorPage.expandCQLBuilder).click()
+        cy.get(CQLEditorPage.functionsTab).wait(1000).click()
+        cy.get(CQLEditorPage.definitionsTab).wait(1000).click()
+        Utilities.waitForElementVisible('[data-testid="cql-builder-errors"]', 90000)
         cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
 
         //Navigate to Saved Definitions tab
@@ -552,7 +556,7 @@ describe('QDM CQL Definitions - Measure ownership Validations', () => {
     it('Verify Non Measure owner unable to Edit/Delete saved Definitions', () => {
 
         //Navigate to All Measures page
-        cy.get(MeasuresPage.allMeasuresTab).click()
+        cy.get(MeasuresPage.allMeasuresTab).wait(1000).click()
         MeasuresPage.actionCenter('view')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLFunctions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLFunctions.cy.ts
@@ -234,12 +234,18 @@ describe('QDM CQL Functions', () => {
         cy.get(CQLEditorPage.savedFunctionsTab).should('contain.text', 'Saved Functions (3)')
 
         //Add errors to CQL
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}define "test":')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}{enter}define \"test\":{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).wait(1000).click()
+
 
         //Navigate to Functions tab
+        cy.get(CQLEditorPage.expandCQLBuilder).wait(1000).click()
+
+        cy.get(CQLEditorPage.collapseCQLBuilder).wait(1000).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()
-        cy.get(CQLEditorPage.functionsTab).click()
+        cy.get(CQLEditorPage.definitionsTab).wait(1000).click()
+        cy.get(CQLEditorPage.functionsTab).wait(1000).click()
+
         cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
 
         //Navigate to Saved Functions tab

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLParameters.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCQLParameters.cy.ts
@@ -278,6 +278,8 @@ describe('QDM CQL Parameters', () => {
 
         //Navigate to Parameters tab
         cy.get(CQLEditorPage.expandCQLBuilder).click()
+        cy.get(CQLEditorPage.collapseCQLBuilder).wait(1000).click()
+        cy.get(CQLEditorPage.expandCQLBuilder).click()
         cy.get(CQLEditorPage.parametersTab).click()
         cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
 
@@ -398,6 +400,7 @@ describe('QDM CQL Parameters - Measure ownership Validations', () => {
 
         //Navigate to All Measures page
         cy.get(MeasuresPage.allMeasuresTab).click()
+        cy.reload()
         MeasuresPage.actionCenter('view')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()


### PR DESCRIPTION
This PR updates the necessary test files.