### PR TITLE
fix: update from several other changes

### DIFF
--- a/cypress/Shared/FHIRMeasuresCQL.ts
+++ b/cypress/Shared/FHIRMeasuresCQL.ts
@@ -349,14 +349,18 @@ export class QiCore4Cql {
     'valueset \"Preventive Care Services - Established Office Visit, 18 and Up\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
     'valueset \"Preventive Care Services-Initial Office Visit, 18 and Up\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
     'valueset \"Home Healthcare Services\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
+    'valueset "End Stage Renal Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353\' \n' +
     'parameter \"Measurement Period\" Interval<DateTime>\n' +
     'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
     'context Patient\n' +
-    'define \"Initial Population\":\n' +
-    'exists \"Qualifying Encounters\"\n' +
-    'define \"Qualifying Encounters\":\n' +
+    'define \"Initial PopulationOne\":\n' +
+    'true\n' +
+    'define "Initial Population":\n' +
+    '   true\n' +
+    ' \n' +
+    'define "Qualifying Encounters":\n' +
     '(\n' +
-    '[Encounter: \"Office Visit\"]\n' +
+    '[Encounter: "Office Visit"]\n' +
     'union [Encounter: \"Annual Wellness Visit"]\n' +
     'union [Encounter: \"Preventive Care Services - Established Office Visit, 18 and Up\"]\n' +
     'union [Encounter: \"Preventive Care Services-Initial Office Visit, 18 and Up\"]\n' +
@@ -364,10 +368,27 @@ export class QiCore4Cql {
     ') ValidEncounter\n' +
     'where ValidEncounter.period during \"Measurement Period\"\n' +
     'and ValidEncounter.isFinishedEncounter()\n' +
+    'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
+    '(Enc E where E.status = \'finished\') is not null\n' +
+    'define "Stratification 1":\n' +
+    'true'
+
+  public static readonly reduced_CQL_Multiple_Populations = 'library TestLibrary4664 version \'0.0.000\'\n' +
+    'using QICore version \'4.1.1\'\n' +
+    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
+    'valueset \"Office Visit\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
+    'valueset \"Annual Wellness Visit\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
+    'valueset \"Preventive Care Services - Established Office Visit, 18 and Up\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
+    'valueset \"Preventive Care Services-Initial Office Visit, 18 and Up\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1023\'\n' +
+    'valueset \"Home Healthcare Services\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\'\n' +
+    'valueset "End Stage Renal Disease": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.353\' \n' +
+    'parameter \"Measurement Period\" Interval<DateTime>\n' +
+    'default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)\n' +
+    'context Patient\n' +
     'define \"Initial PopulationOne\":\n' +
     'true\n' +
-    'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '(Enc E where E.status = \'finished\') is not null\n'
+    'define "Initial Population":\n' +
+    '   true\n'
 
   public static readonly CQL_For_Cohort = 'library TestLibrary4664 version \'0.0.000\'\n' +
     'using QICore version \'4.1.1\'\n' +

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
@@ -9,6 +9,7 @@ import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
 import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
 import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
 import { Toasts } from "../../../../../Shared/Toasts"
+import { QiCore4Cql } from "../../../../../Shared/FHIRMeasuresCQL"
 
 const now = Date.now()
 const measureName = 'RunExecuteTCButtonValidations' + now
@@ -27,8 +28,8 @@ const validTestCaseJson = TestCaseJson.TestCaseJson_Valid
 const invalidTestCaseJson = TestCaseJson.TestCaseJson_Invalid
 const warningTestCaseJson = TestCaseJson.TestCaseJson_with_warnings
 const errorTestCaseJSON_no_ResourceID = TestCaseJson.TestCaseJson_missingResourceIDs
-const measureCQL = MeasureCQL.CQL_Multiple_Populations
 const measureCQLPFTests = MeasureCQL.CQL_Populations
+const measureCQL = QiCore4Cql.reduced_CQL_Multiple_Populations
 
 describe('Run / Execute Test Case button validations', () => {
 
@@ -41,7 +42,7 @@ describe('Run / Execute Test Case button validations', () => {
     afterEach('Logout and Clean up', () => {
 
         OktaLogin.Logout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Run Test Case button is disabled  -- CQL Errors', () => {
@@ -456,7 +457,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.UILogout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Run and Execute Test case for multiple Population Criteria and validate Population Criteria discernment, on Highlighting page and Test Case list page', () => {
@@ -581,7 +582,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
@@ -596,7 +597,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.Logout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Run / Execute single passing Test Case', () => {
@@ -1006,7 +1007,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
@@ -1021,7 +1022,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.Logout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Can "Run Test Case" and "Execute Test Case" when a test case has only a warning', () => {
@@ -1091,10 +1092,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).wait(1000).click()
-
-        cy.get(TestCasesPage.detailsTab).scrollIntoView()
-        cy.get(TestCasesPage.detailsTab).click()
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(Toasts.errorToast, { timeout: 6500 }).should('have.text', Toasts.errorOffsetText)
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -1255,8 +1253,6 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
-        cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
-
         cy.get(Toasts.generalToast, { timeout: 6500 }).should('have.text', Toasts.errorOffsetText)
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -1334,7 +1330,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.Logout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Can "Run Test Cases" on test case list page after when created after pristine groups', () => {
@@ -1351,7 +1347,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
         cy.get(MeasureGroupPage.popBasis).type('boolean')
         cy.get(MeasureGroupPage.popBasisOption).click()
 
-        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial PopulationOne')
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
 
         cy.get(MeasureGroupPage.reportingTab).click()
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
@@ -1427,7 +1423,183 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
         //check the check box for the expected IP
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click().should('be.checked')
+        cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
+
+        //Verify Highlighting tab before clicking on Run Test button
+        cy.get(TestCasesPage.tcHighlightingTab).click()
+        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
+
+        //Click on Execute Test Case button on Edit Test Case page
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.executeTestCaseButton).should('exist')
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.executeTestCaseButton).click()
+        cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
+    })
+
+    it('Can "Run Test Cases" on test case list page after a group has its population basis or scoring value changed' +
+        ' (displays pass / fail) and results are the same for individual run on edit page', () => {
+
+        //Add second Measure Group with return type as Boolean
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        Utilities.setMeasureGroupType()
+
+        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
+        cy.get(MeasureGroupPage.popBasis).should('exist')
+        cy.get(MeasureGroupPage.popBasis).should('be.visible')
+        cy.get(MeasureGroupPage.popBasis).click()
+        cy.get(MeasureGroupPage.popBasis).type('boolean')
+        cy.get(MeasureGroupPage.popBasisOption).click()
+
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
+
+        cy.get(MeasureGroupPage.reportingTab).click()
+        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
+
+        //validation successful save message
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+
+        //Navigate to Test Cases page and add Test Case details
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.newTestCaseButton).should('be.visible')
+        cy.get(TestCasesPage.newTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.newTestCaseButton).click()
+
+        cy.get(TestCasesPage.createTestCaseDialog).should('exist')
+        cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
+
+        cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
+        Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 20000)
+        Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 20000)
+        cy.get(TestCasesPage.createTestCaseTitleInput).type(testCase.title)
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).focus()
+        cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCase.description)
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
+        cy.get(TestCasesPage.createTestCaseGroupInput).type(testCase.group)
+        cy.contains(testCase.group).click()
+
+        TestCasesPage.clickCreateTestCaseButton()
+
+        //Verify created test case Title and Series exists on Test Cases Page
+        TestCasesPage.grabValidateTestCaseTitleAndSeries(testCase.title, testCase.group)
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //Add json to the test case
+        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 42700)
+        Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
+        cy.get(TestCasesPage.aceEditor).should('exist')
+        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 50000)
+        cy.get(TestCasesPage.aceEditor).should('be.visible')
+        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
+        cy.get(TestCasesPage.aceEditor).wait(1000).type(validTestCaseJson, { parseSpecialCharSequences: false })
+
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+
+        cy.get(Toasts.generalToast, { timeout: 8500 }).should('have.text', Toasts.warningOffsetText)
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //click on actual / expected sub-tab
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+
+        //check the check box for the expected IP
+        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
+        cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
+
+        //Verify Highlighting tab before clicking on Run Test button
+        cy.get(TestCasesPage.tcHighlightingTab).click()
+        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
+
+        //Click on Execute Test Case button on Edit Test Case page
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.executeTestCaseButton).should('exist')
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.executeTestCaseButton).click()
+        cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
+
+        //refresh test case list page
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        //open edit page for test case
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //navigate to the details tab for the test case
+        cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
+
+        cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).should('be.visible')
+        cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).click()
+
+        //confirm warning message
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('contain.text', 'No code provided, and a code should be provided from the value set \'US Core Encounter Type\' (http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.0)')
+
+        //change population basis
+        //navigate to measure group / Population Criteria page / tab
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        //set new value for population basis
+        cy.get(MeasureGroupPage.popBasis).should('exist')
+        cy.get(MeasureGroupPage.popBasis).should('be.visible')
+        cy.get(MeasureGroupPage.popBasis).click()
+        cy.get(MeasureGroupPage.popBasis).type('Encounter')
+        cy.get(MeasureGroupPage.popBasisOption).click()
+
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Qualifying Encounters')
+
+        cy.get(MeasureGroupPage.reportingTab).click()
+        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        cy.get(MeasureGroupPage.scoreUpdateMGConfirmMsg).should('contain.text', 'Your Measure Population Basis is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure group.')
+        cy.get(MeasureGroupPage.updatePopulationBasisConfirmationBtn).click()
+
+        //validation successful save message
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //click on actual / expected sub-tab
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+
+        //enter values for the expected population
+        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
+        cy.get(TestCasesPage.testCaseIPPExpected).invoke('click').type('0')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -1449,297 +1621,101 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
+
+        //change scoring
+        //navigate to measure group / Population Criteria page / tab
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+
+        //set new value for population basis
+        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
+
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Qualifying Encounters')
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Qualifying Encounters')
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorSelect, 'Qualifying Encounters')
+
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
+        cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
+
+        //validation successful save message
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //click on actual / expected sub-tab
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+
+        //enter values for the expected populations
+        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
+        cy.get(TestCasesPage.testCaseIPPExpected).invoke('click').type('0')
+
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
+        cy.get(TestCasesPage.testCaseDENOMExpected).invoke('click').type('0')
+
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
+        cy.get(TestCasesPage.testCaseNUMERExpected).invoke('click').type('0')
+
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
+        cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 8500)
+
+        //Verify Highlighting tab before clicking on Run Test button
+        cy.get(TestCasesPage.tcHighlightingTab).click()
+        cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
+
+        //Click on Execute Test Case button on Edit Test Case page
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get(TestCasesPage.executeTestCaseButton).should('exist')
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
+        cy.get(TestCasesPage.executeTestCaseButton).focus()
+        cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
+        cy.get(TestCasesPage.executeTestCaseButton).click()
+        cy.get(TestCasesPage.executeTestCaseButton).click()
+        cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
+
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        //click on actual / expected sub-tab
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
+        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+
+        //attempt to click on 'Run Test Case' to run the test case via the edit page
+        cy.get(TestCasesPage.runTestButton).should('exist')
+        cy.get(TestCasesPage.runTestButton).should('be.visible')
+        cy.get(TestCasesPage.runTestButton).should('be.enabled')
+        cy.get(TestCasesPage.runTestButton).click()
+
+        //navigate to the details tab for the test case
+        cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
+
+        cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).should('be.visible')
+        cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).click()
+
+        //confirm no message
+        cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('contain.text', 'No code provided, and a code should be provided from the value set \'US Core Encounter Type\' (http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.0)')
     })
-
-    it('Can "Run Test Cases" on test case list page after a group has its population basis or scoring value changed' +
-        ' (displays pass / fail) and results are the same for individual run on edit page', () => {
-
-            //Add second Measure Group with return type as Boolean
-            cy.get(EditMeasurePage.measureGroupsTab).click()
-
-            Utilities.setMeasureGroupType()
-
-            Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
-            cy.get(MeasureGroupPage.popBasis).should('exist')
-            cy.get(MeasureGroupPage.popBasis).should('be.visible')
-            cy.get(MeasureGroupPage.popBasis).click()
-            cy.get(MeasureGroupPage.popBasis).type('boolean')
-            cy.get(MeasureGroupPage.popBasisOption).click()
-
-            Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial PopulationOne')
-
-            cy.get(MeasureGroupPage.reportingTab).click()
-            Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
-
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
-
-            //validation successful save message
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
-
-            //Close the Toast message
-            cy.get(TestCasesPage.clearIconBtn).click()
-
-            //Navigate to Test Cases page and add Test Case details
-            cy.get(EditMeasurePage.testCasesTab).click()
-            cy.get(TestCasesPage.newTestCaseButton).should('be.visible')
-            cy.get(TestCasesPage.newTestCaseButton).should('be.enabled')
-            cy.get(TestCasesPage.newTestCaseButton).click()
-
-            cy.get(TestCasesPage.createTestCaseDialog).should('exist')
-            cy.get(TestCasesPage.createTestCaseDialog).should('be.visible')
-
-            cy.get(TestCasesPage.createTestCaseTitleInput).should('exist')
-            Utilities.waitForElementVisible(TestCasesPage.createTestCaseTitleInput, 20000)
-            Utilities.waitForElementEnabled(TestCasesPage.createTestCaseTitleInput, 20000)
-            cy.get(TestCasesPage.createTestCaseTitleInput).type(testCase.title)
-            cy.get(TestCasesPage.createTestCaseDescriptionInput).should('exist')
-            cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.visible')
-            cy.get(TestCasesPage.createTestCaseDescriptionInput).should('be.enabled')
-            cy.get(TestCasesPage.createTestCaseDescriptionInput).focus()
-            cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCase.description)
-            cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
-            cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-            cy.get(TestCasesPage.createTestCaseGroupInput).type(testCase.group)
-            cy.contains(testCase.group).click()
-
-            TestCasesPage.clickCreateTestCaseButton()
-
-            //Verify created test case Title and Series exists on Test Cases Page
-            TestCasesPage.grabValidateTestCaseTitleAndSeries(testCase.title, testCase.group)
-
-            TestCasesPage.clickEditforCreatedTestCase()
-
-            //Add json to the test case
-            Utilities.waitForElementVisible(TestCasesPage.aceEditor, 37700)
-            Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
-            cy.get(TestCasesPage.aceEditor).should('exist')
-            cy.get(TestCasesPage.aceEditor).should('be.visible')
-            cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(2000)
-            cy.get(TestCasesPage.aceEditor).type(validTestCaseJson, { parseSpecialCharSequences: false })
-
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-            cy.get(TestCasesPage.editTestCaseSaveButton).click()
-
-            cy.get(Toasts.generalToast, { timeout: 6500 }).should('have.text', Toasts.warningOffsetText)
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-
-            TestCasesPage.clickEditforCreatedTestCase()
-
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-            //check the check box for the expected IP
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseIPPExpected).click().should('be.checked')
-
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-            cy.get(TestCasesPage.editTestCaseSaveButton).click()
-            Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 8500)
-
-            //Verify Highlighting tab before clicking on Run Test button
-            cy.get(TestCasesPage.tcHighlightingTab).click()
-            cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
-
-            //Click on Execute Test Case button on Edit Test Case page
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-            cy.get(TestCasesPage.executeTestCaseButton).should('exist')
-            cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
-            cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
-            cy.get(TestCasesPage.executeTestCaseButton).focus()
-            cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
-            cy.get(TestCasesPage.executeTestCaseButton).click()
-            cy.get(TestCasesPage.executeTestCaseButton).click()
-            cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
-
-            //refresh test case list page
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-
-            //open edit page for test case
-            TestCasesPage.clickEditforCreatedTestCase()
-
-            //navigate to the details tab for the test case
-            cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
-
-            cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).should('be.visible')
-            cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).click()
-
-            //confirm warning message
-            cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('contain.text', 'No code provided, and a code should be provided from the value set \'US Core Encounter Type\' (http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.0)')
-
-            //change population basis
-            //navigate to measure group / Population Criteria page / tab
-            cy.get(EditMeasurePage.measureGroupsTab).click()
-
-            //set new value for population basis
-            cy.get(MeasureGroupPage.popBasis).should('exist')
-            cy.get(MeasureGroupPage.popBasis).should('be.visible')
-            cy.get(MeasureGroupPage.popBasis).click()
-            cy.get(MeasureGroupPage.popBasis).type('Encounter')
-            cy.get(MeasureGroupPage.popBasisOption).click()
-
-            Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Qualifying Encounters')
-
-            cy.get(MeasureGroupPage.reportingTab).click()
-            Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
-
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-            cy.get(MeasureGroupPage.scoreUpdateMGConfirmMsg).should('contain.text', 'Your Measure Population Basis is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure group.')
-            cy.get(MeasureGroupPage.updatePopulationBasisConfirmationBtn).click()
-
-            //validation successful save message
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
-
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-
-            TestCasesPage.clickEditforCreatedTestCase()
-
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-            //enter values for the expected population
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseIPPExpected).invoke('click').type('0')
-
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-            cy.get(TestCasesPage.editTestCaseSaveButton).click()
-            Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 8500)
-
-            //Verify Highlighting tab before clicking on Run Test button
-            cy.get(TestCasesPage.tcHighlightingTab).click()
-            cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
-
-            //Click on Execute Test Case button on Edit Test Case page
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-            cy.get(TestCasesPage.executeTestCaseButton).should('exist')
-            cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
-            cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
-            cy.get(TestCasesPage.executeTestCaseButton).focus()
-            cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
-            cy.get(TestCasesPage.executeTestCaseButton).click()
-            cy.get(TestCasesPage.executeTestCaseButton).click()
-            cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
-
-            //change scoring
-            //navigate to measure group / Population Criteria page / tab
-            cy.get(EditMeasurePage.measureGroupsTab).click()
-
-            //set new value for population basis
-            Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringProportion)
-
-            Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Qualifying Encounters')
-            Utilities.dropdownSelect(MeasureGroupPage.denominatorSelect, 'Qualifying Encounters')
-            Utilities.dropdownSelect(MeasureGroupPage.numeratorSelect, 'Qualifying Encounters')
-
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-            cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
-            cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
-
-            //validation successful save message
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
-
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-
-            TestCasesPage.clickEditforCreatedTestCase()
-
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-            //enter values for the expected populations
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseIPPExpected).invoke('click').type('0')
-
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseDENOMExpected).invoke('click').type('0')
-
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseNUMERExpected).invoke('click').type('0')
-
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
-            cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-            cy.get(TestCasesPage.editTestCaseSaveButton).click()
-            Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 8500)
-
-            //Verify Highlighting tab before clicking on Run Test button
-            cy.get(TestCasesPage.tcHighlightingTab).click()
-            cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', 'To see the logic highlights, click \'Run Test\'')
-
-            //Click on Execute Test Case button on Edit Test Case page
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-            cy.get(TestCasesPage.executeTestCaseButton).should('exist')
-            cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
-            cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
-            cy.get(TestCasesPage.executeTestCaseButton).focus()
-            cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
-            cy.get(TestCasesPage.executeTestCaseButton).click()
-            cy.get(TestCasesPage.executeTestCaseButton).click()
-            cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
-
-            cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-            cy.get(EditMeasurePage.testCasesTab).click()
-
-            TestCasesPage.clickEditforCreatedTestCase()
-
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-            //attempt to click on 'Run Test Case' to run the test case via the edit page
-            cy.get(TestCasesPage.runTestButton).should('exist')
-            cy.get(TestCasesPage.runTestButton).should('be.visible')
-            cy.get(TestCasesPage.runTestButton).should('be.enabled')
-            cy.get(TestCasesPage.runTestButton).click()
-
-            //navigate to the details tab for the test case
-            cy.get(TestCasesPage.detailsTab).scrollIntoView().click()
-
-            cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).should('be.visible')
-            cy.get(TestCasesPage.testCaseJsonValidationErrorBtn).click()
-
-            //confirm no message
-            cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('contain.text', 'No code provided, and a code should be provided from the value set \'US Core Encounter Type\' (http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.0)')
-        })
 })
 
 describe('Verify multiple IPs on the highlighting tab', () => {
@@ -1761,7 +1737,7 @@ describe('Verify multiple IPs on the highlighting tab', () => {
     afterEach('Logout and Clean up Measures', () => {
 
         OktaLogin.Logout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Multiple IPs appear on the highlighting test case tab', () => {


### PR DESCRIPTION
Fixes RunAndExecuteTestCaseButtonValidations.cy.ts

Summary:
Removed & replaced troublesome CQL with a new, smaller version to avoid our new favorite error.
Updated deleteMeasure() to new syntax.
Removed handful of unneeded interactions/navigations.

Within describe .....populations are treated as zeroes: scenario 2 is just scenario 1 + several other steps.
I updated scenario 1 to pass, then copy/pasted it into scenario 2 to ensure they are the same.
The diff looks really odd & bad below.