### PR TITLE
fix: formatting and compiler errors

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/EditCQLLibraryValidations.cy.ts
@@ -4,7 +4,7 @@ import { CQLLibrariesPage } from "../../../Shared/CQLLibrariesPage"
 import { Header } from "../../../Shared/Header"
 import { Utilities } from "../../../Shared/Utilities"
 import { umlsLoginForm } from "../../../Shared/umlsLoginForm"
-import {CQLEditorPage} from "../../../Shared/CQLEditorPage"
+import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
 
 let CQLLibraryName = 'TestLibrary' + Date.now()
 let newCQLLibraryName = ''
@@ -26,7 +26,6 @@ describe('Edit CQL Library validations', () => {
 
     afterEach('Logout', () => {
 
-        
         Utilities.deleteLibrary(newCQLLibraryName)
     })
 

--- a/cypress/e2e/WebInterface/Measure/Measure Group/UpdateMeasureGroup.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/UpdateMeasureGroup.cy.ts
@@ -277,7 +277,7 @@ describe('Adding an Initial Population to group -- Ratio score only', () => {
         OktaLogin.SessionLogin()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 22700)
@@ -483,7 +483,7 @@ describe('Delete second Initial Population -- Ratio score only', () => {
         OktaLogin.SessionLogin()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore411.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore411.cy.ts
@@ -37,7 +37,7 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', 'Denominator Exceptions',
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
             'Numerator', '', 'Denominator')
 
         //Create Second QDM Measure
@@ -285,7 +285,7 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         MeasuresPage.actionCenter('edit', 5, { altUser: true })
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore600.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore600.cy.ts
@@ -39,7 +39,7 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', 'Denominator Exceptions',
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
             'Numerator', '', 'Denominator')
 
         //Create Second QDM Measure
@@ -66,13 +66,13 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         measureData.measureCql = MeasureCQL.CQL_BoneDensity_Proportion_Boolean
 
         CreateMeasurePage.CreateMeasureAPI(measureQICore, measureQICore, SupportedModels.qiCore6, measureData, 3)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', null, 3)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', undefined, 3)
 
         //Create second QI Core measure
         measureQICore2 = 'QICore600Measure2' + Date.now() + randValue + 2 + randValue
 
         CreateMeasurePage.CreateMeasureAPI(measureQICore2, measureQICore2, SupportedModels.qiCore6, measureData, 4)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', null, 4)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', undefined, 4)
 
         OktaLogin.Login()
 
@@ -287,13 +287,13 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         //validation test: both measures the user is not the owner of
         let measureQICore3 = 'QICore600Measure3' + Date.now() + randValue + 9 + randValue
         CreateMeasurePage.CreateMeasureAPI(measureQICore3, measureQICore3, SupportedModels.qiCore6, options, 5)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, true, 'Initial Population', null, 5)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, true, 'Initial Population', undefined, 5)
 
         OktaLogin.AltLogin()
         MeasuresPage.actionCenter('edit', 5, { altUser: true })
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/MeasureBundle.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/MeasureBundle.cy.ts
@@ -16,12 +16,12 @@ describe('Measure Bundle end points', () => {
     beforeEach('Create Measure and login', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Surgical Absence of Cervix', '', '', 'Surgical Absence of Cervix', '', 'Surgical Absence of Cervix', 'Procedure')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Surgical Absence of Cervix', '', '', 'Surgical Absence of Cervix', '', 'Surgical Absence of Cervix', 'Procedure')
 
         OktaLogin.SessionLogin()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
@@ -62,7 +62,7 @@ describe('Measure Bundle end points', () => {
                 cy.request({
                     url: '/api/measures/' + id,
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     },
                     method: 'GET',
 
@@ -105,7 +105,7 @@ describe('Measure Bundle end points', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
@@ -170,7 +170,7 @@ describe('Measure Bundle end points', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
@@ -195,7 +195,7 @@ describe('Measure bundle end point returns stratifications', () => {
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
@@ -268,7 +268,7 @@ describe('Measure bundle end point returns stratifications', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
@@ -366,7 +366,7 @@ describe('Measure bundle end point returns stratifications', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
@@ -466,7 +466,7 @@ describe('Measure bundle end point returns stratifications', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
@@ -583,7 +583,7 @@ describe('Verify the criteria reference for measure observations', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)
@@ -669,7 +669,7 @@ describe('Verify the criteria reference for measure observations', () => {
                     url: '/api/measures/' + id + '/bundle',
                     method: 'GET',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     }
                 }).then((response) => {
                     expect(response.status).to.eql(200)

--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
@@ -89,7 +89,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         })
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.wait('@draft', { timeout: 60000 }).then((request) => {
-            cy.writeFile(filePath, request.response.body.id)
+            cy.writeFile(filePath, request?.response?.body.id)
         })
         cy.get(Toasts.generalToast).should('contain.text', 'New draft created successfully.')
         cy.log('Draft Created Successfully')
@@ -132,7 +132,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         // capture measureId for new draft
         let draftId
         cy.wait('@newDraft', { timeout: 25000 }).then(int => {
-            draftId = int.response.body.id
+            draftId = int?.response?.body.id
 
             Utilities.waitForElementVisible('[data-testid=measure-action-' + draftId + ']', 30000)
             Utilities.waitForElementEnabled('[data-testid=measure-action-' + draftId + ']', 30000)
@@ -286,7 +286,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToenEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts
@@ -16,7 +16,6 @@ describe('Create CQL Library', () => {
 
     afterEach('Logout', () => {
 
-        
         Utilities.deleteLibrary(CQLLibraryName)
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateNewMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateNewMeasure.cy.ts
@@ -36,8 +36,6 @@ describe('Create New Measure', () => {
         cy.get(MeasuresPage.allMeasuresTab).click()
         //Verify the deleted measure on All Measures page list
         cy.get(MeasuresPage.measureListTitles).should('not.contain', measureName)
-
-        
     })
 
     it('Create QI Core 4.1.1 Measure', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateUpdateTestCaseQICORE411.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateUpdateTestCaseQICORE411.cy.ts
@@ -32,7 +32,7 @@ describe('Create and Update Test Case for Qi Core 4 Measure', () => {
     beforeEach('Create Measure and login', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Surgical Absence of Cervix', '', '', 'Surgical Absence of Cervix', '', 'Surgical Absence of Cervix', 'Procedure')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Surgical Absence of Cervix', '', '', 'Surgical Absence of Cervix', '', 'Surgical Absence of Cervix', 'Procedure')
         OktaLogin.Login()
         MeasuresPage.actionCenter("edit")
         cy.get(EditMeasurePage.cqlEditorTab).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/DeleteCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/DeleteCQLLibrary.cy.ts
@@ -16,11 +16,6 @@ describe('Delete CQL Library', () => {
         OktaLogin.Login()
     })
 
-    afterEach('Logout', () => {
-
-        
-    })
-
     it('Verify Library Owner can Delete Library through Action center on Library list Page', () => {
 
         let ownedCountBefore: number, 

--- a/cypress/e2e/WebInterface/Smoke Tests/DeleteMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/DeleteMeasure.cy.ts
@@ -41,7 +41,6 @@ describe('Delete Measure', () => {
         cy.get(MeasuresPage.allMeasuresTab).click()
         //Verify the deleted measure on All Measures page list
         cy.get(MeasuresPage.measureListTitles).should('not.contain', measureOne)
-
     })
 })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/DeleteTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/DeleteTestCase.cy.ts
@@ -34,10 +34,10 @@ describe('Delete Test Case', () => {
         CqlLibraryName = 'DeleteTCLib' + newTimestamp
         measureCQL = MeasureCQL.ICFCleanTest_CQL.replace('SimpleFhirLibrary', CqlLibraryName)
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2012-01-02', '2013-01-01')
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, null, null, null, null, null,
-            null, null, 'Procedure')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, undefined, undefined, undefined, undefined, undefined,
+            undefined, undefined, 'Procedure')
         TestCasesPage.CreateTestCaseAPI(testCase1.title, testCase1.group, testCase1.description)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')

--- a/cypress/e2e/WebInterface/Smoke Tests/EditMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/EditMeasure.cy.ts
@@ -25,7 +25,7 @@ describe('Edit Measure', () => {
                 url: '/api/measure',
                 method: 'POST',
                 headers: {
-                    Authorization: 'Bearer ' + accessToken.value
+                    Authorization: 'Bearer ' + accessToken?.value
                 },
                 body: {
                     "measureName": measureName,
@@ -49,8 +49,7 @@ describe('Edit Measure', () => {
 
     afterEach('Clean up and Logout', () => {
 
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
-        
+        Utilities.deleteMeasure()
     })
 
     it('Edit Measure Name and verify the measure name is updated on Measures page', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
@@ -23,7 +23,7 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
     before('Create New Measure and Login', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/QDMMeasureExport.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/QDMMeasureExport.cy.ts
@@ -44,7 +44,7 @@ describe('Successful QDM Measure Export', () => {
     before('Create New Measure and Login', () => {
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureDataNonPB)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'SDE Payer',
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'SDE Payer',
             'SDE Payer', '', 'SDE Payer', '', 'SDE Payer')
 
         OktaLogin.Login()
@@ -135,7 +135,7 @@ describe('QDM Measure Export for CMS Measure with huge included Library', () => 
         measureData.measureCql = qdmCMSMeasureCQL
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false,
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false,
             'Qualifying Encounters', 'Denominator Exclusions', '',
             'Encounter without Food Screening', '', 'Qualifying Encounters')
 

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
@@ -29,8 +29,8 @@ describe('QI-Core Measure Export', () => {
 
     before('Create New Measure and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'ipp', '', '', 'num', '', 'denom')
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false)
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'ipp', '', '', 'num', '', 'denom')
 
         OktaLogin.Login()
     })
@@ -165,8 +165,8 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
         measureNameFC = 'HRExport1' + Date.now()
         CqlLibraryNameFC = 'HRExport1Lib' + Date.now()
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureNameFC, CqlLibraryNameFC, measureCQLContent, null, false, mpStartDate, mpEndDate)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Qualifying Encounters', '', '', 'Qualifying Encounters', '', 'Qualifying Encounters', 'Encounter')
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureNameFC, CqlLibraryNameFC, measureCQLContent, 0, false, mpStartDate, mpEndDate)
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Qualifying Encounters', '', '', 'Qualifying Encounters', '', 'Qualifying Encounters', 'Encounter')
 
         OktaLogin.Login()
 
@@ -366,8 +366,8 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
         measureNameFC = 'HRExport2' + Date.now()
         CqlLibraryNameFC = 'HRExport2Lib' + Date.now()
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureNameFC, CqlLibraryNameFC, measureCQLContent, null, false, mpStartDate, mpEndDate)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Qualifying Encounters', '', '', 'Qualifying Encounters', '', 'Qualifying Encounters', 'Encounter')
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureNameFC, CqlLibraryNameFC, measureCQLContent, 0, false, mpStartDate, mpEndDate)
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Qualifying Encounters', '', '', 'Qualifying Encounters', '', 'Qualifying Encounters', 'Encounter')
 
         OktaLogin.Login()
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
@@ -143,14 +143,13 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false, false,
             '2025-01-01', '2025-12-31')
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, null, true)
+        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, undefined, true)
 
         OktaLogin.Login()
     })
 
     after('Clean up', () => {
 
-        
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Cohort_ListQDMPositiveEncounterPerformed.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Cohort_ListQDMPositiveEncounterPerformed.cy.ts
@@ -24,14 +24,13 @@ describe('Measure Creation: Cohort ListQDMPositiveEncounterPerformed', () => {
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false, false,
             '2012-01-01', '2012-12-31')
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, null, true)
+        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, undefined, true)
         OktaLogin.Login()
     })
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
-        Utilities.deleteMeasure()
+       Utilities.deleteMeasure()
     })
 
     it('End to End Cohort ListQDMPositiveEncounterPerformed', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/MeasureWithNegationRationale.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/MeasureWithNegationRationale.cy.ts
@@ -147,7 +147,6 @@ describe('Measure with Negation Rationale', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/ProportionPatient.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/ProportionPatient.cy.ts
@@ -16,68 +16,51 @@ const firstTestCaseTitle = 'DENEXStrat1Fail 2RUnilateralMxProc'
 const testCaseDescription = 'DENOMFail' + now
 const testCaseSeries = 'SBTestSeries'
 const secondTestCaseTitle = 'DENEXStrat2Pass RLMxDxOnsetsEndOfMP'
-const measureCQL = 'library ICFQDMTEST000001 version \'0.0.000\'\n' +
-    '\n' +
-    'using QDM version \'5.6\'\n' +
-    '\n' +
+const measureCQL = 'library ICFQDMTEST000001 version \'0.0.000\'\n\n' +
+    'using QDM version \'5.6\'\n\n' +
     'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n' +
     'include AdultOutpatientEncountersQDM version \'1.0.000\' called AdultOutpatientEncounters\n' +
     'include HospiceQDM version \'1.0.000\' called Hospice\n' +
     'include PalliativeCareQDM version \'4.0.000\' called PalliativeCare\n' +
-    'include AdvancedIllnessandFrailtyQDM version \'1.0.000\' called AIFrailLTCF\n' +
-    '\n' +
-    'codesystem "AdministrativeGender": \'urn:oid:2.16.840.1.113883.5.1\' \n' +
-    'codesystem "SNOMEDCT": \'urn:oid:2.16.840.1.113883.6.96\' \n' +
-    '\n' +
-    'valueset "Bilateral Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1005\' \n' +
-    'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\' \n' +
-    'valueset "History of bilateral mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1068\' \n' +
-    'valueset "Mammography": \'urn:oid:2.16.840.1.113883.3.464.1003.108.12.1018\' \n' +
-    '\n' +
-    'valueset "Outpatient": \'urn:oid:2.16.840.1.113883.3.464.1003.101.12.1087\' \n' +
-    'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\' \n' +
-    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\' \n' +
-    'valueset "Status Post Left Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1069\' \n' +
-    'valueset "Status Post Right Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1070\' \n' +
-    'valueset "Unilateral Mastectomy Left": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1133\' \n' +
-    'valueset "Unilateral Mastectomy Right": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1134\' \n' +
-    'valueset "Unilateral Mastectomy, Unspecified Laterality": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1071\' \n' +
-    '//valueset "Chemistry Tests": \'urn:oid:2.16.840.1.113762.1.4.1147.82\' \n' +
-    'valueset "CMS Sex": \'urn:oid:2.16.840.1.113762.1.4.1021.121\'\n' +
-    '\n' +
+    'include AdvancedIllnessandFrailtyQDM version \'1.0.000\' called AIFrailLTCF\n\n' +
+    'codesystem "AdministrativeGender": \'urn:oid:2.16.840.1.113883.5.1\'\n' +
+    'codesystem "SNOMEDCT": \'urn:oid:2.16.840.1.113883.6.96\'\n\n' +
+    'valueset "Bilateral Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1005\'\n' +
+    'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
+    'valueset "History of bilateral mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1068\'\n' +
+    'valueset "Mammography": \'urn:oid:2.16.840.1.113883.3.464.1003.108.12.1018\'\n' +
+    'valueset "Outpatient": \'urn:oid:2.16.840.1.113883.3.464.1003.101.12.1087\'\n' +
+    'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
+    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
+    'valueset "Status Post Left Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1069\'\n' +
+    'valueset "Status Post Right Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1070\'\n' +
+    'valueset "Unilateral Mastectomy Left": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1133\'\n' +
+    'valueset "Unilateral Mastectomy Right": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1134\'\n' +
+    'valueset "Unilateral Mastectomy, Unspecified Laterality": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1071\'\n' +
+    'valueset "CMS Sex": \'urn:oid:2.16.840.1.113762.1.4.1021.121\'\n\n' +
     'code "Female (finding)": \'248152002\' from "SNOMEDCT" display \'Female (finding)\'\n' +
     'code "Left (qualifier value)": \'7771000\' from "SNOMEDCT" display \'Left (qualifier value)\'\n' +
-    'code "Right (qualifier value)": \'24028007\' from "SNOMEDCT" display \'Right (qualifier value)\'\n' +
-    '\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
+    'code "Right (qualifier value)": \'24028007\' from "SNOMEDCT" display \'Right (qualifier value)\'\n\n' +
+    'parameter "Measurement Period" Interval<DateTime>\n\n' +
+    'context Patient\n\n' +
     'define "SDE Ethnicity":\n' +
-    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n' +
-    '\n' +
+    '  ["Patient Characteristic Ethnicity": "Ethnicity"]\n\n' +
     'define "SDE Payer":\n' +
-    '  ["Patient Characteristic Payer": "Payer"]\n' +
-    '\n' +
+    '  ["Patient Characteristic Payer": "Payer"]\n\n' +
     'define "SDE Race":\n' +
-    '  ["Patient Characteristic Race": "Race"]\n' +
-    '\n' +
+    '  ["Patient Characteristic Race": "Race"]\n\n' +
     'define "SDE Sex":\n' +
-    '    ["Patient Characteristic Sex": "CMS Sex"]\n' +
-    '\n' +
+    '    ["Patient Characteristic Sex": "CMS Sex"]\n\n' +
     'define "Bilateral Mastectomy Diagnosis":\n' +
     '  ["Diagnosis": "History of bilateral mastectomy"] BilateralMastectomyHistory\n' +
     '    where BilateralMastectomyHistory.prevalencePeriod starts on or before \n' +
-    '    end of "Measurement Period"\n' +
-    '\n' +
+    '    end of "Measurement Period"\n\n' +
     'define "Bilateral Mastectomy Procedure":\n' +
     '  ["Procedure, Performed": "Bilateral Mastectomy"] BilateralMastectomyPerformed\n' +
     '    where Global."NormalizeInterval" ( BilateralMastectomyPerformed.relevantDatetime, BilateralMastectomyPerformed.relevantPeriod ) ends on or before \n' +
-    '    end of "Measurement Period"\n' +
-    '\n' +
+    '    end of "Measurement Period"\n\n' +
     'define "Denominator":\n' +
-    '  "Initial Population"\n' +
-    '\n' +
+    '  "Initial Population"\n\n' +
     'define "Denominator Exclusions":\n' +
     '  Hospice."Has Hospice Services"\n' +
     '    or ( ( exists ( "Right Mastectomy Diagnosis" )\n' +
@@ -91,51 +74,43 @@ const measureCQL = 'library ICFQDMTEST000001 version \'0.0.000\'\n' +
     '    or exists "Bilateral Mastectomy Procedure"\n' +
     '    or AIFrailLTCF."Is Age 66 or Older with Advanced Illness and Frailty"\n' +
     '    or AIFrailLTCF."Is Age 66 or Older Living Long Term in a Nursing Home"\n' +
-    '    or PalliativeCare."Has Palliative Care in the Measurement Period"\n' +
-    '\n' +
+    '    or PalliativeCare."Has Palliative Care in the Measurement Period"\n\n' +
     'define "Left Mastectomy Diagnosis":\n' +
     '  ( ["Diagnosis": "Status Post Left Mastectomy"]\n' +
     '    union ( ["Diagnosis": "Unilateral Mastectomy, Unspecified Laterality"] UnilateralMastectomyDiagnosis\n' +
     '        where UnilateralMastectomyDiagnosis.anatomicalLocationSite ~ "Left (qualifier value)"\n' +
     '    ) ) LeftMastectomy\n' +
     '    where LeftMastectomy.prevalencePeriod starts on or before \n' +
-    '    end of "Measurement Period"\n' +
-    '\n' +
+    '    end of "Measurement Period"\n\n' +
     'define "Left Mastectomy Procedure":\n' +
     '  ["Procedure, Performed": "Unilateral Mastectomy Left"] UnilateralMastectomyLeftPerformed\n' +
     '    where Global."NormalizeInterval" ( UnilateralMastectomyLeftPerformed.relevantDatetime, UnilateralMastectomyLeftPerformed.relevantPeriod ) ends on or before \n' +
-    '    end of "Measurement Period"\n' +
-    '\n' +
+    '    end of "Measurement Period"\n\n' +
     'define "Right Mastectomy Diagnosis":\n' +
     '  ( ["Diagnosis": "Status Post Right Mastectomy"] RightMastectomyProcedure\n' +
     '    union ( ["Diagnosis": "Unilateral Mastectomy, Unspecified Laterality"] UnilateralMastectomyDiagnosis\n' +
     '        where UnilateralMastectomyDiagnosis.anatomicalLocationSite ~ "Right (qualifier value)"\n' +
     '    ) ) RightMastectomy\n' +
     '    where RightMastectomy.prevalencePeriod starts on or before \n' +
-    '    end of "Measurement Period"\n' +
-    '\n' +
+    '    end of "Measurement Period"\n\n' +
     'define "Right Mastectomy Procedure":\n' +
     '  ["Procedure, Performed": "Unilateral Mastectomy Right"] UnilateralMastectomyRightPerformed\n' +
     '    where Global."NormalizeInterval" ( UnilateralMastectomyRightPerformed.relevantDatetime, UnilateralMastectomyRightPerformed.relevantPeriod ) ends on or before \n' +
-    '    end of "Measurement Period"\n' +
-    '\n' +
+    '    end of "Measurement Period"\n\n' +
     'define "Initial Population":\n' +
     '  exists ( ["Patient Characteristic Sex": "Female (finding)"] )\n' +
     '    and AgeInYearsAt(date from \n' +
     '      end of "Measurement Period"\n' +
     '    )in Interval[52, 74]\n' +
-    '    and exists AdultOutpatientEncounters."Qualifying Encounters"\n' +
-    '\n' +
+    '    and exists AdultOutpatientEncounters."Qualifying Encounters"\n\n' +
     'define "Numerator":\n' +
     '  exists ( ["Diagnostic Study, Performed": "Mammography"] Mammogram\n' +
     '      where ( Global."NormalizeInterval" ( Mammogram.relevantDatetime, Mammogram.relevantPeriod ) ends during day of Interval["October 1 Two Years Prior to the Measurement Period", \n' +
     '        end of "Measurement Period"]\n' +
     '      )\n' +
-    '  )\n' +
-    '\n' +
+    '  )\n\n' +
     'define "October 1 Two Years Prior to the Measurement Period":\n' +
-    '  DateTime((year from start of "Measurement Period" - 2), 10, 1, 0, 0, 0, 0, 0)\n' +
-    '  '
+    '  DateTime((year from start of "Measurement Period" - 2), 10, 1, 0, 0, 0, 0, 0)'
 
 describe('Measure Creation: Proportion Patient Based', () => {
 
@@ -144,14 +119,13 @@ describe('Measure Creation: Proportion Patient Based', () => {
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false, false,
             '2012-01-01', '2012-12-31')
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, null, true)
+        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, undefined, true)
 
         OktaLogin.Login()
     })
 
     after('Clean up', () => {
 
-        
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Proportion_ListQDMPositiveProcedurePerformed.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Proportion_ListQDMPositiveProcedurePerformed.cy.ts
@@ -25,14 +25,13 @@ describe('Measure Creation: Proportion ListQDMPositiveProcedurePerformed', () =>
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false, false,
             '2012-01-01', '2012-12-31')
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, null, true)
+        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, undefined, true)
 
         OktaLogin.Login()
     })
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts
@@ -74,7 +74,6 @@ describe('Measure Creation: Ratio EncounterPerformed, Multiple Criterias With MO
 
     after('Logout and Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts
@@ -23,24 +23,15 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
     before('Create Measure', () => {
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false, false,
             '2023-01-01', '2023-12-31')
-        OktaLogin.Login()
-        MeasuresPage.actionCenter("edit")
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, null, true)
+        TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, undefined, true)
 
         OktaLogin.Login()
     })
 
     after('Logout and Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 
@@ -327,6 +318,5 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).eq(0).should('contain.text', 'Pass')
         cy.get(TestCasesPage.testCaseStatus).eq(1).should('contain.text', 'Pass')
-
     })
 })

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithMO.cy.ts
@@ -66,10 +66,10 @@ describe('Measure Creation and Testing: CV Episode Measure With MO', () => {
             }
         }
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2023-01-01', '2023-12-31')
         MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.ContinousVariable, 
-            pops, false, null, null, cvPops)
+            pops, false, undefined, undefined, cvPops)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
         OktaLogin.Login()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
@@ -77,7 +77,6 @@ describe('Measure Creation and Testing: CV Episode Measure With MO', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithStratification.cy.ts
@@ -57,7 +57,7 @@ describe('Measure Creation and Testing: CV Episode Measure With Stratification',
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, undefined, false,
             '2021-01-01', '2022-12-31')
 
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -77,7 +77,7 @@ describe('Measure Creation and Testing: CV Episode Measure With Stratification',
         MeasuresPage.actionCenter("edit")
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientWithStratification.cy.ts
@@ -56,21 +56,17 @@ describe('Measure Creation and Testing: CV Patient Measure With Stratification',
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2012-01-01', '2012-12-31')
 
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
 
         OktaLogin.Login()
-
     })
 
     after('Clean up', () => {
 
-        
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
-
+        Utilities.deleteMeasure()
     })
 
     it('End to End CV Patient Measure with Stratification, Pass Result', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
@@ -44,17 +44,16 @@ describe('Measure Creation and Testing: CV Patient With MO', () => {
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2012-01-01', '2012-12-31')
         MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.boolean, MeasureScoring.ContinousVariable, 
-                        pops, false, null, null, cvPops)
+                        pops, false, undefined, undefined, cvPops)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
         OktaLogin.Login()
     })
 
     after('Clean up', () => {
 
-        
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeEncounter.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeEncounter.cy.ts
@@ -27,7 +27,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
 
     before('Create Measure and Test Case', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2012-01-02', '2013-01-01')
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', 'Encounter')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -37,7 +37,6 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
@@ -21,7 +21,7 @@ describe('Measure Creation and Testing: Cohort Episode w/ Stratification', () =>
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2022-01-01', '2023-01-01')
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', 'Encounter')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -30,7 +30,6 @@ describe('Measure Creation and Testing: Cohort Episode w/ Stratification', () =>
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 
@@ -40,7 +39,7 @@ describe('Measure Creation and Testing: Cohort Episode w/ Stratification', () =>
         MeasuresPage.actionCenter("edit")
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientBoolean.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientBoolean.cy.ts
@@ -21,7 +21,7 @@ describe('Measure Creation and Testing: Cohort Patient Boolean', () => {
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2012-01-01', '2012-12-31')
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -30,7 +30,6 @@ describe('Measure Creation and Testing: Cohort Patient Boolean', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 
@@ -40,7 +39,7 @@ describe('Measure Creation and Testing: Cohort Patient Boolean', () => {
         MeasuresPage.actionCenter("edit")
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end}{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientWithStratification.cy.ts
@@ -38,7 +38,7 @@ describe('Measure Creation and Testing: Cohort Patient w/ Stratification', () =>
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2022-01-01', '2023-01-01')
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -46,7 +46,6 @@ describe('Measure Creation and Testing: Cohort Patient w/ Stratification', () =>
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/ProportionEpisode.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/ProportionEpisode.cy.ts
@@ -55,7 +55,7 @@ describe('Measure Creation and Testing: Proportion Episode Measure', () => {
 
     before('Create Measure, Test Case and Login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2023-01-01', '2023-12-31')
             MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.Proportion, pops)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -65,8 +65,7 @@ describe('Measure Creation and Testing: Proportion Episode Measure', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('End to End Proportion Episode Measure, Pass Result', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeSingleIPNoMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeSingleIPNoMO.cy.ts
@@ -54,7 +54,6 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
         denomExclusion: 'Denominator Exclusions',
         numerator: 'Numerator',
         numExclusion: 'Numerator Exclusions'
-
     }
 
     beforeEach('Create Measure and Test Case', () => {
@@ -64,7 +63,7 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
         CqlLibraryName = 'RatioEpSglIPNoMO' + newTimestamp
         measureCQL = baseMeasureCQL.replace('library RatioEpisodeSingleIPNoMO', 'library RatioEpSglIPNoMO' + newTimestamp)
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2022-01-01', '2022-12-31')
             MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.Ratio, pops)
         TestCasesPage.CreateTestCaseAPI(testCaseTitleIppPass, testCaseDescription, testCaseSeries, testCaseJsonIppPass)
@@ -83,7 +82,6 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
 
     afterEach('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeTwoIPsWithMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeTwoIPsWithMOs.cy.ts
@@ -21,7 +21,7 @@ describe('Measure Creation and Testing: Ratio Episode Two IPs w/ MOs', () => {
 
     before('Create Measure and Test Case', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2022-01-01', '2022-12-31')
         TestCasesPage.CreateTestCaseAPI(testCaseTitlePass, testCaseDescription, testCaseSeries, testCaseJsonIppPass)
 
@@ -82,7 +82,6 @@ describe('Measure Creation and Testing: Ratio Episode Two IPs w/ MOs', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientSingleIPNoMOwithDRC.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientSingleIPNoMOwithDRC.cy.ts
@@ -63,12 +63,11 @@ describe('Measure Creation and Testing: Ratio Patient Single IP w/o MO w/ DRC', 
         denomExclusion: 'Denominator Exclusions',
         numerator: 'Numerator',
         numExclusion: 'Numerator Exclusions'
-
     }
 
     before('Create Measure and Test Case', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2022-01-01', '2022-12-31')
             MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.boolean, MeasureScoring.Ratio, pops)
         TestCasesPage.CreateTestCaseAPI(testCaseTitleIppPass, testCaseDescription, testCaseSeries, testCaseJsonIppPass)
@@ -77,7 +76,6 @@ describe('Measure Creation and Testing: Ratio Patient Single IP w/o MO w/ DRC', 
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOs.cy.ts
@@ -56,7 +56,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
 
     before('Create Measure and Test Case', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2023-01-01', '2024-01-01')
 
         TestCasesPage.CreateTestCaseAPI(testCaseTitleIpp1Pass, testCaseDescription, testCaseSeries, testCaseJsonIppPass)
@@ -116,9 +116,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
 
     after('Clean up', () => {
 
-        OktaLogin.UILogout()
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('End to End Ratio Patient Two IPs w/ MOs Pass Result', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts
@@ -55,7 +55,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs, using same
 
     before('Create Measure and Test Case', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, undefined, false,
             '2023-01-01', '2024-01-01')
 
         TestCasesPage.CreateTestCaseAPI(testCaseTitleIpp1Pass, testCaseDescription, testCaseSeries, testCaseJsonIppPass)
@@ -66,7 +66,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs, using same
         MeasuresPage.actionCenter("edit")
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
@@ -112,8 +112,6 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs, using same
     })
 
     after('Clean up', () => {
-
-        OktaLogin.UILogout()
 
         Utilities.deleteMeasure(measureName, CqlLibraryName)
     })

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts
@@ -71,7 +71,7 @@ describe('Measure Creation and Testing: CV Patient Measure With Stratification',
     before('Create Measure, Test Case and Login', () => {
 
         CreateMeasurePage.CreateMeasureAPI(measureName, libraryName, SupportedModels.qiCore6, opts)
-        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.ContinousVariable, pops, false, null, null, cvPops)
+        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.ContinousVariable, pops, false, undefined, undefined, cvPops)
         MeasureGroupPage.addStratificationDataAPI(strats)
         TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description, testCase.json)
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEncounter600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEncounter600.cy.ts
@@ -36,7 +36,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
         TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description, testCase.json)
 
         OktaLogin.Login()
-        MeasuresPage.actionCenter('edit', null)
+        MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{end}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/ProportionBoolean600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/ProportionBoolean600.cy.ts
@@ -93,7 +93,6 @@ describe('Measure Creation and Testing: Proportion Episode Measure', () => {
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 30000)
         cy.get(TestCasesPage.executeTestCaseButton).click()
 
-
         //verify Passing Tab's text
         cy.get(TestCasesPage.testCaseListPassingPercTab).should('exist')
         cy.get(TestCasesPage.testCaseListPassingPercTab).should('be.visible')
@@ -104,7 +103,6 @@ describe('Measure Creation and Testing: Proportion Episode Measure', () => {
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('exist')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('be.visible')
         cy.get(TestCasesPage.testCaseListCoveragePercTab).should('contain.text', '95%')
-
 
         //after versioning, there should be no change to test results or coverage
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/RatioEncounterSingleIPWithMOs600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/RatioEncounterSingleIPWithMOs600.cy.ts
@@ -48,7 +48,7 @@ describe('Measure Creation and Testing: Ratio Encounter Single IP w/ MOs', () =>
         MeasuresPage.actionCenter("edit")
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end}{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 8500)

--- a/cypress/e2e/WebInterface/Smoke Tests/SaveCQL.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/SaveCQL.cy.ts
@@ -17,7 +17,7 @@ describe('Save CQL on CQL Editor Page', () => {
 
     afterEach('Logout', () => {
         
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Create New Measure and Add CQL to the Measure', () => {

--- a/cypress/e2e/WebInterface/Test Cases/CopyTestCases.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/CopyTestCases.cy.ts
@@ -47,7 +47,7 @@ describe('Copy QDM Test Cases', () => {
         //Create QDM Measure, PC and Test Case
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureDataQDM)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp', 'boolean', 1)
-        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, null, false, false, 1)
+        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, undefined, false, false, 1)
 
         //Create 2nd QDM Measure
         measureDataQDM2.ecqmTitle = secondMeasureName + randValue

--- a/cypress/e2e/WebInterface/Test Cases/DeleteTestCaseNotTheOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/DeleteTestCaseNotTheOwner.cy.ts
@@ -29,7 +29,7 @@ describe('Delete Test Case', () => {
 
     beforeEach('Create measure and login', () => {
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2012-01-02', '2013-01-01')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
@@ -41,15 +41,14 @@ describe('Delete Test Case', () => {
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, null, null, null, null, null,
-            null, null, 'Procedure')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, undefined, undefined, undefined, undefined, undefined,
+            undefined, undefined, 'Procedure')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
     })
 
     afterEach('Logout and Clean up Measures', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteMeasure()
     })
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMCQMExecutionFailureErrorValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMCQMExecutionFailureErrorValidations.cy.ts
@@ -98,7 +98,6 @@ describe('QDM CQM-Execution failure error validations: CQL Errors and missing gr
 
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
@@ -199,7 +198,6 @@ describe('QDM CQM-Execution failure error validations: Data transformation- MADi
 
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
@@ -35,12 +35,12 @@ describe('Sort by each of the test case list page\'s columns', () => {
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
         TestCasesPage.CreateTestCaseAPI(secondTestCaseTitle, secondTestCaseSeries, secondTestCaseDescription, validTestCaseJson, false, true)
 

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseListPagination.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseListPagination.cy.ts
@@ -12,15 +12,11 @@ let TCSeries = []
 let TCTitle = []
 let TCDescription = []
 
-let measureCQL = 'library CohortEpisodeEncounter1699460161402 version \'0.0.000\'\n' +
-    '\n' +
-    'using QICore version \'4.1.1\'\n' +
-    '\n' +
+let measureCQL = 'library CohortEpisodeEncounter1699460161402 version \'0.0.000\'\n\n' +
+    'using QICore version \'4.1.1\'\n\n' +
     'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include CQMCommon version \'1.0.000\' called Global\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
+    'include CQMCommon version \'1.0.000\' called Global\n\n' +
+    'context Patient\n\n' +
     'define "Initial Population":\n' +
     '   Global."Inpatient Encounter"'
 
@@ -42,7 +38,7 @@ describe('Test Case List Pagination', () => {
                     cy.request({
                         url: '/api/measures/' + id + '/test-cases',
                         headers: {
-                            authorization: 'Bearer ' + accessToken.value
+                            authorization: 'Bearer ' + accessToken?.value
                         },
                         method: 'POST',
                         body: {
@@ -68,7 +64,7 @@ describe('Test Case List Pagination', () => {
 
     afterEach('Delete Measure', () => {
 
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Verify pagination', () => {

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseNameDropdown.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseNameDropdown.cy.ts
@@ -27,7 +27,7 @@ describe('Test Case UI quality of life features', () => {
         CqlLibraryName = 'TestLibrary5' + Date.now()
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
         TestCasesPage.CreateTestCaseAPI(secondTestCaseTitle, secondTestCaseSeries, secondTestCaseDescription, validTestCaseJson, false, true)
         OktaLogin.SessionLogin()
@@ -35,9 +35,7 @@ describe('Test Case UI quality of life features', () => {
 
     afterEach('Clean up', () => {
 
-        
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Test Case name dropdown switches between test cases', () => {

--- a/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
@@ -8,7 +8,6 @@ import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
 import { Header } from "../../../../Shared/Header"
-import { Toasts } from "../../../../Shared/Toasts"
 
 let measureName = 'ProportionEpisode' + Date.now()
 let CqlLibraryName = 'ProportionEpisode' + Date.now()
@@ -17,40 +16,29 @@ let testCaseTitle = 'PASS'
 let testCaseDescription = 'PASS' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let testCaseJson = TestCaseJson.ProportionEpisode_PASS
-let measureCQL = 'library ProportionEpisodeMeasure version \'0.0.000\'\n' +
-    '\n' +
-    'using QICore version \'4.1.1\'\n' +
-    '\n' +
+let measureCQL = 'library ProportionEpisodeMeasure version \'0.0.000\'\n\n' +
+    'using QICore version \'4.1.1\'\n\n' +
     'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include CQMCommon version \'1.0.000\' called Global\n' +
-    '\n' +
-    'codesystem "SNOMED": \'http://snomed.info/sct\'\n' +
-    '\n' +
-    'valueset "Encounter Inpatient": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307\'\n' +
-    '\n' +
-    'code "Unscheduled (qualifier value)": \'103390000\' from "SNOMED" display \'Unscheduled (qualifier value)\'\n' +
-    '\n' +
+    'include CQMCommon version \'1.0.000\' called Global\n\n' +
+    'codesystem "SNOMED": \'http://snomed.info/sct\'\n\n' +
+    'valueset "Encounter Inpatient": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307\'\n\n' +
+    'code "Unscheduled (qualifier value)": \'103390000\' from "SNOMED" display \'Unscheduled (qualifier value)\'\n\n' +
     'parameter "Measurement Period" Interval<DateTime>\n' +
-    '  default Interval[@2022-01-01T00:00:00.0, @2023-01-01T00:00:00.0)\n' +
-    '\n' +
-    'context Patient\n' +
-    '\n' +
+    '  default Interval[@2022-01-01T00:00:00.0, @2023-01-01T00:00:00.0)\n\n' +
+    'context Patient\n\n' +
     'define "Initial Population":\n' +
     '   [Encounter: "Encounter Inpatient"] InptEncounter\n' +
-    '      where InptEncounter.status = \'finished\' \n' +
-    '       \n' +
+    '      where InptEncounter.status = \'finished\' \n\n' +
     'define "Denominator":\n' +
     '    "Initial Population" IP\n' +
-    '      where IP.period ends during day of "Measurement Period"\n' +
-    '\n' +
+    '      where IP.period ends during day of "Measurement Period"\n\n' +
     'define "Numerator":\n' +
     '    "Denominator" denom \n' +
-    '    where Global."LengthInDays"(denom.period) > 120\n' +
-    '\n' +
+    '    where Global."LengthInDays"(denom.period) > 120\n\n' +
     'define function "Measure Observation"(Encounter Encounter): \n' +
     '  Count({\n' +
     '        Encounter Enc\n' +
-    '          where Enc.priority ~ "Unscheduled (qualifier value)"          \n' +
+    '          where Enc.priority ~ "Unscheduled (qualifier value)"\n' +
     '          })'
 
 
@@ -60,10 +48,10 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
         CqlLibraryName = 'ProportionEpisode' + Date.now()
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, null, false,
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
             '2023-01-01', '2023-12-31')
 
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(null, false, 'Initial Population',
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population',
             '', '', 'Numerator', '', 'Denominator', 'Encounter')
 
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
@@ -104,9 +92,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
     after('Clean up', () => {
 
-        
-
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure()
     })
 
     it('Versioned Measure: Create New Test Case, delete is enabled', () => {
@@ -156,7 +142,6 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
 
-
         //verify user can delete newly created test case after versioning
         TestCasesPage.checkTestCase(2)
         TestCasesPage.checkTestCase(2)
@@ -177,7 +162,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         })
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.wait('@draft', { timeout: 60000 }).then((request) => {
-            cy.writeFile(filePath, request.response.body.id)
+            cy.writeFile(filePath, request?.response?.body.id)
         })
         cy.get('.toast').should('contain.text', 'New draft created successfully.')
         cy.log('Draft Created Successfully')
@@ -199,7 +184,6 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
-
     })
 
     it('Versioned Measure: Edit Test Case, delete is disabled', () => {
@@ -261,7 +245,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         })
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.wait('@draft', { timeout: 60000 }).then((request) => {
-            cy.writeFile(filePath, request.response.body.id)
+            cy.writeFile(filePath, request?.response?.body.id)
         })
         cy.get('.toast').should('contain.text', 'New draft created successfully.')
         cy.log('Draft Created Successfully')
@@ -283,7 +267,5 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
-
     })
-
 })


### PR DESCRIPTION
Updates in many files but almost all changes are very minor.

- Whitespace removal or general formatting changes
- Remove optional parameters or update types (null -> undefined or null -> 0 ver commonly)
- Condense large CQL strings
- Remove many tests UILogout step
- Added {moveToEnd} in many "save CQL" sequences
- Added optional ? in some places to eliminate TS errors