### PR TITLE
feat: new test for force unlock on login and logout

### DIFF
--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -608,4 +608,35 @@ export class Utilities {
                 cy.log('No action. Unsupported type.')
         }
     }
+
+    public static verifyAllLocksDeleted() {
+        // only works with harpUser now, no current use-case to support altUser
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.request({
+                url: '/api/measures/unlock', 
+                headers: {
+                    authorization: 'Bearer ' + accessToken.value,
+                },
+                method: 'DELETE'
+            }).then((response) => {
+                expect(response.status).to.eql(200)
+                expect(response.body).to.include('No measure locks found for harpId: ' + harpUser)
+                expect(response.body).to.include('No test case locks found for harpId: ' + harpUser)
+            })
+        })
+
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.request({
+                url: '/api/cql-libraries/unlock', 
+                headers: {
+                    authorization: 'Bearer ' + accessToken.value,
+                },
+                method: 'DELETE'
+            }).then((response) => {
+                expect(response.status).to.eql(200)
+                expect(response.body).to.include('No library locks found for harpId: ' + harpUser)
+            })
+        })
+    }
 }

--- a/cypress/e2e/WebInterface/Measure/Locking/MeasureUnlockOnLoginLogout.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Locking/MeasureUnlockOnLoginLogout.cy.ts
@@ -1,0 +1,57 @@
+import { Environment } from "../../../../Shared/Environment"
+import { Utilities } from "../../../../Shared/Utilities"
+import { OktaLogin } from "../../../../Shared/OktaLogin"
+import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { Header } from "../../../../Shared/Header"
+
+describe('Measure Unlock fires when the user logs in & logs out', () => {
+
+    it('aaaaaaa', () => {
+
+        cy.intercept('/api/measures/unlock').as('measureUnlock')
+        cy.intercept('/api/cql-libraries/unlock').as('libraryUnlock')
+
+        //Login 
+        sessionStorage.clear()
+        cy.clearAllCookies()
+        cy.clearLocalStorage()
+        cy.setAccessTokenCookie()
+
+        cy.visit('/login', { onBeforeLoad: (win) => { win.sessionStorage.clear() } })
+
+        cy.get(OktaLogin.usernameInput, { timeout: 110000 }).should('be.enabled')
+        cy.get(OktaLogin.usernameInput).type(Environment.credentials().harpUser)
+        cy.get(OktaLogin.passwordInput, { timeout: 110000 }).should('be.enabled')
+        cy.get(OktaLogin.passwordInput).type(Environment.credentials().password)
+        cy.get(OktaLogin.signInButton, { timeout: 110000 }).should('be.enabled')
+        cy.get(OktaLogin.signInButton).click()
+
+        cy.wait('@measureUnlock', { timeout: 20000 }).then(mUnlock => {
+            expect(mUnlock.response.statusCode).to.eql(200)
+        })
+
+        cy.wait('@libraryUnlock', { timeout: 20000 }).then(lUnlock => {
+            expect(lUnlock.response.statusCode).to.eql(200)
+        })
+
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
+
+        Utilities.verifyAllLocksDeleted()
+
+        //Logout 
+        cy.get(Header.userProfileSelect).click()
+        Utilities.waitForElementVisible(Header.userProfileSelectSignOutOption, 15000)
+        cy.get(Header.userProfileSelectSignOutOption).click({ force: true })
+        Utilities.waitForElementVisible(OktaLogin.usernameInput, 45000)
+
+        cy.wait('@measureUnlock', { timeout: 20000 }).then(mUnlock => {
+            expect(mUnlock.response.statusCode).to.eql(200)
+        })
+
+        cy.wait('@libraryUnlock', { timeout: 20000 }).then(lUnlock => {
+            expect(lUnlock.response.statusCode).to.eql(200)
+        })
+
+        Utilities.verifyAllLocksDeleted()
+    })
+})


### PR DESCRIPTION
Adds new test MeasureUnlockOnLoginLogout.cy.ts

Compared to most of our Cypress tests, this is a bit odd.

The test logs in, checks that all locks were released, then logs out & re-checks all locks were released.
Most of the code is split out from OktaLogin.Login() and .UILogot() but needs to be separate to manage the intercepts.