### PR TITLE
fix: remove steps, remove import scenario

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseID/QDMTestCaseID.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseID/QDMTestCaseID.cy.ts
@@ -303,7 +303,6 @@ describe('QDM Measure - Test case number on a Draft Measure', () => {
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
         cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
-       // cy.get(TestCasesPage.createTestCaseDescriptionInput).focus()
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCase2.description)
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')


### PR DESCRIPTION
Fixes QDMTestcaseID.cy.ts

1. Removes QDM import scenario completely - no longer a feature in Madie.
2. Remove several steps from remaining tests that were not necessary.
