### PR TITLE
Regression failure fixes: Webinterface tests:  ExpectedValuesForObservations test file fix 231

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -831,7 +831,7 @@ export class TestCasesPage {
 
     public static ValidateValueAddedToTestCaseJson(ValueToBeAdded: string): void {
 
-        cy.get(this.aceEditor).type('{command}f')
+        cy.get(this.tcSearchIcone).click()
         cy.get('input.ace_search_field').first().type(ValueToBeAdded)
 
         cy.get(this.aceEditor).invoke('text').then(


### PR DESCRIPTION
This PR contains a necessary update to the TestCasePage support file to resolve a failure seen in the ExpectedValuesForObservations regression test file, while executing the last automated regression test suite run.