### PR TITLE
Regression failure fixes: Webinterface Tests: Several files related to RTE field references

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -191,37 +191,31 @@ export class EditMeasurePage {
     public static readonly measureDevelopersAlertMsg = '[data-testid="developers-helper-text"]'
 
     //Description Page
-    public static readonly measureDescriptionRTETextBox = '[data-testid="rich-text-editor-content"]'
+    public static readonly measureGenericFieldRTETextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureDescriptionSaveButton = '[data-testid="measure-description-save"]'
     public static readonly measureDescriptionSuccessMessage = '[data-testid="measureDescriptionSuccess"]'
 
     //Copyright Page
-    public static readonly measureCopyrightTextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureCopyrightSaveButton = '[data-testid="measure-copyright-save"]'
     public static readonly measureCopyrightSuccessMessage = '[data-testid="measureCopyrightSuccess"]'
 
     //Disclaimer Page
-    public static readonly measureDisclaimerTextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureDisclaimerSaveButton = '[data-testid="measure-disclaimer-save"]'
     public static readonly measureDisclaimerSuccessMessage = '[data-testid="measureDisclaimerSuccess"]'
 
     //Rationale Page
-    public static readonly measureRationaleTextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureRationaleSaveButton = '[data-testid="measure-rationale-save"]'
     public static readonly measureRationaleSuccessMessage = '[data-testid="measureRationaleSuccess"]'
 
     //Purpose
-    public static readonly measurePurposeTextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measurePurposeSaveBtn = '[data-testid="measure-purpose-save"]'
     public static readonly measurePurposeSavedMsg = '[data-testid="measurePurposeSuccess"]'
 
     //Guidance Page
-    public static readonly measureGuidanceTextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureGuidanceSaveButton = '[data-testid="measure-guidance-usage-save"]'
     public static readonly measureGuidanceSuccessMessage = '[data-testid="measureGuidance (Usage)Success"]'
 
     //Clinical Guidance / Recommendation Page
-    public static readonly measureClinicalRecommendationTextBox = '[data-testid="generic-field-rich-text-editor"]'
     public static readonly measureClinicalRecommendationSaveButton = '[data-testid="measure-clinical-recommendation-statement-save"]'
     public static readonly measureClinicalRecommendationSuccessMessage = '[data-testid="measureClinical Recommendation StatementSuccess"]'
 

--- a/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/CreateMeasure/CreateMeasureValidations.cy.ts
@@ -200,19 +200,19 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
 
         //type some value in the text box and, then, clear text box
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('exist')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.visible')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).type('Some test value')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('be.visible')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('Some test value')
         cy.get(Utilities.DiscardButton).click()
         Utilities.clickOnDiscardChanges()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('not.contain.text')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('not.contain.text')
 
         //type some value in the text box and save it
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('exist')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.visible')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).type('Some test value')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('be.visible')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('Some test value')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('exist')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('be.visible')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).should('be.enabled')
@@ -241,7 +241,7 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).should('be.visible')
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
 
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('contain.text', 'Some test value')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', 'Some test value')
 
         //if new changes are made to Clinical Recommendation but, then, discarded, the previous value appears
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -258,19 +258,19 @@ describe('Validations on Measure Details page', () => {
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
 
         //clear current value
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('exist')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.visible')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).type('{selectAll}{del}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('be.visible')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{selectAll}{del}')
 
         //enter some new value that will not be saved
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('exist')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('be.visible')
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).type('Some new test value')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('be.visible')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('Some new test value')
         cy.get(Utilities.DiscardButton).click()
         Utilities.clickOnDiscardChanges()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('contain.text', 'Some test value')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', 'Some test value')
     })
 })
 

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
@@ -3,11 +3,11 @@ import { CreateMeasurePage, SupportedModels } from "../../../../Shared/CreateMea
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { Header } from "../../../../Shared/Header"
-import {MadieObject, PermissionActions, Utilities} from "../../../../Shared/Utilities"
+import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
 import { QiCore4Cql } from "../../../../Shared/FHIRMeasuresCQL"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import {Environment} from "../../../../Shared/Environment"
+import { Environment } from "../../../../Shared/Environment"
 
 const now = Date.now()
 let randValue = (Math.floor((Math.random() * 1000) + 1))
@@ -67,25 +67,25 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).clear().type(description)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(description)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
 
         //Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).clear().type(copyright)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(copyright)
         cy.get(EditMeasurePage.measureCopyrightSaveButton).click()
         cy.get(EditMeasurePage.measureCopyrightSuccessMessage).should('be.visible')
 
         //Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).clear().type(disclaimer)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(disclaimer)
         cy.get(EditMeasurePage.measureDisclaimerSaveButton).click()
         cy.get(EditMeasurePage.measureDisclaimerSuccessMessage).should('be.visible')
 
         //Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).clear().type(rationale)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(rationale)
         cy.get(EditMeasurePage.measureRationaleSaveButton).click()
         cy.get(EditMeasurePage.measureRationaleSuccessMessage).should('be.visible')
 
@@ -109,8 +109,8 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Purpose
         cy.get(EditMeasurePage.leftPanelPurpose).click()
-        Utilities.waitForElementVisible(EditMeasurePage.measurePurposeTextBox, 50000)
-        cy.get(EditMeasurePage.measurePurposeTextBox).type('This is a purpose.')
+        Utilities.waitForElementVisible(EditMeasurePage.measureGenericFieldRTETextBox, 50000)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('This is a purpose.')
         cy.get(EditMeasurePage.measurePurposeSaveBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.measurePurposeSavedMsg, 50000)
         cy.get(EditMeasurePage.measurePurposeSavedMsg).should('contain.text', 'Measure Purpose Information Saved Successfully')
@@ -120,13 +120,13 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).clear().type(guidance)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(guidance)
         cy.get(EditMeasurePage.measureGuidanceSaveButton).click()
         cy.get(EditMeasurePage.measureGuidanceSuccessMessage).should('be.visible')
 
         //Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).clear().type(clinicalRecommendation)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(clinicalRecommendation)
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
@@ -167,46 +167,46 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).should('contain.text', description)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', description)
         cy.log('Measure Description added successfully')
 
         //copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).should('contain.text', copyright)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', copyright)
         cy.log('Measure Copyright added successfully')
 
         //disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).should('contain.text', disclaimer)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', disclaimer)
         cy.log('Measure Disclaimer added successfully')
 
         //rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).should('contain.text', rationale)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', rationale)
         cy.log('Measure Rationale added successfully')
 
         //Purpose
         cy.get(EditMeasurePage.leftPanelPurpose).click()
-        cy.get(EditMeasurePage.measurePurposeTextBox).should('contain.text', 'This is a purpose.')
-        cy.get(EditMeasurePage.measurePurposeTextBox).clear().type('This is a purpose updated.')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', 'This is a purpose.')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('This is a purpose updated.')
         cy.get(EditMeasurePage.measurePurposeSaveBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.measurePurposeSavedMsg, 50000)
         cy.get(EditMeasurePage.measurePurposeSavedMsg).should('contain.text', 'Measure Purpose Information Saved Successfully')
         Utilities.waitForElementToNotExist(EditMeasurePage.measurePurposeSavedMsg, 50000)
         cy.reload()
-        Utilities.waitForElementVisible(EditMeasurePage.measurePurposeTextBox, 50000)
-        cy.get(EditMeasurePage.measurePurposeTextBox).should('contain.text', 'This is a purpose updated.')
+        Utilities.waitForElementVisible(EditMeasurePage.measureGenericFieldRTETextBox, 50000)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', 'This is a purpose updated.')
         cy.log('Measure Purpose updated successfully')
 
 
         //guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).should('contain.text', guidance)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', guidance)
         cy.log('Measure Guidance added successfully')
 
         //Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).should('contain.text', clinicalRecommendation)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', clinicalRecommendation)
         cy.log('Measure Clinical Recommendation added successfully')
 
         //definition

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureOwnershipValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureOwnershipValidations.cy.ts
@@ -76,23 +76,23 @@ describe('Read only for measure, measure group, and test cases that user does no
 
         cy.get(EditMeasurePage.leftPanelDescription).should('be.visible')
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
 
         cy.get(EditMeasurePage.leftPanelCopyright).should('be.visible')
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
 
         cy.get(EditMeasurePage.leftPanelDisclaimer).should('be.visible')
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
 
         cy.get(EditMeasurePage.leftPanelRationale).should('be.visible')
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
 
         cy.get(EditMeasurePage.leftPanelGuidance).should('be.visible')
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
 
 
         cy.get(EditMeasurePage.leftPanelQiCoreDefinition).should('be.visible')

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/RTEField.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/RTEField.cy.ts
@@ -40,15 +40,17 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).clear()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).type('{selectAll}{backspace}')
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).type(description)
+        //measureGenericFieldRTETextBox
+        //measureDescriptionRTETextBox
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).type('{selectAll}{backspace}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).type(description)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).wait(1500).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
         //apply RTE field formatting
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).type('{selectAll}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{selectAll}')
         cy.get(EditMeasurePage.frmtBoldBtn).click()
         cy.get(EditMeasurePage.frmtItalicizeBtn).click()
         cy.get(EditMeasurePage.frmtUnderlineBtn).click()
@@ -59,7 +61,7 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
         //confirm html formatting that is in the field
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><ol><li><p><strong><em><del><u>description</u></del></em></strong></p></li></ol></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><ol><li><p><strong><em><del><u>description</u></del></em></strong></p></li></ol></div>')
     })
 
     it('Verify the entry, undo, redo, bulletted list, embedded table, save and the resulting HTML text formatting that in the RTE field', () => {
@@ -71,34 +73,34 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).clear()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).type('{selectAll}{backspace}')
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).type(description)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).type('{selectAll}{backspace}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).type(description)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).wait(1500).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
         //apply RTE field formatting
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).type('{selectAll}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{selectAll}')
         cy.get(EditMeasurePage.frmtBoldBtn).click()
         cy.get(EditMeasurePage.frmtItalicizeBtn).click()
         cy.get(EditMeasurePage.frmtUnderlineBtn).click()
         cy.get(EditMeasurePage.frmtStrikeThroughBtn).wait(1500).click({ force: true })
         cy.get(EditMeasurePage.measureDescriptionSaveButton).focus()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><del><u>description</u></del></em></strong></p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><del><u>description</u></del></em></strong></p></div>')
 
 
         //undo
         cy.get(EditMeasurePage.rteToolBar).find(EditMeasurePage.unDoBtn).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).click({ force: true })
         cy.get(EditMeasurePage.measureDescriptionSaveButton).focus()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><u>description</u></em></strong></p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><u>description</u></em></strong></p></div>')
 
         //redo
         cy.get(EditMeasurePage.rteToolBar).find(EditMeasurePage.reDoBtn).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).click({ force: true })
         cy.get(EditMeasurePage.measureDescriptionSaveButton).focus()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><del><u>description</u></del></em></strong></p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><del><u>description</u></del></em></strong></p></div>')
 
         //bulletted list
         cy.get(EditMeasurePage.bulletedListBtn).click()
@@ -107,19 +109,19 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
         //add embedded table
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.embdTableBtn).click()
 
         //confirm html formatting that is in the field
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).click({ force: true }).wait(500)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).click({ force: true }).wait(500)
 
         //save
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><del><u>description</u></del></em></strong></p><p><br class="ProseMirror-trailingBreak"></p><div class="tableWrapper"><table style="min-width: 75px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><strong><em><del><u>description</u></del></em></strong></p><p><br class="ProseMirror-trailingBreak"></p><div class="tableWrapper"><table style="min-width: 75px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
     })
 })
 
@@ -149,21 +151,21 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.leftPanelDescription).click()
 
         //add embedded table
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
         cy.get(EditMeasurePage.embdTableBtn).click()
 
 
 
 
         //confirm html formatting that is in the field
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).wait(1500).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(1500).click({ force: true })
 
         //save
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><div class="tableWrapper"><table style="min-width: 75px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><div class="tableWrapper"><table style="min-width: 75px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
 
         //add row above, row below, column left, column right and confirm
         cy.get(EditMeasurePage.embdTableAddRowAboveBtn).wait(1500).click()
@@ -176,7 +178,7 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><div class="tableWrapper"><table style="min-width: 100px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><div class="tableWrapper"><table style="min-width: 100px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
 
         //remove two rows, remove two columns and confirm
         cy.get(EditMeasurePage.embdTableRemoveRowBtn).wait(1500).click()
@@ -184,7 +186,7 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.embdTableRemoveColBtn).wait(1500).click()
         cy.get(EditMeasurePage.embdTableRemoveColBtn).wait(1500).click({ force: true })
         cy.get(EditMeasurePage.measureDescriptionSaveButton).focus()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><div class="tableWrapper"><table style="min-width: 50px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><div class="tableWrapper"><table style="min-width: 50px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div></div>')
 
         //remove embedded table, entirely
         cy.get(EditMeasurePage.embdTableRemoveTblBtn).wait(1500).click({ force: true })
@@ -194,7 +196,7 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 90000)
 
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><br class="ProseMirror-trailingBreak"></p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p><br class="ProseMirror-trailingBreak"></p></div>')
 
 
     })

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociation.cy.ts
@@ -409,34 +409,34 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}{backspace}')
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).wait(500).type(QDMdescription).wait(2000)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}{backspace}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).wait(500).type(QDMdescription).wait(2000)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
 
         //Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).type(QDMcopyright)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMcopyright)
         cy.get(EditMeasurePage.measureCopyrightSaveButton).click()
         cy.get(EditMeasurePage.measureCopyrightSuccessMessage).should('be.visible')
 
         //Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).type(QDMdisclaimer)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMdisclaimer)
         cy.get(EditMeasurePage.measureDisclaimerSaveButton).click()
         cy.get(EditMeasurePage.measureDisclaimerSuccessMessage).should('be.visible')
 
         //Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).type(QDMrationale)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMrationale)
         cy.get(EditMeasurePage.measureRationaleSaveButton).click()
         cy.get(EditMeasurePage.measureRationaleSuccessMessage).should('be.visible')
 
@@ -464,17 +464,17 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).type(QDMguidance)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMguidance)
         cy.get(EditMeasurePage.measureGuidanceSaveButton).click()
         cy.get(EditMeasurePage.measureGuidanceSuccessMessage).should('be.visible')
 
         //Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).type(QDMclinicalRecommendation)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMclinicalRecommendation)
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
@@ -542,27 +542,27 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdescription + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdescription + '</p></div>')
 
         //Confirm Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMcopyright + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMcopyright + '</p></div>')
 
         //Confirm Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdisclaimer + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdisclaimer + '</p></div>')
 
         //Confirm Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMrationale + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMrationale + '</p></div>')
 
         //Confirm Steward & Developers
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()
@@ -576,15 +576,15 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMguidance + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMguidance + '</p></div>')
 
         //Confirm Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMclinicalRecommendation + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMclinicalRecommendation + '</p></div>')
     })
 })
 
@@ -1092,23 +1092,23 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdescription + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdescription + '</p></div>')
 
         //Confirm Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMcopyright + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMcopyright + '</p></div>')
 
         //Confirm Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdisclaimer + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMdisclaimer + '</p></div>')
 
         //Confirm Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureRationaleTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMrationale + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMrationale + '</p></div>')
 
         //Confirm Steward & Developers
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()
@@ -1122,13 +1122,13 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMguidance + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMguidance + '</p></div>')
 
         //Confirm Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMclinicalRecommendation + '</p></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div contenteditable="true" role="textbox" translate="no" class="tiptap ProseMirror" tabindex="0"><p>' + QDMclinicalRecommendation + '</p></div>')
     })
 })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
@@ -24,7 +24,7 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
-      
+
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -42,25 +42,25 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureDescriptionRTETextBox).clear().type('Percentage of cataract surgeries for patients aged 18 and older with a diagnosis of uncomplicated cataract and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following the cataract surgery')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Percentage of cataract surgeries for patients aged 18 and older with a diagnosis of uncomplicated cataract and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following the cataract surgery')
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
 
         //Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureCopyrightTextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureCopyrightSaveButton).click()
         cy.get(EditMeasurePage.measureCopyrightSuccessMessage).should('be.visible')
 
         //Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureDisclaimerTextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureDisclaimerSaveButton).click()
         cy.get(EditMeasurePage.measureDisclaimerSuccessMessage).should('be.visible')
 
         //Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureRationaleTextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureRationaleSaveButton).click()
         cy.get(EditMeasurePage.measureRationaleSuccessMessage).should('be.visible')
 
@@ -84,13 +84,13 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
 
         //Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGuidanceTextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureGuidanceSaveButton).click()
         cy.get(EditMeasurePage.measureGuidanceSuccessMessage).should('be.visible')
 
         //Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureClinicalRecommendationTextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 


### PR DESCRIPTION
This PR streamlines references to the generic RTE field across a few different regression tests files. Initially, this PR was to resolve only the failure seen in the RETField test file but I noticed that there was some redundancies in some of the RTE field / page component references with some of the variables that we were using.