### PR TITLE
fix: correct typo, update for new version

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
@@ -51,7 +51,6 @@ describe('QDM Library Includes fields', () => {
 
     afterEach('Clean up and Logout', () => {
 
-        
         Utilities.deleteMeasure()
     })
 
@@ -87,7 +86,7 @@ describe('QDM Library Includes fields', () => {
             .find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable)
             .find('[data-testid="library-results-tbl"]')
             .find('[data-testid="library-results-table-body"]')
-            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / ApplyVTEQDM9.1.000yahu1257View / ApplyVTEQDM9.0.000yahu1257View / ApplyVTEQDM8.3.000yahu1257View / ApplyVTEQDM8.2.000yahu1257View / Apply')
+            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / ApplyVTEQDM10.0.000yahu1257View / ApplyVTEQDM9.1.000yahu1257View / ApplyVTEQDM9.0.000yahu1257View / ApplyVTEQDM8.3.000yahu1257View / Apply')
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()
@@ -113,7 +112,7 @@ describe('QDM Library Includes fields', () => {
             .find(CQLEditorPage.librarySearchTable)
             .find('[data-testid="library-results-tbl"]')
             .find('[data-testid="library-results-table-body"]')
-            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / ApplyVTEQDM9.1.000yahu1257View / ApplyVTEQDM9.0.000yahu1257View / ApplyVTEQDM8.3.000yahu1257View / ApplyVTEQDM8.2.000yahu1257View / Apply')
+            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / ApplyVTEQDM10.0.000yahu1257View / ApplyVTEQDM9.1.000yahu1257View / ApplyVTEQDM9.0.000yahu1257View / ApplyVTEQDM8.3.000yahu1257View / Apply')
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()

--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/DraftMeasure.cy.ts
@@ -10,7 +10,6 @@ import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { LandingPage } from "../../../../Shared/LandingPage"
 import { Toasts } from "../../../../Shared/Toasts"
 
-
 let updatedMeasuresPageName = ''
 let updatedMeasuresPageNameSecond = ''
 let randValue = (Math.floor((Math.random() * 1000) + 1))
@@ -286,7 +285,7 @@ describe('Draft and Version Validations -- add and cannot create draft of a draf
         cy.get(MeasuresPage.measureCQLToElmVersionTxtBox).should('not.be.empty')
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToenEnd}{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()


### PR DESCRIPTION
QDMLibraryIncludes - update to add this year's new version of the library to the text v10.0.0

DraftMeasure - fixed a procedural typo from a recent update. Cypress blew up when command moveToEnd was misspelled 