### PR TITLE
fix: changed wait timing to catch toast

### DIFF
--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/ShiftTestCaseDates/Qi-CoreShiftTestCaseDatesValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/ShiftTestCaseDates/Qi-CoreShiftTestCaseDatesValidations.cy.ts
@@ -7,6 +7,7 @@ import { TestCase, TestCasesPage } from "../../../../../Shared/TestCasesPage"
 import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
+import { Toasts } from "../../../../../Shared/Toasts"
 
 const now = Date.now()
 const measureName = 'QiCoreShiftDates' + now
@@ -129,7 +130,7 @@ describe('Shift Test Case Dates tests - Qi-Core Measure', () => {
         })
     })
 
-    it('Shift single test case dates to the past using the acion center option', () => {
+    it('Shift single test case dates to the past using the action center option', () => {
 
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -159,10 +160,9 @@ describe('Shift Test Case Dates tests - Qi-Core Measure', () => {
         //save the shift test case
         Utilities.waitForElementEnabled(TestCasesPage.shiftSpecificTestCasesSaveBtn, 3500)
         cy.get(TestCasesPage.shiftSpecificTestCasesSaveBtn).click()
-        Utilities.waitForElementVisible(EditMeasurePage.successMessage, 3500)
 
         //confirm success message
-        cy.get(TestCasesPage.TestCasesSuccessMsg).should('contain.text', 'All Test Case dates successfully shifted.')
+        cy.get(Toasts.otherSuccessToast, { timeout: 9500 }).should('contain.text', 'All Test Case dates successfully shifted.')
 
         //Validate if the Measurement period start date is updated for first Test case
         cy.getCookie('accessToken').then((accessToken) => {


### PR DESCRIPTION
Fixes Qi-CoreShiftTestCaseDatesValidations.cy.ts

Changed waits & checks timing to catch success toast. Having the wait & check separate was too slow; the toast was seen and would then disappear before it could be validated.