### PR TITLE
feat: update for TS upgrade, dropping hcqis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ pipeline {
   parameters {
     choice(
       choices: [
-        'cy:parallel:test','cy:parallel:test:ui:smoketests','cy:parallel:test:ui:smoketests:hqcis','cy:parallel:dev:ui:smoketests','cy:parallel:dev:ui:smoketests:hqcis',
-        'cy:parallel:test:all:tests','cy:parallel:hcqis-test:all:tests','test:specific:files:parallel', 'test:specific:files:parallel:hqcis','dev:all:ui:tests','dev:all:tests',
+        'cy:parallel:test','cy:parallel:test:ui:smoketests','cy:parallel:dev:ui:smoketests',
+        'cy:parallel:test:all:tests','test:specific:files:parallel','dev:all:ui:tests','dev:all:tests',
         'dev:ui:smoketests','dev:ui:cqllibrary:cqlEditor','dev:ui:cqllibrary','dev:ui:measure:cqlEditor',
         'dev:measure:editMeasure:ui:tests','dev:ui:testCases:testCasePopulationValues',
         'dev:ui:cqllibrary:versionAndDraft','dev:all:services:tests','dev:services:measureService:tests',
@@ -214,9 +214,6 @@ pipeline {
           case "${TEST_SCRIPT}" in
             impl:*)
               RERUN_SCRIPT="impl:rerun:failures"
-              ;;
-            *hcqis*|*hqcis*)
-              RERUN_SCRIPT="test:specific:files:parallel:hqcis:rerun"
               ;;
             *)
               RERUN_SCRIPT="test:specific:files:parallel"

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
 			}
 		},
 		"node_modules/@madie/madie-models": {
-			"version": "1.4.59",
-			"resolved": "https://registry.npmjs.org/@madie/madie-models/-/madie-models-1.4.59.tgz",
-			"integrity": "sha512-zSE5dkRlLyebH518cY/am40ONpHLVai64D6+AXy5x2uO7ZpDa6Ke7bols3+xkQM0AdO5TKYKBcjqJLvS8eTzoQ==",
+			"version": "1.4.61",
+			"resolved": "https://registry.npmjs.org/@madie/madie-models/-/madie-models-1.4.61.tgz",
+			"integrity": "sha512-4MmMZPCu0eTjBT+vbp0qa374QslZe5ym8+8lLwQY5EhpOc1M3Bihlb87IxiCf4sxzcRMv1aGkU8zW2q+dZ3owQ==",
 			"license": "ISC"
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -342,9 +342,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-			"integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+			"version": "24.12.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+			"integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -588,11 +588,12 @@
 			"license": "MIT"
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.1",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+			"integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
 			"dev": true,
 			"license": "MPL-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -638,9 +639,9 @@
 			}
 		},
 		"node_modules/bare-fs": {
-			"version": "4.5.5",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
-			"integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+			"integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -663,9 +664,9 @@
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.7.1.tgz",
-			"integrity": "sha512-ebvMaS5BgZKmJlvuWh14dg9rbUI84QeV3WlWn6Ph6lFI8jJoh7ADtVTyD2c93euwbe+zgi0DVrl4YmqXeM9aIA==",
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+			"integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -683,20 +684,24 @@
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.1.tgz",
-			"integrity": "sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+			"integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"streamx": "^2.21.0",
+				"streamx": "^2.25.0",
 				"teex": "^1.0.1"
 			},
 			"peerDependencies": {
+				"bare-abort-controller": "*",
 				"bare-buffer": "*",
 				"bare-events": "*"
 			},
 			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
 				"bare-buffer": {
 					"optional": true
 				},
@@ -706,9 +711,9 @@
 			}
 		},
 		"node_modules/bare-url": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-			"integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+			"integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -737,9 +742,9 @@
 			"license": "MIT"
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-			"integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -770,9 +775,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1230,12 +1235,13 @@
 			"license": "MIT"
 		},
 		"node_modules/cypress": {
-			"version": "15.11.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-15.11.0.tgz",
-			"integrity": "sha512-NXDE6/fqZuzh1Zr53nyhCCa4lcANNTYWQNP9fJO+tzD3qVTDaTUni5xXMuigYjMujQ7CRiT9RkJJONmPQSsDFw==",
+			"version": "15.13.1",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-15.13.1.tgz",
+			"integrity": "sha512-jLkgo75zlwo7PhXp0XJot+zIfFSDzN1SvTml6Xf3ETM1XHRWnH3Q4LAR3orCo/BsnxPnhjG3m5HYSvn9DAtwBg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cypress/request": "^3.0.10",
 				"@cypress/xvfb": "^1.2.4",
@@ -1525,7 +1531,8 @@
 			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1155343.tgz",
 			"integrity": "sha512-oD9vGBV2wTc7fAzAM6KC0chSgs234V8+qDEeK+mcbRj2UvcuA7lgBztGi/opj/iahcXD3BSj8Ymvib628yy9FA==",
 			"dev": true,
-			"license": "BSD-3-Clause"
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/diff": {
 			"version": "7.0.0",
@@ -2986,9 +2993,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lru-cache": {
-			"version": "11.2.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"version": "11.3.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+			"integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -3086,13 +3093,13 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -3134,6 +3141,7 @@
 			"integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"browser-stdout": "^1.3.1",
 				"chokidar": "^4.0.1",
@@ -3235,9 +3243,9 @@
 			"license": "MIT"
 		},
 		"node_modules/mocha/node_modules/brace-expansion": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3707,9 +3715,9 @@
 			"license": "MIT"
 		},
 		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4246,9 +4254,9 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-			"integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -4407,9 +4415,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sax": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -4421,7 +4429,6 @@
 			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			},
@@ -4430,9 +4437,9 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-			"integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -4490,14 +4497,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -4671,9 +4678,9 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4795,9 +4802,9 @@
 			}
 		},
 		"node_modules/systeminformation": {
-			"version": "5.31.4",
-			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.4.tgz",
-			"integrity": "sha512-lZppDyQx91VdS5zJvAyGkmwe+Mq6xY978BDUG2wRkWE+jkmUF5ti8cvOovFQoN5bvSFKCXVkyKEaU5ec3SJiRg==",
+			"version": "5.31.5",
+			"resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.5.tgz",
+			"integrity": "sha512-5SyLdip4/3alxD4Kh+63bUQTJmu7YMfYQTC+koZy7X73HgNqZSD2P4wOZQWtUncvPvcEmnfIjCoygN4MRoEejQ==",
 			"dev": true,
 			"license": "MIT",
 			"os": [
@@ -5023,6 +5030,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -5241,9 +5249,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -12,26 +12,18 @@
 	"scripts": {
 		"cypress:open": "cypress open --e2e -b chrome",
 		"cypress:open:dev": "cypress open --env configFile=dev --e2e -b chrome",
-		"cypress:open:hcqis-dev": "cypress open --env configFile=hcqis-dev --e2e -b chrome",
 		"cypress:open:test": "cypress open --env configFile=test --e2e -b chrome",
-		"cypress:open:hcqis-test": "cypress open --env configFile=hcqis-test --e2e -b chrome",
 		"cypress:open:impl": "cypress open --env configFile=impl --e2e -b chrome",
 		"cypress:run": "cypress run --spec 'cypress/e2e/**/*'",
 		"cy:run": "cypress run --env configFile=dev --browser chrome --headed",
-		"cy:run:hcqis-test:headed": "NO_COLOR=1 cypress run --env configFile=hcqis-test --browser chrome --headed",
 		"cy:run:test:headed": "NO_COLOR=1 cypress run --env configFile=test --browser chrome --headed",
 		"cy:run:dev:headed": "NO_COLOR=1 cypress run --env configFile=dev --browser chrome --headed",
-		"cy:run:hqcis-dev:headed": "NO_COLOR=1 cypress run --env configFile=hcqis-dev --browser chrome --headed",
 		"cy:parallel:test": "cypress-parallel -s cy:run:test:headed -t 3 -d 'cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/test/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
 		"cy:parallel:test:ui:smoketests": "cypress-parallel -s cy:run:test:headed -t 3 -d 'cypress/e2e/WebInterface/Smoke Tests/**/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
-		"cy:parallel:test:ui:smoketests:hqcis": "cypress-parallel -s cy:run:hcqis-test:headed -t 3 -d 'cypress/e2e/WebInterface/Smoke Tests/**/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
 		"cy:parallel:dev:ui:smoketests": "cypress-parallel -s cy:run:dev:headed -t 3 -d 'cypress/e2e/WebInterface/Smoke Tests/**/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
-		"cy:parallel:dev:ui:smoketests:hqcis": "cypress-parallel -s cy:run:hqcis-dev:headed -t 3 -d 'cypress/e2e/WebInterface/Smoke Tests/**/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
 		"cy:parallel:test:all:tests": "cypress-parallel -s cy:run:test:headed -t 3 -d 'cypress/e2e/**/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
-		"cy:parallel:hcqis-test:all:tests": "cypress-parallel -s cy:run:hcqis-test:headed -t 3 -d 'cypress/e2e/**/*.cy.ts' -p 'cypress/parallel-reporter-config.json'",
 		"test:specific:files:parallel": "node -e \"const fs=require('fs');const {spawnSync}=require('child_process');const list='test-files.txt';if(!fs.existsSync(list)){console.error('Missing spec list file:',list);process.exit(1);}const specs=fs.readFileSync(list,'utf8').split(/\\r?\\n/).map(s=>s.trim()).filter(Boolean);if(!specs.length){console.error('Spec list is empty after reading',list);process.exit(1);}const npx=process.platform==='win32'?'npx.cmd':'npx';const args=['cypress-parallel','-s','cy:run:test:headed','-t','3','--spec',...specs,'-p','cypress/parallel-reporter-config.json'];console.log('cypress-parallel args:', args.join(' '));const res=spawnSync(npx,args,{stdio:'inherit',env:{...process.env,NO_COLOR:'1'}});process.exit(res.status||0);\"",
-		"test:specific:files:parallel:hqcis": "node -e \"const fs=require('fs');const {spawnSync}=require('child_process');const list='cypress/test-files.txt';if(!fs.existsSync(list)){console.error('Missing spec list file:',list);process.exit(1);}const specs=fs.readFileSync(list,'utf8').split(/\\r?\\n/).map(s=>s.trim()).filter(Boolean);if(!specs.length){console.error('Spec list is empty after reading',list);process.exit(1);}const npx=process.platform==='win32'?'npx.cmd':'npx';const args=['cypress-parallel','-s','cy:run:hcqis-test:headed','-t','3','--spec',...specs,'-p','cypress/parallel-reporter-config.json'];console.log('cypress-parallel args:', args.join(' '));const res=spawnSync(npx,args,{stdio:'inherit',env:{...process.env,NO_COLOR:'1'}});process.exit(res.status||0);\"",
-		"test:specific:files:parallel:hqcis:rerun": "node -e \"const fs=require('fs');const {spawnSync}=require('child_process');const list='test-files.txt';if(!fs.existsSync(list)){console.error('Missing spec list file:',list);process.exit(1);}const specs=fs.readFileSync(list,'utf8').split(/\\r?\\n/).map(s=>s.trim()).filter(Boolean);if(!specs.length){console.error('Spec list is empty after reading',list);process.exit(1);}const npx=process.platform==='win32'?'npx.cmd':'npx';const args=['cypress-parallel','-s','cy:run:hcqis-test:headed','-t','3','--spec',...specs,'-p','cypress/parallel-reporter-config.json'];console.log('cypress-parallel args:', args.join(' '));const res=spawnSync(npx,args,{stdio:'inherit',env:{...process.env,NO_COLOR:'1'}});process.exit(res.status||0);\"",
+		"dev:specific:files:parallel": "node -e \"const fs=require('fs');const {spawnSync}=require('child_process');const list='test-files.txt';if(!fs.existsSync(list)){console.error('Missing spec list file:',list);process.exit(1);}const specs=fs.readFileSync(list,'utf8').split(/\\r?\\n/).map(s=>s.trim()).filter(Boolean);if(!specs.length){console.error('Spec list is empty after reading',list);process.exit(1);}const npx=process.platform==='win32'?'npx.cmd':'npx';const args=['cypress-parallel','-s','cy:run:dev:headed','-t','3','--spec',...specs,'-p','cypress/parallel-reporter-config.json'];console.log('cypress-parallel args:', args.join(' '));const res=spawnSync(npx,args,{stdio:'inherit',env:{...process.env,NO_COLOR:'1'}});process.exit(res.status||0);\"",
 		"compile": "tsc --noEmit",
 		"combine:reports": "npx mochawesome-merge 'cypress/results/*.json' > mochawesome.json",
 		"generateOne:report": "npx marge mochawesome.json",
@@ -132,6 +124,6 @@
 		"cookie": "^0.7.0",
 		"tar-fs": "^3.0.9",
 		"qs": "^6.14.1",
-		"serialize-javascript": "^7.0.3"
+		"serialize-javascript": "^7.0.5"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
     "compilerOptions": {
         /* Basic Options */
-        "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+        "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
         "module": "commonjs", /* Specify module code generation: 'none', commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
         "lib": [
             "es6",
             "dom",
             "es2017"
         ],
-        "downlevelIteration": true,
         "skipLibCheck": true, // do not check types in node_modules folder
         "types": ["cypress", "node", "cypress-commands", "cy-verify-downloads", "cypress-real-events"]
     },


### PR DESCRIPTION
Summary:
- Updated tsconfig file to account for somewhat recent upgrades to our TypeScript version. Changes remove several errors for popping into your IDE.
- Removed all hcqis options from Jenkinsfile & package.json. Leaving config/hcqis-test.json & ....dev.json for now, just in case.
- Also forced 1 npm package upgrade on package.json to resolve a dependabot issue.
- General upgrades on new package-lock.json
