### PR TITLE
fix: clarify CQL, update selector

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -69,8 +69,8 @@ export class CQLLibraryPage {
     public static readonly cqlLibraryExperimentalChkBox = '[id="experimental"]'
     public static readonly editSavedLibraryAlias = '[data-testid="library-alias-input"]'
     public static readonly libraryInfoPanel = '#page-header'
-    public static readonly draftBubble = '[data-testid="draft-bubble"]'
-
+    public static readonly draftBubble = '[data-testid="draft-chip"]'
+    
     // Edit page action center
     public static readonly actionCenterButton = '[data-testid="action-center-actual-icon"]'
     public static readonly actionCenterDelete = '[data-testid="DeleteLibrary"]'

--- a/cypress/e2e/WebInterface/CQL Library/CQL Editor/ValidateCQLLibraryEditor.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Editor/ValidateCQLLibraryEditor.cy.ts
@@ -20,11 +20,6 @@ describe('Validate Qi-Core CQL on CQL Library page', () => {
         OktaLogin.SessionLogin()
     })
 
-    afterEach('Logout', () => {
-
-        
-    })
-
     it('Add valid CQL on CQL Library Editor and verify no errors appear', () => {
         //Navigate to CQL Library Page
         cy.get(Header.cqlLibraryTab).click()
@@ -288,11 +283,6 @@ describe('CQL Library: CQL Editor: Qi-Core valueSet', () => {
         CQLLibraryPage.createCQLLibraryAPI(apiCQLLibraryName, CQLLibraryPublisher)
 
         OktaLogin.SessionLogin()
-    })
-
-    afterEach('Logout and Clean up Measures', () => {
-
-        
     })
 
     it('Value Sets are valid', () => {

--- a/cypress/fixtures/CQLWithoutCodeSystemName.txt
+++ b/cypress/fixtures/CQLWithoutCodeSystemName.txt
@@ -10,8 +10,9 @@ valueset "Preventive Care Services-Initial Office Visit, 18 and Up": 'http://cts
 valueset "Home Healthcare Services": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016'
 
 {home}parameter "Measurement Period" Interval<DateTime>
+default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0]
+
 {home}code "Assessed Patient": '2' display 'Assessed Patient'
-	default Interval[@2019-01-01T00:00:00.0, @2020-01-01T00:00:00.0)
 
 {home}context Patient
 


### PR DESCRIPTION
Minor fixes.

AddDraftToVersionedCQLLibrary - 1 selector. changed & updated.

ValidateCQLLibraryEditor - re-ordered CQL lines. Updates to the granularity of errors caused a different error to throw instead of the specific error we wanted.