### PR TITLE
feat: new test for calculator checks

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -380,6 +380,25 @@ export class TestCasesPage {
     public static readonly leftNavExpand = '[data-testid="test-case-sidebar-expand-icon"]'
     public static readonly leftNavMenuList = '[data-testid="test-case-sidebar"]'
 
+    public static readonly openDateCalculator = '[data-testid="editor-calculator-button"]'
+    public static readonly calculatorTool = {
+        durDiffTab: '[data-testid="duration-difference-tab"]',
+        startDate: '[data-testid="start-date-input"]',
+        endDate: '[data-testid="end-date-input"]',
+        precision: '#precision-select',
+        includeEndDateCheckbox: '#endDateInclusive',
+        calculateDuration: '[data-testid="calculate-duration"]',
+        durationResults: '[data-testid="duration-result"]',
+        differenceResults: '[data-testid="difference-result"]',
+        computedDateTab: '[data-testid="computed-date-tab"]',
+        initialDate: '[data-testid="initial-date-input"]',
+        addRadio: '[data-testid="add-subtract-option-radio-buttons-group"] input[type="radio"]:first', //name = mui-101
+        subtractRadio: '[data-testid="add-subtract-option-radio-buttons-group"] input[type="radio"]:last',
+        dwmyInput: '[data-testid="precision-number-input"]',
+        dwmyUnitsSelect: '[data-testid="precision-input"]', //same as above?
+        close: '[data-testid="calculation-close-button"]'
+    }
+
     //This function grabs the data-testid value off of the view button and extracts the id out of it.
     //Then, it puts that id in a file. For added control, the optional "eleTableEntry" parameter can be
     //used to specify which entry we are wanting to grab the id off of. For example, if you have two entries

--- a/cypress/e2e/WebInterface/Test Cases/CalculatorDates.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/CalculatorDates.cy.ts
@@ -1,0 +1,120 @@
+import { CreateMeasurePage, CreateMeasureOptions, SupportedModels } from "../../../Shared/CreateMeasurePage"
+import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
+import { TestCase, TestCasesPage } from "../../../Shared/TestCasesPage"
+import { OktaLogin } from "../../../Shared/OktaLogin"
+import { Utilities } from "../../../Shared/Utilities"
+import { MeasuresPage } from "../../../Shared/MeasuresPage"
+import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
+import { TestCaseJson } from "../../../Shared/TestCaseJson"
+import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
+import { QiCore6Cql } from "../../../Shared/FHIRMeasuresCQL"
+const dayjs = require('dayjs')
+
+const now = Date.now()
+const measureName = 'CalculatorDates' + now
+const libraryName = 'CalculatorDatesLib' + now
+const testCase: TestCase = {
+    title: 'cohortEnc',
+    description: 'testing test cases',
+    group: 'IPPass',
+    json: TestCaseJson.fromCMS529IPP
+}
+const opts: CreateMeasureOptions = {
+    // test measure based on CMS529FHIR, same config as CohortEncounter600.cy.ts
+    measureCql: QiCore6Cql.cqlCMS529, 
+    mpStartDate: '2026-01-01',
+    mpEndDate: '2026-12-31'
+}
+const today = dayjs().format('MM/DD/YYYY')
+
+
+describe('Check all variations of calculated dates', () => {
+
+    beforeEach('Create Measure and Test Case', () => {
+
+        CreateMeasurePage.CreateMeasureAPI(measureName, libraryName, SupportedModels.qiCore6, opts)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', 'Encounter')
+        TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description, testCase.json)
+
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+
+        cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.clickEditforCreatedTestCase()
+        cy.get(TestCasesPage.openDateCalculator).click()
+    })
+
+    afterEach('Clean up', () => {
+
+        OktaLogin.Logout()
+        Utilities.deleteMeasure()
+    })
+
+    it('Check all options in Duration/Difference tab', () => {
+
+        // verify initial
+        cy.contains('Start Date').should('be.visible')
+        cy.contains('End Date').should('be.visible')
+        cy.contains('Precision').should('be.visible')
+        cy.contains('Duration Result').should('be.visible')
+        cy.contains('Difference Result').should('be.visible')
+
+        // years, enter start end calculate
+        cy.get(TestCasesPage.calculatorTool.startDate).type('01/01/2020')
+        cy.get(TestCasesPage.calculatorTool.endDate).type('06/01/2020')
+        cy.get(TestCasesPage.calculatorTool.calculateDuration).click()
+
+        cy.get(TestCasesPage.calculatorTool.durationResults).should('have.text', '0 years')
+        cy.get(TestCasesPage.calculatorTool.differenceResults).should('have.text', '1 years')
+
+        // switch to months, check include end date
+        Utilities.dropdownSelect(TestCasesPage.calculatorTool.precision, 'months')
+        cy.get(TestCasesPage.calculatorTool.includeEndDateCheckbox).click()
+        cy.get(TestCasesPage.calculatorTool.calculateDuration).click()
+
+        cy.get(TestCasesPage.calculatorTool.durationResults).should('have.text', '5 months')
+        cy.get(TestCasesPage.calculatorTool.differenceResults).should('have.text', '6 months')
+
+        // switch to weeks, leave include on
+        Utilities.dropdownSelect(TestCasesPage.calculatorTool.precision, 'weeks')
+        cy.get(TestCasesPage.calculatorTool.calculateDuration).click()
+
+        cy.get(TestCasesPage.calculatorTool.durationResults).should('have.text', '21 weeks')
+        cy.get(TestCasesPage.calculatorTool.differenceResults).should('have.text', '22 weeks')
+
+        //switch to days
+        Utilities.dropdownSelect(TestCasesPage.calculatorTool.precision, 'days')
+        cy.get(TestCasesPage.calculatorTool.calculateDuration).click()
+
+        cy.get(TestCasesPage.calculatorTool.durationResults).should('have.text', '153 days')
+        cy.get(TestCasesPage.calculatorTool.differenceResults).should('have.text', '153 days')
+
+        // click on both Today buttons
+        cy.get('[data-testid="ds-btn"]').eq(0).click()
+        cy.get(TestCasesPage.calculatorTool.startDate).should('have.value', today)
+
+        cy.get('[data-testid="ds-btn"]').eq(1).click()
+        cy.get(TestCasesPage.calculatorTool.endDate).should('have.value', today)
+
+        // close
+        cy.get(TestCasesPage.calculatorTool.close).click()
+    })
+
+    it.skip('Check all options in Computed Date tab', () => {
+
+        // verify initial
+        cy.contains('Initial Date').should('be.visible')
+        cy.contains('Add/Subtract').should('be.visible')
+        cy.contains('Dayys/Weeks/Months/Years').should('be.visible')
+        cy.contains('Computed Date Result').should('be.visible')
+    })
+})


### PR DESCRIPTION
Added new test for https://jira.cms.gov/browse/MAT-9063
Also sets up for the next few calculator stories.

Performs basic validations of labels, then steps through a basic calculation using each option from the 1st tab.

Note the object style. selectors on TestCasesPage.ts
I wanted to try this to package the related selectors all together. If this style doesn't work, I could also try adding Shared/Calculator.ts to house these.