### PR TITLE
fix: updated test and removed unused stuff

### DIFF
--- a/cypress/Shared/CQLLibrariesPage.ts
+++ b/cypress/Shared/CQLLibrariesPage.ts
@@ -18,7 +18,7 @@ export class CQLLibrariesPage {
 
     //Libraries row 0 elements
     public static readonly cqlLibraryVersionList = '[data-testid="cqlLibrary-button-0_version"]'
-    public static readonly row0_Status = '[data-testid="cqlLibrary-button-0_status"]'
+    public static readonly row0_Status = '[data-testid="cqlLibrary-button-0_draft"]'
     public static readonly row0_ExpandArrow = '[data-testid="cqlLibrary-button-0_expandArrow"]'
 
     //Action Center buttons
@@ -63,7 +63,6 @@ export class CQLLibrariesPage {
             cy.wait('@cqlLibrary').then(({ response }) => {
                 expect(response.statusCode).to.eq(200)
             })
-
         })
         cy.get('[data-testid="CQL Library Details"]').click()
     }
@@ -100,7 +99,6 @@ export class CQLLibrariesPage {
             cy.wait('@cqlLibrary').then(({ response }) => {
                 expect(response.statusCode).to.eq(200)
             })
-
         })
     }
 
@@ -108,7 +106,6 @@ export class CQLLibrariesPage {
 
         cy.readFile('cypress/fixtures/cqlLibraryId').should('exist').then((fileContents) => {
             cy.get('[data-testid="cqlLibrary-button-' + fileContents + '-content"]').should('contain', expectedValue)
-
         })
     }
 

--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -7,7 +7,6 @@ import { CQLEditorPage } from "./CQLEditorPage"
 import { SupportedModels } from "./CreateMeasurePage"
 
 export enum EditLibraryActions {
-
     delete,
     version,
     draft,
@@ -27,10 +26,6 @@ export type CreateLibraryOptions = {
 const filePath = 'cypress/fixtures/cqlLibraryId'
 
 export class CQLLibraryPage {
-    // older 2 tabs
-    public static readonly allLibrariesBtn = '[data-testid="all-cql-libraries-tab"]' // all refs removed
-    public static readonly myLibrariesBtn = '[data-testid="my-cql-libraries-tab"]' // all refs removed
-    // new 3 tabs, with LibrarySearchh = true
     public static readonly ownedLibrariesTab = '[data-testid="owned-libraries-tab"]'
     public static readonly sharedLibrariesTab = '[data-testid="shared-libraries-tab"]'
     public static readonly allLibrariesTab = '[data-testid="all-libraries-tab"]'
@@ -50,9 +45,6 @@ export class CQLLibraryPage {
     public static readonly libraryListTitles = '[data-testid="cqlLibrary-list"]'
     public static readonly LibFilterTextField = '[data-testid="library-search-input"]'
     public static readonly filterByDropdown = '[data-testid="filter-by"]'
-    public static readonly LibFilterSubmitBtn = '[data-testid="library-filter-submit"]'
-    public static readonly LibFilterLabel = '[id="mui-2-label"]'
-    public static readonly LibTableRows = '[data-testid="row-item"]'
     public static readonly cqlLibraryModelQICore = '[data-testid="cql-library-model-option-QI-Core v4.1.1"]'
     public static readonly saveCQLLibraryBtn = '[data-testid="continue-button"]'
     public static readonly updateCQLLibraryBtn = '[data-testid="cql-library-save-button"]'
@@ -98,7 +90,6 @@ export class CQLLibraryPage {
     public static readonly cqlLibraryModelQDM = '[data-testid="cql-library-model-option-QDM v5.6"]'
 
     public static createCQLLibrary(CQLLibraryName: string, CQLLibraryPublisher: string): void {
-
 
         cy.get(Header.cqlLibraryTab).should('be.visible')
 

--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
@@ -10,6 +10,7 @@ let CqlLibraryOne: string
 const CQLLibraryPublisher = 'SemanticBits'
 const versionNumber = '1.0.000'
 const filePath = 'cypress/fixtures/cqlLibraryId'
+const filePath2 = 'cypress/fixtures/cqlLibraryId2'
 
 describe('Action Center Buttons - Add Draft to CQL Library', () => {
 
@@ -20,8 +21,6 @@ describe('Action Center Buttons - Add Draft to CQL Library', () => {
         CQLLibraryPage.versionLibraryAPI(versionNumber)
     })
 
-    // just this 1st test has been prepped for when FF LibrarySearch = true, see references to MAT-5119
-    // as of right now, this version should fail in DEV but pass in TEST
     it('Add Draft to the versioned Library from Owned Libraries', () => {
 
         //Add Draft to Versioned Library
@@ -43,38 +42,25 @@ describe('Action Center Buttons - Add Draft to CQL Library', () => {
         })
         cy.get(CQLLibrariesPage.createDraftContinueBtn).click()
 
-        //once this epic https://jira.cms.gov/browse/MAT-5119, is ready for deployment, the following code can be
-        //uncommented and used
-        // cy.wait('@draft', { timeout: 60000 }).then((request) => {
-        //     cy.writeFile(filePath2, request.response.body.id)
-        // })
-
-        //This check will need to be removed once epic https://jira.cms.gov/browse/MAT-5119 is ready for deployment
         cy.wait('@draft', { timeout: 60000 }).then((request) => {
-            cy.writeFile(filePath, request.response.body.id)
+            cy.writeFile(filePath2, request.response.body.id)
         })
 
         cy.get(CQLLibrariesPage.VersionDraftMsgs).should('contain.text', 'New Draft of CQL Library is Successfully created')
 
-        //once this epic https://jira.cms.gov/browse/MAT-5119, is ready for deployment, the following code can be
-        //uncommented and used
-
-        // cy.get(CQLLibrariesPage.cqlLibraryVersionList).should('contain', '1.0.000')
-        // cy.get(CQLLibrariesPage.row0_Status).should('contain', 'Draft')
-        //
-        // cy.get(CQLLibrariesPage.row0_ExpandArrow).should('be.visible')
-        // cy.get(CQLLibrariesPage.row0_ExpandArrow).click()
-        //
-        // cy.readFile(filePath).should('exist').then((fileContents) => {
-        //     cy.get('[data-testid="cqlLibrary-expanded-' + fileContents + '"]').should('be.visible')
-        //     cy.get('[data-testid="cqlLibrary-button-' + fileContents + '-version-content"]').should('contain.text', '1.0.000')
-        //     cy.get('[data-testid="cqlLibrary-button-' + fileContents + '-content"]').should('contain.text', CqlLibraryOne)
-        //     cy.get('[data-testid="view-cql-library-button-' + fileContents + '"]').should('be.visible')
-        //     cy.get('[data-testid="view-cql-library-button-' + fileContents + '"]').should('be.enabled')
-        // })
-
-        //This check will need to be removed once epic https://jira.cms.gov/browse/MAT-5119 is ready for deployment
         cy.get(CQLLibrariesPage.cqlLibraryVersionList).should('contain', '1.0.000')
+        cy.get(CQLLibrariesPage.row0_Status).should('contain', 'Draft')
+        
+        cy.get(CQLLibrariesPage.row0_ExpandArrow).should('be.visible')
+        cy.get(CQLLibrariesPage.row0_ExpandArrow).click()
+        
+        cy.readFile(filePath).should('exist').then((fileContents) => {
+            cy.get('[data-testid="cqlLibrary-expanded-' + fileContents + '"]').should('be.visible')
+            cy.get('[data-testid="cqlLibrary-button-' + fileContents + '-version-content"]').should('contain.text', '1.0.000')
+            cy.get('[data-testid="cqlLibrary-button-' + fileContents + '-content"]').should('contain.text', CqlLibraryOne)
+            cy.get('[data-testid="view-cql-library-button-' + fileContents + '"]').should('be.visible')
+            cy.get('[data-testid="view-cql-library-button-' + fileContents + '"]').should('be.enabled')
+        })
 
         cy.log('Draft Created Successfully')
 
@@ -85,12 +71,7 @@ describe('Action Center Buttons - Add Draft to CQL Library', () => {
 
         cy.setAccessTokenCookie()
 
-
-        //Delete Draft Library after epic https://jira.cms.gov/browse/MAT-5119
-        //Utilities.deleteLibrary(CqlLibraryOne,false, 2)
-
-        //Delete Draft Library before epic https://jira.cms.gov/browse/MAT-5119
-        Utilities.deleteLibrary(CqlLibraryOne)
+        Utilities.deleteLibrary(CqlLibraryOne,false, 2)
     })
 
     it('Add Draft to the versioned Library from Edit Library screen', () => {


### PR DESCRIPTION
Updates AddDraftToVersionedCQLLibrary.cy.ts

I had left this test with updates already prepared when FF "LibrarySearch" was released.
So I made those expected updates here, plus found several unused selectors around CQL Libraries.