### PR TITLE
fix: correct sequence for change in RAV default

### DIFF
--- a/cypress/Shared/MeasureCQL.ts
+++ b/cypress/Shared/MeasureCQL.ts
@@ -1680,15 +1680,11 @@ export class MeasureCQL {
         '  AgeInYearsAt (start of "Measurement Period") >= 20\n'
 
     public static readonly QiCoreCQLSDE = 'library QiCoreCQLLibrary1739988331418 version \'0.0.000\'\n' +
-
-        'using QICore version \'4.1.1\'\n' +
-        '\n' +
+        'using QICore version \'4.1.1\'\n\n' +
         'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
         'include SupplementalDataElements version \'3.5.000\' called SDE\n' +
-        'include MATGlobalCommonFunctionsFHIR4 version \'1.0.000\' called Global\n' +
-        '\n' +
-        'codesystem "ICD10CM": \'http://hl7.org/fhir/sid/icd-10-cm\'\n' +
-        '\n' +
+        'include MATGlobalCommonFunctionsFHIR4 version \'1.0.000\' called Global\n\n' +
+        'codesystem "ICD10CM": \'http://hl7.org/fhir/sid/icd-10-cm\'\n\n' +
         'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
         'valueset "Atherosclerosis and Peripheral Arterial Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.21\'\n' +
         'valueset "Breastfeeding": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1047.73\'\n' +
@@ -1731,8 +1727,6 @@ export class MeasureCQL {
         '\n' +
         'context Patient\n' +
         '\n' +
-        '\n' +
-        '\n' +
         'define "SDE Ethnicity":\n' +
         '  SDE."SDE Ethnicity"\n' +
         '\n' +
@@ -1748,30 +1742,26 @@ export class MeasureCQL {
         'define "Patients Age 20 or Older at Start of Measurement Period":\n' +
         '  AgeInYearsAt (start of "Measurement Period") >= 20\n' +
         '\n' +
-        '\n' +
-        '\n' +
-        'define "Qualifying Encounter during Measurement Period":\n' +
-        '  ( [Encounter: "Annual Wellness Visit"]\n' +
-        '                union [Encounter: "Office Visit"]\n' +
-        '                union [Encounter: "Outpatient Consultation"]\n' +
-        '                union [Encounter: "Outpatient Encounters for Preventive Care"]\n' +
-        '                union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
-        '                union [Encounter: "Preventive Care Services - Other"]\n' +
-        '                union [Encounter: "Preventive Care Services-Individual Counseling"]\n' +
-        '                union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"] ) ValidEncounter\n' +
-        '                    where ValidEncounter.period during "Measurement Period"\n' +
-        '                    and ValidEncounter.status = \'finished\'\n' +
-        '\n' +
-        'define "Statin Therapy Ordered during Measurement Period":\n' +
-        '  ( [MedicationRequest: "Low Intensity Statin Therapy"]\n' +
-        '                union [MedicationRequest: "Moderate Intensity Statin Therapy"]\n' +
-        '                union [MedicationRequest: "High Intensity Statin Therapy"] ) StatinOrdered\n' +
-        '                    where StatinOrdered.authoredOn during "Measurement Period"\n' +
-        '                    and StatinOrdered.status in { \'active\', \'completed\' }\n' +
-        '                    and StatinOrdered.intent = \'order\'\n' +
-        '\n' +
-        '\n' +
-        '\n' +
+        // 'define "Qualifying Encounter during Measurement Period":\n' +
+        // '  ( [Encounter: "Annual Wellness Visit"]\n' +
+        // '                union [Encounter: "Office Visit"]\n' +
+        // '                union [Encounter: "Outpatient Consultation"]\n' +
+        // '                union [Encounter: "Outpatient Encounters for Preventive Care"]\n' +
+        // '                union [Encounter: "Preventive Care Services - Established Office Visit, 18 and Up"]\n' +
+        // '                union [Encounter: "Preventive Care Services - Other"]\n' +
+        // '                union [Encounter: "Preventive Care Services-Individual Counseling"]\n' +
+        // '                union [Encounter: "Preventive Care Services-Initial Office Visit, 18 and Up"] ) ValidEncounter\n' +
+        // '                    where ValidEncounter.period during "Measurement Period"\n' +
+        // '                    and ValidEncounter.status = \'finished\'\n' +
+        // '\n' +
+        // 'define "Statin Therapy Ordered during Measurement Period":\n' +
+        // '  ( [MedicationRequest: "Low Intensity Statin Therapy"]\n' +
+        // '                union [MedicationRequest: "Moderate Intensity Statin Therapy"]\n' +
+        // '                union [MedicationRequest: "High Intensity Statin Therapy"] ) StatinOrdered\n' +
+        // '                    where StatinOrdered.authoredOn during "Measurement Period"\n' +
+        // '                    and StatinOrdered.status in { \'active\', \'completed\' }\n' +
+        // '                    and StatinOrdered.intent = \'order\'\n' +
+        // '\n' +
         'define "Denominator Exceptions 1":\n' +
         '  true\n' +
         '\n' +
@@ -1779,9 +1769,7 @@ export class MeasureCQL {
         '  true\n' +
         '\n' +
         'define "Denominator Exceptions 3":\n' +
-        '  true\n' +
-        '\n' +
-        '\n'
+        '  true\n'
 
     public static readonly SBTESTCMS347_CQL = 'library SBTESTCMS347 version \'0.0.016\'\n' +
         '\n' +

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/RAVSubTabValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/RAVSubTabValidations.cy.ts
@@ -74,20 +74,11 @@ describe('QiCore Test Cases : RAV Sub tab validations', () => {
 
         // go through discard cycle 
         // patientBasis works for all 2 choice radios
-        cy.get(MeasureGroupPage.qdmPatientBasis).eq(0).click()
+        cy.get(MeasureGroupPage.qdmPatientBasis).eq(1).click()
         cy.get(TestCasesPage.discardRavChangesOption).click()
         Utilities.clickOnDiscardChanges()
-        cy.get(MeasureGroupPage.qdmPatientBasis).eq(1).should('be.checked')
+        cy.get(MeasureGroupPage.qdmPatientBasis).eq(0).should('be.checked')
 
-        cy.get(TestCasesPage.saveRAVOption).should('be.disabled')
-        cy.get(TestCasesPage.discardRavChangesOption).should('be.disabled')
-
-        // re-do & save
-        cy.get(MeasureGroupPage.qdmPatientBasis).eq(0).click()
-        cy.get(TestCasesPage.saveRAVOption).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test Case Configuration Updated Successfully')
-
-        // check buttons disabled
         cy.get(TestCasesPage.saveRAVOption).should('be.disabled')
         cy.get(TestCasesPage.discardRavChangesOption).should('be.disabled')
 
@@ -138,6 +129,22 @@ describe('QiCore Test Cases : RAV Sub tab validations', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
+        //navigate to the RAV side tab section on the test cases tab
+        Utilities.waitForElementVisible(TestCasesPage.qdmRAVSideNavLink, 30000)
+        cy.get(TestCasesPage.qdmRAVSideNavLink).click()
+
+        // go through discard cycle 
+        // patientBasis works for all 2 choice radios
+        cy.get(MeasureGroupPage.qdmPatientBasis).eq(1).click()
+
+        cy.get(TestCasesPage.saveRAVOption).should('be.enabled')
+        cy.get(TestCasesPage.saveRAVOption).click()
+        Utilities.waitForElementDisabled(TestCasesPage.saveRAVOption, 22000)
+
+        //Navigate to test case page
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
         //Navigate to Edit Test Case page
         TestCasesPage.clickEditforCreatedTestCase()
 
@@ -182,14 +189,14 @@ describe('QiCore Test Cases : RAV Sub tab validations', () => {
 
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('exist')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
-        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '0%')
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '29%')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', 'Coverage')
 
         //Navigate to the RAV side tab and select Yes
         Utilities.waitForElementVisible(TestCasesPage.qdmRAVSideNavLink, 30000)
         cy.get(TestCasesPage.qdmRAVSideNavLink).click()
 
-        cy.get(MeasureGroupPage.qdmPatientBasis).eq(0).click()
+        cy.get(MeasureGroupPage.qdmPatientBasis).eq(1).click()
         cy.get(TestCasesPage.saveRAVOption).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test Case Configuration Updated Successfully')
 
@@ -204,7 +211,7 @@ describe('QiCore Test Cases : RAV Sub tab validations', () => {
 
 
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
-        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '29%')
+        cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '0%')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', 'Coverage')
     })
 })


### PR DESCRIPTION
Follow up to last sprint's https://jira.cms.gov/browse/MAT-9039

This PR changes the QiCore test to account for switching RAV default values.
See https://github.com/MeasureAuthoringTool/madie-cypress/pull/2453 for the same switch to QDM.

Also adjusted a shared CQL to account for changes inherited from cq-framework.
It removes 2 definitions that were not used by any of the populations, which eliminates an error when the test cases load & cannot determine references.