### PR TITLE
fix: revert tests to original

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCodeSearch.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCodeSearch.cy.ts
@@ -184,10 +184,9 @@ describe('QDM Code Search fields', () => {
         cy.get(CQLEditorPage.applyCodeBtn).click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Code AMB has already been defined in CQL.')
 
-        // commented out until https://jira.cms.gov/browse/MAT-9848 is fixed
         //Save and Discard changes button should be disabled
-        //cy.get(CQLEditorPage.saveCQLButton).should('be.disabled')
-        //cy.get(EditMeasurePage.cqlEditorDiscardButton).should('be.disabled')
+        cy.get(CQLEditorPage.saveCQLButton).should('be.disabled')
+        cy.get(EditMeasurePage.cqlEditorDiscardButton).should('be.disabled')
 
         //Navigate to Saved Codes tab
         cy.get(CQLEditorPage.savedCodesTab).click()

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLParameters.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLParameters.cy.ts
@@ -364,7 +364,7 @@ describe('Delete Saved Parameters', () => {
 
             cy.get(CQLEditorPage.modalXButton).should('be.visible')
 
-            cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should('have.text', 'Are you sure you want to delete this Parameter? ')
+            cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should('have.text', 'Are you sure you want to delete this Parameter?')
 
             cy.get(CQLEditorPage.modalActionWarning).should('have.text', 'This Action cannot be undone.')
 


### PR DESCRIPTION
https://jira.cms.gov/browse/MAT-9848

This PR restores the tests mentioned in the Jira ticket to their original forms.