### PR TITLE
feat: update tests for transfer UI

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -138,9 +138,8 @@ export class MeasuresPage {
             filePath = 'cypress/fixtures/measureId' + measureNumber
         }
         cy.readFile(filePath).should('exist').then((fileContents) => {
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 1200000)
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"] > [class="px-1"] > [type="checkbox"]', 90000)
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"] > [class="px-1"] > [class=" cursor-pointer"]', 90000)
+            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"] > [class="px-1"] > [type="checkbox"]', 60000)
+            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"] > [class="px-1"] > [class=" cursor-pointer"]', 60000)
             cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[type="checkbox"]').scrollIntoView()
             cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[type="checkbox"]').check()
         })

--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -7,6 +7,7 @@ import { Measure } from "@madie/madie-models"
 
 const adminApiKey = Environment.credentials().adminApiKey
 const harpUser = Environment.credentials().harpUser
+const harpUserALT = Environment.credentials().harpUserALT
 
 export enum PermissionActions {
     GRANT = 'GRANT',
@@ -179,16 +180,18 @@ export class Utilities {
     }
 
     public static deleteVersionedMeasure(measureName: string, cqlLibraryName: string, deleteSecondMeasure?: boolean, altUser?: boolean, measureNumber?: number): void {
-
+        let user = ''
         let measurePath = 'cypress/fixtures/measureId'
         if ((measureNumber === undefined) || (measureNumber === null)) {
             measureNumber = 0
         }
         if (altUser) {
+            user = harpUserALT
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookieALT()
         } else {
+            user = harpUser
             cy.clearAllCookies()
             cy.clearLocalStorage()
             cy.setAccessTokenCookie()
@@ -207,7 +210,7 @@ export class Utilities {
                     headers: {
                         Authorization: 'Bearer ' + accessToken.value,
                         'api-key': adminApiKey,
-                        'harpId': harpUser
+                        'harpId': user
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
@@ -1,9 +1,8 @@
 import { Environment } from "../../../../Shared/Environment"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
+import { Utilities } from "../../../../Shared/Utilities"
 import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { LandingPage } from "../../../../Shared/LandingPage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { EditMeasureActions, EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
@@ -11,159 +10,95 @@ import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { TestCaseJson } from "../../../../Shared/TestCaseJson"
 import { Header } from "../../../../Shared/Header"
+import { Toasts } from "../../../../Shared/Toasts"
 
-let measureName = 'TestMeasure' + Date.now()
-let cqlLibraryName = 'TestCql' + Date.now()
-let updatedCqlLibraryName = cqlLibraryName + 'someUpdate'
-let updatedMeasureName = measureName + 'someUpdate'
-let randValue = (Math.floor((Math.random() * 1000) + 1))
-let randomMeasureName = 'TransferTestMeasure' + randValue + 5
-let versionNumber = '1.0.000'
-let harpUserALT = Environment.credentials().harpUserALT
-let measureCQL = MeasureCQL.SBTEST_CQL
-let testCaseTitle = 'Title for Auto Test'
-let testCaseDescription = 'DENOMFail' + Date.now()
-let testCaseSeries = 'SBTestSeries'
-let testCaseJson = TestCaseJson.TestCaseJson_Valid
+const now = Date.now()
+const measureName = 'MeasureTransfer' + now
+const cqlLibraryName = 'MeasureTransferLib' + now
+const randomMeasureName = 'TransferedMeasure' + now
 
-describe('Measure Transfer', () => {
+const versionNumber = '1.0.000'
+const harpUserALT = Environment.credentials().harpUserALT
+const measureCQL = MeasureCQL.SBTEST_CQL
+const testCaseJson = TestCaseJson.TestCaseJson_Valid
+const testCaseTitle = 'Title for Auto Test'
+const testCaseDescription = 'DENOMFail'
+const testCaseSeries = 'SBTestSeries'
 
-    let randValue = (Math.floor((Math.random() * 1000) + 1))
-    let newMeasureName = measureName + randValue
-    let newCqlLibraryName = cqlLibraryName + randValue
-
-    beforeEach('Create Measure and Set Access Token', () => {
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-    })
-
-    afterEach('Clean up', () => {
-
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-        OktaLogin.Logout()
-    })
-
-    it('Verify transferred Measure is viewable under My Measures tab', () => {
-
-        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
-
-        //Login as ALT User
-        OktaLogin.AltLogin()
-        cy.get(LandingPage.sharedMeasures).click()
-        cy.get(MeasuresPage.measureListTitles).should('contain', newMeasureName)
-    })
-
-    it('Verify Measure can be edited by the transferred user', () => {
-
-        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
-
-        //Login as ALT User
-        OktaLogin.AltLogin()
-
-        //Edit Measure details
-        cy.get(LandingPage.sharedMeasures).click()
-        MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.measureNameTextBox).clear().type(updatedMeasureName)
-        cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type(updatedCqlLibraryName)
-        cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
-
-        //Edit Measure CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
-
-        Utilities.typeFileContents('cypress/fixtures/CQLForTestCaseExecution.txt', EditMeasurePage.cqlEditorTextBox)
-
-        //save CQL on measure
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
-        //Click on the measure group tab
-        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
-        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-
-        cy.get(MeasureGroupPage.addMeasureGroupButton).click()
-        MeasureGroupPage.setMeasureGroupType()
-
-        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
-        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
-
-        cy.get(MeasureGroupPage.reportingTab).click()
-
-        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
-
-        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
-
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
-        Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
-
-        //Create New Test case
-        TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
-    })
-})
-
-//Skipping until feature flag TransferMeasure is removed
-describe.skip('Measure Transfer - Action Centre buttons', () => {
-
-    let randValue = (Math.floor((Math.random() * 1000) + 1))
-    let newMeasureName = measureName + randValue + 5
-    let newCqlLibraryName = cqlLibraryName + randValue + 5
+describe('Measure Transfer - Measure set transfer & Non-owner checks', () => {
+    /* 
+        includes verifications for initiating transfer from MeasuresPage
+        and
+        tranferred measures are viewable on Owned Measures tab
+    */
 
     beforeEach('Create Measure and Set Access Token', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-    })
-
-    afterEach('Clean up', () => {
-
-        OktaLogin.Logout()
-    })
-
-    it('Verify Measure owner can transfer Measure from Action centre transfer button on My Measures page', () => {
-
-        //Login as Regular user and transfer Measure to ALT user
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp')
         OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        //wait for alert / successful save message to appear
+        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+    })
 
-        MeasuresPage.actionCenter('transfer')
+    it('Verify all instances in the Measure set (Version and Draft) are Transferred to the new owner', () => {
+
+        cy.get(Header.measures).click()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
+
+        //Version the Measure
+        MeasuresPage.actionCenter('version')
+        cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type(versionNumber)
+        cy.get(MeasuresPage.measureVersionContinueBtn).click()
+        cy.get(Toasts.generalToast).should('contain.text', 'New version of measure is Successfully created')
+        cy.log('Version Created Successfully')
+        cy.reload()
+
+        //Draft the Versioned Measure
+        MeasuresPage.actionCenter('draft')
+        cy.intercept('/api/measures/*/draft').as('drafted')
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(randomMeasureName)
+        cy.get(MeasuresPage.createDraftContinueBtn).click()
+        cy.wait('@drafted').then(int => {
+            // capture measureId of new draft
+            cy.writeFile('cypress/fixtures/measureId1', int.response.body.id)
+        })
+        cy.get(Toasts.generalToast).should('contain.text', 'New draft created successfully.')
+        cy.log('Draft Created Successfully')
+
+        //Share Measure with ALT User
+        MeasuresPage.actionCenter('transfer', 1)
         //Verify message on the transfer pop up screen
         cy.get('[class="transfer-dialog-info-text"]').should('contain.text', 'You are about to Transfer the following measure(s). All versions and drafts will be transferred, so only the most recent measure name appears here.')
         cy.get(MeasuresPage.newOwnerTextbox).type(harpUserALT)
         cy.get(MeasuresPage.transferContinueButton).click()
-
-        //Logout and Delete Measure with ALT user
         OktaLogin.UILogout()
+
+        //Login as ALT User
         cy.clearAllCookies()
         cy.clearLocalStorage()
+        cy.clearAllSessionStorage({ log: true })
         cy.setAccessTokenCookieALT()
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName, false, false)
+        OktaLogin.AltLogin()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
 
-    })
+        // ALT User now owns both measures in the measureSet
+        cy.get(MeasuresPage.measureListTitles).should('contain', randomMeasureName)
+        
+        cy.readFile('cypress/fixtures/measureId1').should('exist').then((fileContents) => {
+            cy.get('[data-testid="measure-name-' + fileContents + '_expandArrow"]').click().wait(1000)
+            cy.get(MeasuresPage.measureListTitles).should('contain', measureName)
+        })
 
-    it('Verify Measure owner can transfer Measure from Action centre transfer button on Edit Measure page', () => {
-
-        //Login as Regular user and transfer Measure to ALT user
-        OktaLogin.Login()
-        //Navigate to Edit Measure page
-        MeasuresPage.actionCenter('edit')
-        EditMeasurePage.actionCenter(EditMeasureActions.transfer)
-        cy.get(MeasuresPage.newOwnerTextbox).type(harpUserALT)
-        cy.get(MeasuresPage.transferContinueButton).click()
-
-        //Logout and Delete Measure with ALT user
         OktaLogin.UILogout()
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.setAccessTokenCookieALT()
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName, false, false)
-
+        Utilities.deleteMeasure(null, null, false, true, 1)
+        Utilities.deleteVersionedMeasure(measureName, cqlLibraryName, false, true)
     })
 
     it('Verify Transfer button disabled for non Measure owner', () => {
@@ -187,132 +122,44 @@ describe.skip('Measure Transfer - Action Centre buttons', () => {
 
         //Logout and Delete Measure with Regular user
         OktaLogin.UILogout()
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.setAccessTokenCookie()
-        Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
-    })
-
-})
-
-describe('Measure Transfer - Multiple instances', () => {
-
-    let randValue = (Math.floor((Math.random() * 1000) + 1))
-    let newMeasureName = measureName + randValue
-    let newCqlLibraryName = cqlLibraryName + randValue
-
-    beforeEach('Create Measure and Set Access Token', () => {
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp')
-        OktaLogin.Login()
-        MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
-        //Click on the measure group tab
-        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
-        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-
-        cy.get(MeasureGroupPage.reportingTab).click()
-
-        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
-
-        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
-
-        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationDescQiCore, 5000)
-
-        cy.get(MeasureGroupPage.improvementNotationDescQiCore).type('some imporvement notation description')
-
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
-        Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
-
-        cy.get(Header.measures).click()
-    })
-
-    afterEach('LogOut', () => {
-
-        OktaLogin.Logout()
-    })
-
-    it('Verify all instances in the Measure set (Version and Draft) are Transferred to the user', () => {
-
-
-        //Version the Measure
-        MeasuresPage.actionCenter('version')
-        cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
-        cy.get(MeasuresPage.confirmMeasureVersionNumber).type(versionNumber)
-        cy.get(MeasuresPage.measureVersionContinueBtn).click()
-        cy.get('.toast').should('contain.text', 'New version of measure is Successfully created')
-        cy.log('Version Created Successfully')
-        cy.reload()
-
-        //Draft the Versioned Measure
-        MeasuresPage.actionCenter('draft')
-
-        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(randomMeasureName)
-        cy.get(MeasuresPage.createDraftContinueBtn).click()
-        cy.get('.toast').should('contain.text', 'New draft created successfully.')
-        cy.log('Draft Created Successfully')
-
-        OktaLogin.UILogout()
-        //Share Measure with ALT User
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.clearAllSessionStorage({ log: true })
-        cy.setAccessTokenCookie()
-        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
-
-
-        //Login as ALT User
-        cy.clearAllCookies()
-        cy.clearLocalStorage()
-        cy.clearAllSessionStorage({ log: true })
-        cy.setAccessTokenCookieALT()
-        OktaLogin.AltLogin()
-        cy.get(LandingPage.sharedMeasures).click()
-        cy.get('[class="table-body measures-list"]').should('contain', randomMeasureName)
+        Utilities.deleteMeasure()
     })
 })
 
 describe('Delete Test Case with Transferred user', () => {
-
-    let randValue = (Math.floor((Math.random() * 1000) + 1))
-    let newMeasureName = measureName + randValue
-    let newCqlLibraryName = cqlLibraryName + randValue
+    /* 
+        includes verification for initiating transfer from EditMeasurePage
+        and
+        transferred measures are editable by new owner
+    */
 
     beforeEach('Create Measure and Set Access Token', () => {
 
-        cy.setAccessTokenCookie()
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
+        OktaLogin.Login()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
+
+        MeasuresPage.actionCenter('edit')
+        
+        EditMeasurePage.actionCenter(EditMeasureActions.transfer)
+        //Verify message on the transfer pop up screen
+        cy.get('[class="transfer-dialog-info-text"]').should('contain.text', 'You are about to Transfer the following measure(s). All versions and drafts will be transferred, so only the most recent measure name appears here.')
+        cy.get(MeasuresPage.newOwnerTextbox).type(harpUserALT)
+        cy.get(MeasuresPage.transferContinueButton).click()
+        OktaLogin.UILogout()
     })
 
     afterEach('Clean up', () => {
 
-        Utilities.deleteMeasure(measureName, cqlLibraryName)
-        OktaLogin.Logout()
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure(null, null, false, true)
     })
 
-    it('Verify Test Case can be deleted by the Transferred user', () => {
-
-        //Share Measure with ALT User
-        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+    it('Verify Test Case can be deleted by the new owner after transfer', () => {
 
         //Login as Alt User
         OktaLogin.AltLogin()
-        cy.get(LandingPage.sharedMeasures).click()
         MeasuresPage.actionCenter('edit')
 
         cy.get(EditMeasurePage.testCasesTab).click()


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-8400

Re-organizes & consolidates test scenarios. Removed use of API transfer since this now allows transfer in UI.
Removed skip from some tests because they will ve released in 2.3.1

Also: updated deleteVersionedMeasure() to correct a small bug.
Previously this function would only work with primary user, even when you specified altUser.
Now it will honor the choice of altUser.