### PR TITLE
Regression failure fixes: Webinterface tests: VersionedMeasure_CreateEditDeleteTestCase test file 2211

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
@@ -161,6 +161,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
         //verify user can delete newly created test case after versioning
         TestCasesPage.checkTestCase(2)
+        TestCasesPage.checkTestCase(2)
 
         cy.get(TestCasesPage.actionCenterDelete).should('be.enabled')
 


### PR DESCRIPTION
This PR resolves issue seen while executing the VersionedMeasure_CreateEditDeleteTestCase test file, during the last regression run.