### PR TITLE
fix: update export file names, various others

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -191,7 +191,7 @@ export class EditMeasurePage {
     public static readonly measureDevelopersAlertMsg = '[data-testid="developers-helper-text"]'
 
     //Description Page
-    public static readonly measureDescriptionRTETextBox = '[data-testid="generic-field-rich-text-editor"]'
+    public static readonly measureDescriptionRTETextBox = '[data-testid="rich-text-editor-content"]'
     public static readonly measureDescriptionSaveButton = '[data-testid="measure-description-save"]'
     public static readonly measureDescriptionSuccessMessage = '[data-testid="measureDescriptionSuccess"]'
 

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/MeasureButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/MeasureButtons.cy.ts
@@ -8,7 +8,6 @@ import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { Header } from "../../../../Shared/Header"
 import { Environment } from "../../../../Shared/Environment"
-import { LandingPage } from "../../../../Shared/LandingPage"
 import { QdmCql } from "../../../../Shared/QDMMeasuresCQL"
 
 const path = require('path')
@@ -18,12 +17,12 @@ const { deleteDownloadsFolderBeforeEach } = require('cypress-delete-downloads-fo
 let randValue = (Math.floor((Math.random() * 1000) + 1))
 let measureCQLPFTests = MeasureCQL.CQL_Populations
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
+let qdmMeasureCQL = QdmCql.simpleQDM_CQL
 let measureQICore = ''
 let measureQDM = ''
 let qdmCQLLibrary = ''
 let qiCoreCQLLibrary = ''
 let harpUserALT = Environment.credentials().harpUserALT
-let qdmMeasureCQL = QdmCql.simpleQDM_CQL
 
 const measureData: CreateMeasureOptions = {}
 
@@ -313,7 +312,7 @@ describe('Export measure on the Edit Measure page', () => {
     })
 
     it('Export QiCore 4.1.1 measure', () => {
-        const exportName = 'eCQMTitle4QICore-v0.0.000-FHIR4.zip'
+        const exportName = 'eCQMTitle4QICore-v0.0.000-FHIR.zip'
         const fullPathToExport = path.join(downloadsFolder, exportName)
 
         OktaLogin.Login()

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportExtensionsValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportExtensionsValidations.cy.ts
@@ -58,10 +58,10 @@ describe('Check extensions data in QiCore 4.1.1 export', () => {
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('export')
-        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR4.zip', {timeout: 5500})
+        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR.zip', {timeout: 5500})
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', {zipFile: 'AutoTestTitle-v0.0.000-FHIR4.zip', path: downloadsFolder})
+        cy.task('unzipFile', {zipFile: 'AutoTestTitle-v0.0.000-FHIR.zip', path: downloadsFolder})
             .then(results => {
                 cy.log('unzipFile Task finished')
                 cy.wait(1000)
@@ -109,10 +109,10 @@ describe('Check extensions data in QiCore 6.0.0 export', () => {
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('export')
-        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR6.zip', {timeout: 5500})
+        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR.zip', {timeout: 5500})
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', {zipFile: 'AutoTestTitle-v0.0.000-FHIR6.zip', path: downloadsFolder})
+        cy.task('unzipFile', {zipFile: 'AutoTestTitle-v0.0.000-FHIR.zip', path: downloadsFolder})
             .then(results => {
                 cy.log('unzipFile Task finished')
                 cy.wait(1000)

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/ExportMeasureWithInfo.cy.ts
@@ -53,10 +53,10 @@ describe('QI-Core Measure Export with Info', () => {
         Utilities.waitForElementVisible(MeasuresPage.ownedMeasures, 60000)
 
         MeasuresPage.actionCenter('export', null, exportOptions)
-        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR6.zip', { timeout: 5500 })
+        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR.zip', { timeout: 5500 })
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', { zipFile: 'AutoTestTitle-v0.0.000-FHIR6.zip', path: downloadsFolder })
+        cy.task('unzipFile', { zipFile: 'AutoTestTitle-v0.0.000-FHIR.zip', path: downloadsFolder })
             .then(results => {
                 cy.log('unzipFile Task finished')
                 cy.wait(1000)
@@ -119,10 +119,10 @@ describe('QI-Core Measure Export for Publish', () => {
         Utilities.waitForElementVisible(MeasuresPage.ownedMeasures, 60000)
 
         MeasuresPage.actionCenter('export', null, exportOptions)
-        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR6.zip', { timeout: 5500 })
+        cy.verifyDownload('AutoTestTitle-v0.0.000-FHIR.zip', { timeout: 5500 })
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', { zipFile: 'AutoTestTitle-v0.0.000-FHIR6.zip', path: downloadsFolder })
+        cy.task('unzipFile', { zipFile: 'AutoTestTitle-v0.0.000-FHIR.zip', path: downloadsFolder })
             .then(results => {
                 cy.log('unzipFile Task finished')
                 cy.wait(1000)

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
@@ -13,7 +13,7 @@ const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
 const measureCQL = MeasureCQL.zipfileExportQICore
-const expectedFileName = 'eCQMTitle4QICore-v0.0.000-FHIR4.zip'
+const expectedFileName = 'eCQMTitle4QICore-v0.0.000-FHIR.zip'
 
 describe('FHIR Measure Export, Not the Owner', () => {
 

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
@@ -114,7 +114,7 @@ describe('QI-Core Measure Export', () => {
 
         MeasuresPage.actionCenter('export')
 
-        cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR4.zip', { timeout: 15000 })
+        cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR.zip', { timeout: 15000 })
         cy.log('Successfully verified zip file export')
 
         OktaLogin.Logout()
@@ -122,10 +122,10 @@ describe('QI-Core Measure Export', () => {
 
     it('Unzip the downloaded file and verify file types for QI-Core Measure', () => {
 
-        cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR4.zip', { timeout: 15000 })
+        cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR.zip', { timeout: 15000 })
 
         // unzipping the Measure Export
-        cy.task('unzipFile', { zipFile: 'eCQMTitle4QICore-v1.0.000-FHIR4.zip', path: downloadsFolder })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QICore-v1.0.000-FHIR.zip', path: downloadsFolder })
             .then(results => {
                 cy.log('unzipFile Task finished')
             })
@@ -184,10 +184,10 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
         MeasuresPage.actionCenter('export')
 
         //verify zip file exists
-        cy.verifyDownload('eCQMTitle4QICore-v0.0.000-FHIR4.zip', { timeout: 5500 })
+        cy.verifyDownload('eCQMTitle4QICore-v0.0.000-FHIR.zip', { timeout: 5500 })
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', { zipFile: 'eCQMTitle4QICore-v0.0.000-FHIR4.zip', path: downloadsFolder })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QICore-v0.0.000-FHIR.zip', path: downloadsFolder })
             .then(results => {
                 cy.log('unzipFile Task finished')
             })
@@ -195,7 +195,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
 
     it('Verify content of a Qi Core measure HR file, before versioning', () => {
 
-        cy.verifyDownload('eCQMTitle4QICore-v0.0.000-FHIR4.zip', { timeout: 15000 })
+        cy.verifyDownload('eCQMTitle4QICore-v0.0.000-FHIR.zip', { timeout: 15000 })
 
         //remove the baseUrl so that we can visit a local file
         Cypress.config('baseUrl', null)
@@ -229,9 +229,9 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
                 '[http://terminology.hl7.org/CodeSystem/measure-type#outcome: \'Outcome\']\nRate Aggregation\t\n\n' +
                 'test rA\n\n\nImprovement Notation\t[http://terminology.hl7.org/CodeSystem/measure-improvement-notation#increase: ' +
                 '\'Increased score indicates improvement\']\nInitial Population\tID: InitialPopulation_1\nDescription:\n\n' +
-                'test IP P\n\nLogic Definition: Qualifying Encounters\nDenominator\tID: Denominator_1\nDescription:\n\n' +
-                'test d P\n\nLogic Definition: Qualifying Encounters\nNumerator\tID: Numerator_1\nDescription:\n\ntest n P\n\n' +
-                'Logic Definition: Qualifying Encounters\nMeasure Logic\nPrimary Library\t' +
+                'test IP P\n\nCriteria: Qualifying Encounters\nDenominator\tID: Denominator_1\nDescription:\n\n' +
+                'test d P\n\nCriteria: Qualifying Encounters\nNumerator\tID: Numerator_1\nDescription:\n\ntest n P\n\n' +
+                'Criteria: Qualifying Encounters\nMeasure Logic\nPrimary Library\t' +
                 'https://madie.cms.gov/Library/'+ CqlLibraryNameFC + '\nContents\tPopulation Criteria\n' +
                 'Logic Definitions\nTerminology\nDependencies\nData Requirements')
 
@@ -248,7 +248,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
                 '    union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
                 '    union [Encounter: "Home Healthcare Services"] ) ValidEncounter\n' +
                 '    where ValidEncounter.period during "Measurement Period"\n' +
-                '\n' +
+                'Definition\n' +
                 'Denominator\n' +
                 '\n' +
                 'define "Qualifying Encounters":\n' +
@@ -258,7 +258,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
                 '    union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
                 '    union [Encounter: "Home Healthcare Services"] ) ValidEncounter\n' +
                 '    where ValidEncounter.period during "Measurement Period"\n' +
-                '\n' +
+                'Definition\n' +
                 'Numerator\n' +
                 '\n' +
                 'define "Qualifying Encounters":\n' +
@@ -356,7 +356,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
                 'Path: type\n' +
                 'ValueSet: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\n' +
                 '\n' +
-                'Generated using version 0.4.8 of the sample-content-ig Liquid templates')
+                'Generated using version 0.4.9 of the sample-content-ig Liquid templates')
         })
     })
 })
@@ -418,10 +418,10 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
         MeasuresPage.actionCenter('export')
 
         //verify zip file exists
-        cy.readFile('cypress/downloads/eCQMTitle4QICore-v1.0.000-FHIR4.zip', { timeout: 500000 }).should('exist')
+        cy.readFile('cypress/downloads/eCQMTitle4QICore-v1.0.000-FHIR.zip', { timeout: 500000 }).should('exist')
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', { zipFile: 'eCQMTitle4QICore-v1.0.000-FHIR4.zip', path: downloadsFolder })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QICore-v1.0.000-FHIR.zip', path: downloadsFolder })
             .then(results => {
                 cy.log('unzipFile Task finished')
             })
@@ -429,7 +429,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
 
     it('Verify the content of the HR file, for a Qi Core Measure, after the measure has been versioned', () => {
 
-        cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR4.zip', { timeout: 15000 })
+        cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR.zip', { timeout: 15000 })
 
         //remove the baseUrl so that we can visit a local file
         Cypress.config('baseUrl', null)
@@ -462,9 +462,9 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
                 '[http://terminology.hl7.org/CodeSystem/measure-type#outcome: \'Outcome\']\nRate Aggregation\t\n\n' +
                 'test rA\n\n\nImprovement Notation\t[http://terminology.hl7.org/CodeSystem/measure-improvement-notation#increase:' +
                 ' \'Increased score indicates improvement\']\nInitial Population\tID: InitialPopulation_1\nDescription:\n\n' +
-                'test IP P\n\nLogic Definition: Qualifying Encounters\nDenominator\tID: Denominator_1\nDescription:\n\n' +
-                'test d P\n\nLogic Definition: Qualifying Encounters\nNumerator\tID: Numerator_1\nDescription:\n\n' +
-                'test n P\n\nLogic Definition: Qualifying Encounters\nMeasure Logic\nPrimary Library\t' +
+                'test IP P\n\nCriteria: Qualifying Encounters\nDenominator\tID: Denominator_1\nDescription:\n\n' +
+                'test d P\n\nCriteria: Qualifying Encounters\nNumerator\tID: Numerator_1\nDescription:\n\n' +
+                'test n P\n\nCriteria: Qualifying Encounters\nMeasure Logic\nPrimary Library\t' +
                 'https://madie.cms.gov/Library/' + CqlLibraryNameFC + '\nContents\tPopulation Criteria\n' +
                 'Logic Definitions\nTerminology\nDependencies\nData Requirements')
 
@@ -480,7 +480,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
                 '    union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
                 '    union [Encounter: "Home Healthcare Services"] ) ValidEncounter\n' +
                 '    where ValidEncounter.period during "Measurement Period"\n' +
-                '\n' +
+                'Definition\n' +
                 'Denominator\n' +
                 '\n' +
                 'define "Qualifying Encounters":\n' +
@@ -490,7 +490,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
                 '    union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"]\n' +
                 '    union [Encounter: "Home Healthcare Services"] ) ValidEncounter\n' +
                 '    where ValidEncounter.period during "Measurement Period"\n' +
-                '\n' +
+                'Definition\n' +
                 'Numerator\n' +
                 '\n' +
                 'define "Qualifying Encounters":\n' +
@@ -588,7 +588,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
                 'Path: type\n' +
                 'ValueSet: http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\n' +
                 '\n' +
-                'Generated using version 0.4.8 of the sample-content-ig Liquid templates')
+                'Generated using version 0.4.9 of the sample-content-ig Liquid templates')
         })
     })
 })


### PR DESCRIPTION
Part 1 of https://jira.cms.gov/browse/MAT-9018

We have several tests impacted by this small change. This PR includes all tests from Measure/ and Smoke/ that needed the update.
The majority of changes were very simple: remove the 4 or 6 designating the FHIR version from the expected file name.
See comments below for additional changes.