### PR TITLE
fix: repair test with new measure

### DIFF
--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -29,8 +29,8 @@ export enum MeasureScoring {
 // valid for proportion, cohort, ratio
 export type MeasureGroups = {
     initialPopulation: string,
-    denominator: string,
-    numerator: string,
+    denominator?: string,
+    numerator?: string,
     denomExclusion?: string,
     numExclusion?: string,
     denomException?: string,
@@ -768,7 +768,6 @@ export class MeasureGroupPage {
         let measureGroupPath = 'cypress/fixtures/groupId'
         const numUuid = uuidv4()
         const denomUuid = uuidv4()
-
         if (denominatorObservation) {
             denominatorObservation.id = uuidv4()
             denominatorObservation.criteriaReference = denomUuid
@@ -785,20 +784,24 @@ export class MeasureGroupPage {
                 "name": "initialPopulation",
                 "definition": populations.initialPopulation,
                 "description": "<p>initial pop</p>"
-            },
-            {
+            }
+        ]
+        if (populations.denominator) {
+            popsArray.push({
                 "id": denomUuid,
                 "name": "denominator",
                 "definition": populations.denominator,
                 "description": "<p>denom</p>"
-            },
-            {
+            })
+        }
+        if (populations.numerator) {
+            popsArray.push({
                 "id": numUuid,
                 "name": "numerator",
                 "definition": populations.numerator,
                 "description": "<p>num</p>"
-            },
-        ]
+            })
+        }
         if (populations.denomExclusion) {
             popsArray.push({
                 "id": uuidv4(),

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -3,6 +3,7 @@ import { Environment } from "./Environment"
 import { Utilities } from "./Utilities"
 import dateTimeISO = CypressCommandLine.dateTimeISO
 import { CQLEditorPage } from "./CQLEditorPage"
+import { MeasuresPage } from "./MeasuresPage"
 
 export type TestCase = {
     title: string,
@@ -908,6 +909,7 @@ export class TestCasesPage {
                 cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled').click()
 
                 cy.readFile('cypress/fixtures/measureId').should('exist').then((id) => {
+                    Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
                     cy.get('[data-testid="measure-name-' + id + '_select"]')
                         .find('input')
                         .focus()


### PR DESCRIPTION
Updates TestCaseCopyToNewMeasure.cy.ts

During last regression cycle, this test started failing because the PROD measure it relied on was deleted during a Help Desk investigation.
This PR reconfigures the test scenario to look at another PROD measure. Most changes are only to account for this, although I did reduce the actual "copy to" action to 1 test case instead of "all" for performance reasons.

Also, this PR enhances `MeasureGroupPage.CreateMeasureGroupAPI()` to better support Cohort measures by only requiring declaration of IP instead of IP, Denom, and Num.