### PR TITLE
feat: refactor to remove test case import

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -260,7 +260,6 @@ export class TestCasesPage {
     public static readonly raceOmbElementTab = '[data-testid="demographics-race-omb"]'
     public static readonly genderDdOnElementTab = '[id="gender-selector"]'
     public static readonly genderSelectValuesElementTab = '[class="MuiList-root MuiList-padding MuiMenu-list css-r8u8y9"]'
-    public static readonly bonnieImportTestCaseBtn = '[data-testid="import-test-cases-from-bonnie-button"]'
     public static readonly highlightingPCTabSelector = '[data-testid="population-criterion-selector"]'
     public static readonly lastSavedDate = '[data-testid="test-case-title-0_lastModifiedAt"]'
     public static readonly testCaseNameDropdown = '#edit-test-case-bread-crumbs > .MuiInputBase-root > .MuiSelect-select'
@@ -296,8 +295,6 @@ export class TestCasesPage {
 
     //import test case
     public static readonly importTestCasesBtn = '[data-testid="import-test-cases-button"]'
-    public static readonly qdmImportTestCasesBtn = '[data-testid="show-import-test-cases-button"]'
-
     public static readonly filAttachDropBox = '[data-testid="file-drop-input"]'
     public static readonly importInProgress = '[data-testid = "testcase-list-loading-spinner"]'
     public static readonly importWarningMessages = '[data-testid="import-warning-messages"]'
@@ -313,13 +310,11 @@ export class TestCasesPage {
     public static readonly importTestCaseCancelBtnOnModal = '[data-testid="test-case-import-cancel-btn"]'
     public static readonly importTestCaseAlertMessage = '[class="madie-alert warning"]'
     public static readonly importTestCaseBtn = '[data-testid="import-test-case-btn"]'
-    public static readonly testCaseFileImport = '[data-testid="import-file-input"]'
     public static readonly tcFileDrop = '[data-testid="file-drop-div"]'
     public static readonly tcImportButton = '[data-testid="select-file-button"]'
     public static readonly tcImportError = '[data-testid="test-case-import-error-div"]'
     public static readonly testCasesNonBonnieFileImportModal = '[data-testid="test-case-import-content-div"]'
     public static readonly testCasesNonBonnieFileImportFileLineAfterSelectingFile = '[data-testid="test-case-preview-header"]'
-    public static readonly importTestCaseSuccessMsg = '[data-testid="success-toast"]'
     public static readonly importTestCaseSuccessInfo = '[id="content"]'
 
     //Export Test Cases
@@ -471,28 +466,6 @@ export class TestCasesPage {
         })
 
         cy.get(EditMeasurePage.testCasesTab).click()
-    }
-
-    public static clickQDMImportTestCaseButton(): void {
-
-        cy.readFile('cypress/fixtures/measureId').should('exist').then((measureID) => {
-            cy.intercept('PUT', '/api/measures/' + measureID + '/test-cases/imports/qdm').as('testCaseList')
-            //click import button on modal window
-
-            cy.get(this.importTestCaseBtnOnModal).click()
-            //spinner indicating that import progress is busy is shown / is visible
-            cy.get(this.importInProgress).should('be.visible')
-
-            //wait until the import buttong appears on the page, again
-            Utilities.waitForElementVisible(this.qdmImportTestCasesBtn, 50000)
-
-            //list is returned
-            cy.wait('@testCaseList').then(({ response }) => {
-                expect(response.statusCode).to.eq(200)
-            })
-        })
-
-
     }
 
     public static grabValidateTestCaseNumber(testCaseNumber: number): void {
@@ -836,18 +809,6 @@ export class TestCasesPage {
         return user
     }
 
-    public static ImportTestCaseFile(TestCaseFile: string): void {
-
-        //Upload valid Json file
-        cy.get(this.testCaseFileImport).attachFile(TestCaseFile)
-
-        cy.get(this.importTestCaseSuccessMsg).should('contain.text', 'Test Case JSON copied into editor. QI-Core Defaults have been added. Please review and save your Test Case.')
-
-        //Save uploaded Test case
-        cy.get(this.editTestCaseSaveButton).click({ force: true })
-        Utilities.waitForElementDisabled(this.editTestCaseSaveButton, 6500)
-    }
-
     public static ValidateValueAddedToTestCaseJson(ValueToBeAdded: string): void {
 
         cy.get(this.tcSearchIcone).click()
@@ -899,7 +860,6 @@ export class TestCasesPage {
             .parent('tr')
             .find('input[type="checkbox"]')
             .check()
-
     }
 
     /*
@@ -965,15 +925,6 @@ export class TestCasesPage {
             case TestCaseAction.shiftDates:
                 // still coming, tbd
                 break
-
         }
-
-    }
-
-    public static checkToastMessageOK(element: string) {
-
-        cy.get(element).each(msg => {
-            expect(msg.text()).to.be.oneOf(['Test case updated successfully!', 'Test case updated successfully with warnings in JSON', 'Test case updated successfully with warnings in JSONMADiE only supports a timezone offset of 0. MADiE has overwritten any timezone offsets that are not zero.', 'Test case updated successfully with errors in JSONMADiE only supports a timezone offset of 0. MADiE has overwritten any timezone offsets that are not zero.', 'Test case updated successfully with errors in JSON'])
-        })
     }
 }

--- a/cypress/e2e/Services/Measure Service/MeasureAssociation.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureAssociation.cy.ts
@@ -8,6 +8,7 @@ import { TestCasesPage } from "../../../Shared/TestCasesPage"
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
 import { Header } from "../../../Shared/Header"
+import { Toasts } from "../../../Shared/Toasts"
 
 let randValue = (Math.floor((Math.random() * 1000) + 1))
 let measureCQLPFTests = MeasureCQL.CQL_Populations
@@ -215,7 +216,7 @@ describe('Measure Association: Validations', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         Utilities.waitForElementVisible('.toast', 35000)
         cy.get('.toast').should('contain.text', 'New version of measure is Successfully created')
-        Utilities.waitForElementToNotExist(TestCasesPage.importTestCaseSuccessMsg, 35000)
+        Utilities.waitForElementToNotExist(Toasts.otherSuccessToast, 35000)
         OktaLogin.UILogout()
         cy.getCookie('accessToken').then((accessToken) => {
             cy.readFile('cypress/fixtures/measureId1').should('exist').then((qdmId2) => {

--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
@@ -6,7 +6,6 @@ import { MeasureCQL } from "../../../../Shared/MeasureCQL"
 import { Utilities } from "../../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { Header } from "../../../../Shared/Header"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { LandingPage } from "../../../../Shared/LandingPage"
 import { Toasts } from "../../../../Shared/Toasts"
@@ -28,7 +27,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
 
         newMeasureName = 'DraftVersionValidations' + Date.now() + randValue
         newCqlLibraryName = 'DraftVersionValidationsLib' + Date.now() + randValue
-        //Create New Measure and Measure Group
+
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, cohortMeasureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI()
 
@@ -179,7 +178,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(Toasts.generalToast).should('contain.text', 'New draft created successfully.')
         cy.log('Draft Created Successfully')
 
-        Utilities.waitForElementToNotExist(TestCasesPage.importTestCaseSuccessMsg, 100000)
+        Utilities.waitForElementToNotExist(Toasts.otherSuccessToast, 30000)
 
         // allow for measures to load, if not already done
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
@@ -207,10 +206,15 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
 
         //Search for the Measure using original 4.1.1 Measure name
         cy.log('Search Measure with measure name')
+        Utilities.dropdownSelect(MeasuresPage.filterByDropdown, 'Measure')
         cy.get(MeasuresPage.searchInputBox).clear().type(newMeasureName).type('{enter}')
+        
+        // expand to see original
+        cy.get('[data-testid*="_expandArrow"]').click()
         cy.get(MeasuresPage.measureListTitles).should('contain', newMeasureName)
 
-        cy.get('[class="px-1"]').find('[class=" cursor-pointer"]').eq(0).click()
+        // check original measure
+        cy.get('[class="expanded-row"]').find('input[type="checkbox"]').click()
         cy.wait(2000)
         cy.get('[data-testid="draft-action-tooltip"]').should('have.attr', 'aria-label', 'You cannot draft a 4.1.1 measure when a 6.0.0 version is available')
     })
@@ -259,7 +263,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(Toasts.generalToast).should('contain.text', 'New draft created successfully.')
         cy.log('v6 Draft Created Successfully')
 
-        Utilities.waitForElementToNotExist(TestCasesPage.importTestCaseSuccessMsg, 100000)
+        Utilities.waitForElementToNotExist(Toasts.otherSuccessToast, 30000)
 
         //navigate back to the main MADiE / measure list page
         cy.get(Header.mainMadiePageButton).click()
@@ -321,7 +325,8 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
     })
 })
 
-describe('Draft and Version Validations - upgrade QiCore v6.0.0 to v7.0.0', () => {
+//skipping due to Stu7 not being active / set to true, yet, in PROD
+describe.skip('Draft and Version Validations - upgrade QiCore v6.0.0 to v7.0.0', () => {
 
     beforeEach('Create Measure, add Cohort group and Login', () => {
 
@@ -347,8 +352,8 @@ describe('Draft and Version Validations - upgrade QiCore v6.0.0 to v7.0.0', () =
 
         OktaLogin.UILogout()
     })
-    //skipping due to Stu7 not being active / set to true, yet, in PROD
-    it.skip('Change model from v6.0.0 - to - v7.0.0 with versioning and drafting but cannot draft from 7.0.0 back down', () => {
+    
+    it('Change model from v6.0.0 - to - v7.0.0 with versioning and drafting but cannot draft from 7.0.0 back down', () => {
 
         updatedMeasuresPageName = 'upgradedTo7' + Date.now()
 
@@ -390,7 +395,7 @@ describe('Draft and Version Validations - upgrade QiCore v6.0.0 to v7.0.0', () =
         cy.log('v7 Draft Created Successfully')
 
         // version to 2.0.000
-        Utilities.waitForElementToNotExist(TestCasesPage.importTestCaseSuccessMsg, 100000)
+        Utilities.waitForElementToNotExist(Toasts.otherSuccessToast, 30000)
 
         //Search for the Measure using Measure name
         cy.log('Search Measure with measure name')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
@@ -9,7 +9,7 @@ import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
 import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
 import { Header } from "../../../../../Shared/Header"
 import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
-import { CQLLibraryPage } from "../../../../../Shared/CQLLibraryPage"
+import { Toasts } from "../../../../../Shared/Toasts"
 
 let measureName = 'RatioListQDMPositiveEncounterPerformedWithMO' + Date.now()
 let measureCQL2RunObservations = MeasureCQL.CQLQDMObservationRun
@@ -261,7 +261,6 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         measureData.mpStartDate = '2023-01-01'
         measureData.mpEndDate = '2024-01-01'
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson, false, false)
         OktaLogin.Login()
@@ -269,11 +268,10 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
 
     afterEach('Clean up', () => {
 
-        OktaLogin.Logout()
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
-
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure()
     })
+
     it('Test Case expected / actual measure observation field aligns with what has been entered in the population criteria and other appropriate fields and sections', () => {
 
         //Click on Edit Measure
@@ -285,28 +283,24 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         CQLEditorPage.validateSuccessfulCQLUpdate()
 
         //fill out group details
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
-        cy.get(MeasureGroupPage.initialPopulationSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
-        cy.get(MeasureGroupPage.denominatorSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
+         cy.get(EditMeasurePage.measureGroupsTab).click()
+         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
+
+        Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
+        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
+
         cy.get(MeasureGroupPage.addDenominatorObservationLink).click()
-        cy.get(MeasureGroupPage.denominatorObservation).click()
-        cy.get('[data-value="Denominator Observations"]').click()
-        cy.get(MeasureGroupPage.denominatorAggregateFunction).click()
-        cy.get('[data-value="Average"]').click()
-        cy.get(MeasureGroupPage.denominatorExclusionSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(4).click()
-        cy.get(MeasureGroupPage.numeratorSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorObservation, 'Denominator Observations')
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorAggregateFunction, 'Average')
+
+        Utilities.populationSelect(MeasureGroupPage.denominatorExclusionSelect, 'Denominator Exclusions')
+        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, 'Numerator')
+
         cy.get(MeasureGroupPage.addNumeratorObservationLink).click()
-        cy.get(MeasureGroupPage.numeratorObservation).click()
-        cy.get('[data-value="Denominator Observations"]').click()
-        cy.get(MeasureGroupPage.numeratorAggregateFunction).click()
-        cy.get('[data-value="Average"]').click()
-        cy.get(MeasureGroupPage.numeratorExclusionSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorObservation, 'Numerator Observations')
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorAggregateFunction, 'Average')
+
+        Utilities.populationSelect(MeasureGroupPage.numeratorExclusionSelect, 'Denominator Exclusions')
 
         //save group details
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
@@ -346,7 +340,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
 
         //save test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.importTestCaseSuccessMsg).should('contain.text', 'Test Case Updated Successfully')
+        cy.get(Toasts.otherSuccessToast).should('contain.text', 'Test Case Updated Successfully')
 
         //navigate to the main measures page and edit the measure
         cy.get(Header.measures).click()
@@ -374,6 +368,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.numer1Observation).should('be.visible')
         cy.get(TestCasesPage.numer2Observation).should('not.exist')
     })
+
     it('Non-owner of measure cannot edit observation fields', () => {
 
         //Click on Edit Measure
@@ -386,26 +381,22 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         //fill out group details
         cy.get(EditMeasurePage.measureGroupsTab).click()
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
-        cy.get(MeasureGroupPage.initialPopulationSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
-        cy.get(MeasureGroupPage.denominatorSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
+
+        Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
+        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
+
         cy.get(MeasureGroupPage.addDenominatorObservationLink).click()
-        cy.get(MeasureGroupPage.denominatorObservation).click()
-        cy.get('[data-value="Denominator Observations"]').click()
-        cy.get(MeasureGroupPage.denominatorAggregateFunction).click()
-        cy.get('[data-value="Average"]').click()
-        cy.get(MeasureGroupPage.denominatorExclusionSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(4).click()
-        cy.get(MeasureGroupPage.numeratorSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorObservation, 'Denominator Observations')
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorAggregateFunction, 'Average')
+
+        Utilities.populationSelect(MeasureGroupPage.denominatorExclusionSelect, 'Denominator Exclusions')
+        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, 'Numerator')
+
         cy.get(MeasureGroupPage.addNumeratorObservationLink).click()
-        cy.get(MeasureGroupPage.numeratorObservation).click()
-        cy.get('[data-value="Denominator Observations"]').click()
-        cy.get(MeasureGroupPage.numeratorAggregateFunction).click()
-        cy.get('[data-value="Average"]').click()
-        cy.get(MeasureGroupPage.numeratorExclusionSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(5).click()
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorObservation, 'Numerator Observations')
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorAggregateFunction, 'Average')
+
+        Utilities.populationSelect(MeasureGroupPage.numeratorExclusionSelect, 'Denominator Exclusions')
 
         //save group details
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
@@ -445,7 +436,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
 
         //save test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.importTestCaseSuccessMsg).should('contain.text', 'Test Case Updated Successfully')
+        cy.get(Toasts.otherSuccessToast).should('contain.text', 'Test Case Updated Successfully')
 
         // //log out of MADiE
         // OktaLogin.UILogout()
@@ -455,7 +446,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.clearLocalStorage()
         OktaLogin.AltLogin()
         cy.get(MeasuresPage.allMeasuresTab).click()
-        cy.reload()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
 
         //edit the measure
         MeasuresPage.actionCenter('edit')
@@ -479,10 +470,9 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.numer0Observation).should('not.be.enabled')
         cy.get(TestCasesPage.numer1Observation).should('not.be.enabled')
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('not.be.enabled')
-        OktaLogin.UILogout()
-
     })
 })
+
 describe('QDM Measure: Test Case: with Observations: Expected / Actual results', () => {
 
     beforeEach('Create Measure', () => {
@@ -495,11 +485,10 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
         measureData.mpStartDate = '2023-01-01'
         measureData.mpEndDate = '2025-01-01'
 
-        //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, QDMTCJsonwMOElements, false, false)
         OktaLogin.Login()
-        //Click on Edit Measure
+
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
@@ -510,33 +499,28 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
     afterEach('Clean up', () => {
 
         OktaLogin.Logout()
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
-
+        Utilities.deleteMeasure()
     })
+
     it('Test Case expected / actual measure observation field aligns with what has been entered in the population criteria and other appropirate fields and sections', () => {
 
         //fill out group details
         cy.get(EditMeasurePage.measureGroupsTab).click()
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
-        cy.get(MeasureGroupPage.initialPopulationSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(14).click()
-        cy.get(MeasureGroupPage.denominatorSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(4).click()
+
+        Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
+        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
+
         cy.get(MeasureGroupPage.addDenominatorObservationLink).click()
-        cy.get(MeasureGroupPage.denominatorObservation).click()
-        cy.get(TestCasesPage.SelectionOptionChoice).contains('Denominator Observations').click()
-        cy.get(MeasureGroupPage.denominatorAggregateFunction).click()
-        cy.get(MeasureGroupPage.aggregateFunctionDropdownList).eq(0).click()
-        cy.get(MeasureGroupPage.denominatorExclusionSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(3).click()
-        cy.get(MeasureGroupPage.numeratorSelect).click()
-        cy.get(MeasureGroupPage.measurePopulationOption).eq(15).click()
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorObservation, 'Denominator Observations')
+        Utilities.dropdownSelect(MeasureGroupPage.denominatorAggregateFunction, 'Average')
+
+        Utilities.populationSelect(MeasureGroupPage.denominatorExclusionSelect, 'Denominator Exclusions')
+        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, 'Numerator')
+
         cy.get(MeasureGroupPage.addNumeratorObservationLink).click()
-        cy.get(MeasureGroupPage.numeratorObservation).click()
-        cy.get(TestCasesPage.SelectionOptionChoice).contains('Numerator Observations').click()
-        cy.get(MeasureGroupPage.numeratorAggregateFunction).click()
-        cy.get(MeasureGroupPage.aggregateFunctionDropdownList).contains('Sum').click()
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorObservation, 'Numerator Observations')
+        Utilities.dropdownSelect(MeasureGroupPage.numeratorAggregateFunction, 'Sum')
 
         //save group details
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
@@ -573,7 +557,7 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
 
         //save test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.importTestCaseSuccessMsg).should('contain.text', 'Test Case Updated Successfully')
+        cy.get(Toasts.otherSuccessToast).should('contain.text', 'Test Case Updated Successfully')
 
         cy.get(TestCasesPage.runQDMTestCaseBtn).click()
 
@@ -583,6 +567,5 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
         cy.get(TestCasesPage.denomExclusionActualCheckBox).should('contain.value', '0')
         cy.get(TestCasesPage.numActualCheckBox).should('contain.value', '1')
         cy.get(TestCasesPage.numeratorMeasureObservationActualValue).should('contain.value', '1')
-
     })
 })


### PR DESCRIPTION
First pass at refactoring to remove unused aspects of the single test case import feature (recently removed from Madie).
 
Functions removed were not used in any tests.
Selectors were either unused or only used in removed functions.

Tests using selectors were switched to use the same values from Toasts.ts
I ran the affected tests & made necessary fixes to return them to passing, see comments for details.