### PR TITLE
fix: test cleanup for Smoke CQL Library tests

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts
@@ -5,8 +5,7 @@ import { Utilities } from "../../../Shared/Utilities"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 
 let CQLLibraryName = ''
-let CQLLibraryPublisher = ''
-let model = ''
+const CQLLibraryPublisher = 'SemanticBits'
 
 describe('Create CQL Library', () => {
 
@@ -19,13 +18,11 @@ describe('Create CQL Library', () => {
 
         OktaLogin.Logout()
         Utilities.deleteLibrary(CQLLibraryName)
-
     })
 
     it('Navigate to CQL Library Page and create New QI-Core  CQL Library', () => {
 
         CQLLibraryName = 'QICoreCQLLibrary' + Date.now()
-        CQLLibraryPublisher = 'SemanticBits'
 
         CQLLibraryPage.createCQLLibrary(CQLLibraryName, CQLLibraryPublisher)
     })
@@ -33,12 +30,10 @@ describe('Create CQL Library', () => {
     it('Navigate to CQL Library Page and create New QDM CQL Library', () => {
 
         CQLLibraryName = 'QDMCQLLibrary' + Date.now()
-        CQLLibraryPublisher = 'SemanticBits'
-        model = 'QDM v5.6'
+        const model = 'QDM v5.6'
 
         cy.get(Header.cqlLibraryTab).should('be.visible')
-
-        cy.get(Header.cqlLibraryTab).click().wait(1500)
+        cy.get(Header.cqlLibraryTab).click()
 
         Utilities.waitForElementEnabled(CQLLibraryPage.createCQLLibraryBtn, 60000)
 
@@ -56,6 +51,7 @@ describe('Create CQL Library', () => {
 
         CQLLibraryPage.clickCreateLibraryButton()
         Utilities.waitForElementToNotExist('[class="toast success"]', 60000)
+        
         cy.get(Header.cqlLibraryTab).should('be.visible')
         cy.get(Header.cqlLibraryTab).click()
 

--- a/cypress/e2e/WebInterface/Smoke Tests/DeleteCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/DeleteCQLLibrary.cy.ts
@@ -3,13 +3,12 @@ import { Utilities } from "../../../Shared/Utilities"
 import { CQLLibraryPage, EditLibraryActions } from "../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 import { Header } from "../../../Shared/Header"
-import { CQLEditorPage } from "../../../Shared/CQLEditorPage";
+import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
-const libraryName = 'DeleteCQLLibraryTest' + randValue
+const libraryName = 'DeleteCQLLibraryTest' + Date.now()
 const publisher = 'Mayo Clinic'
 
-describe('Delete CQL Library - Library List Page', () => {
+describe('Delete CQL Library', () => {
 
     beforeEach('Create library and Login', () => {
 
@@ -22,7 +21,7 @@ describe('Delete CQL Library - Library List Page', () => {
         OktaLogin.Logout()
     })
 
-    it('Verify Library Owner can Delete Library through Library page Action center on Library list Page', () => {
+    it('Verify Library Owner can Delete Library through Action center on Library list Page', () => {
 
         let ownedCountBefore: number, 
             ownedCountAfter: number, 
@@ -95,24 +94,8 @@ describe('Delete CQL Library - Library List Page', () => {
         //Verify the deleted library is not on All Measures page list
         cy.get(CQLLibraryPage.libraryListTitles).should('not.contain', libraryName)
     })
-})
 
-describe('Delete CQL Library - Edit Library Page', () => {
-
-    beforeEach('Create library and Login', () => {
-
-        CQLLibraryPage.createCQLLibraryAPI(libraryName, publisher)
-        OktaLogin.Login()
-    })
-
-    afterEach('Logout', () => {
-
-        OktaLogin.Logout()
-    })
-
-    it('Verify Library Owner can Delete Library through Library page Action center on Edit Library Page', () => {
-
-        cy.get(Header.cqlLibraryTab).click()
+    it('Verify Library Owner can Delete Library through Action center on Edit Library Page', () => {
 
         CQLLibrariesPage.clickEditforCreatedLibrary()
 

--- a/cypress/e2e/WebInterface/Smoke Tests/EditCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/EditCQLLibrary.cy.ts
@@ -2,19 +2,20 @@ import { OktaLogin } from "../../../Shared/OktaLogin"
 import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { Header } from "../../../Shared/Header"
 import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
+import { Utilities } from "../../../Shared/Utilities"
+import { MeasuresPage } from "../../../Shared/MeasuresPage"
 
-let CQLLibraryName = 'TestLibrary' + Date.now()
-let updatedCQLLibraryName = 'UpdatedTestLibrary' + Date.now()
-let CQLLibraryPublisher = 'SemanticBits'
+const CQLLibraryName = 'SmokeEditLibrary' + Date.now()
+const updatedCQLLibraryName = 'UpdatedSELibrary' + Date.now()
+const CQLLibraryPublisher = 'SemanticBits'
 
-describe('Edit Measure', () => {
-    before('Create Measure', () => {
+describe('Smoke test - Edit CQL Library', () => {
 
-        //Create CQL Library
+    before('Create Library', () => {
+
         CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
         OktaLogin.Login()
-        cy.reload()
-
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
     })
 
     afterEach('Logout', () => {
@@ -22,19 +23,16 @@ describe('Edit Measure', () => {
     })
 
     it('Edit CQL Library Name and verify the library is updated on CQL Library page', () => {
-        cy.reload()
+
         //Edit CQL Library Name
         CQLLibrariesPage.clickEditforCreatedLibrary()
 
-        cy.get('[id="measures-main-nav-bar-tab"]').click()
-        //Edit CQL Library Name
-        CQLLibrariesPage.clickEditforCreatedLibrary()
-        cy.reload()
-        cy.get(CQLLibraryPage.cqlLibraryNameTextbox).wait(1000).clear()
-        cy.get(CQLLibraryPage.cqlLibraryNameTextbox).type(updatedCQLLibraryName)
+        cy.get(CQLLibraryPage.cqlLibraryNameTextbox).should('have.value', CQLLibraryName)
+        cy.get(CQLLibraryPage.cqlLibraryNameTextbox).clear().type(updatedCQLLibraryName)
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
 
         cy.get(CQLLibraryPage.genericSuccessMessage).should('be.visible')
+            .and('have.text', 'CQL updated successfully')
 
         cy.log('CQL Library Updated Successfully')
 


### PR DESCRIPTION
Clean-up and basic refactoring for 3 Smoke tests of CQL Library functionality.

See comments for details.