### PR TITLE
fix(cypress): align RTE selectors with new Tiptap DOM and harden alt-user login

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -198,7 +198,9 @@ export class EditMeasurePage {
     public static readonly measureDevelopersAlertMsg = '[data-testid="developers-helper-text"]'
 
     //Description Page
-    public static readonly measureGenericFieldRTETextBox = '[data-testid="generic-field-rich-text-editor"]'
+    // The element with this testid is now itself the contenteditable; the outer
+    // [data-testid="generic-field-rich-text-editor"] is just a non-typeable wrapper.
+    public static readonly measureGenericFieldRTETextBox = '[data-testid="genericField-rich-text-editor-content"]'
     public static readonly measureRTEPurposeContentField = '[data-testid="genericField-rich-text-editor-content"]'
     public static readonly measureDescriptionSaveButton = '[data-testid="measure-description-save"]'
     public static readonly measureDescriptionSuccessMessage = '[data-testid="measureDescriptionSuccess"]'

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -132,10 +132,13 @@ export class MeasureGroupPage {
     public static readonly rateAggregation = '[data-testid="rateAggregation-rich-text-editor-content"]'
     public static readonly readOnlyRateAggregation = '#rateAggregation'
     public static readonly improvementNotationSelect = '[id="improvement-notation-select"]'
-    public static readonly improvementNotationDescText = '[data-testid="improvement-notation-description-rich-text-editor"]'
+    // The outer `improvement-notation-description-rich-text-editor` is now just a wrapper
+    // that includes a non-typeable toolbar; the actual contenteditable lives at the
+    // `improvementNotationDescription-rich-text-editor-content` testid.
+    public static readonly improvementNotationDescText = '[data-testid="improvementNotationDescription-rich-text-editor-content"]'
     public static readonly readOnlyImpNotationDescription = '#improvementNotationDescription'
     // When the flag "EnhancedTextFormatting" is removed, replace the below variable's value with that wheich is commented out
-    public static readonly improvementNotationDescQiCore = '[data-testid="improvement-notation-description-rich-text-editor"]'
+    public static readonly improvementNotationDescQiCore = '[data-testid="improvementNotationDescription-rich-text-editor-content"]'
     public static readonly improvementNotationValues = '[class="MuiList-root MuiList-padding MuiMenu-list css-ubifyk"]'
     public static readonly measureReportingSaveBtn = '[data-testid="measure-Reporting-save"]'
 

--- a/cypress/Shared/OktaLogin.ts
+++ b/cypress/Shared/OktaLogin.ts
@@ -245,8 +245,11 @@ export class OktaLogin {
             cy.visitWithRetry('/');
         }
 
-        // 3) First attempt: wait for login form or landing page
-        waitForEither(35000).then((state) => {
+        // 3) First attempt: wait for login form or landing page.
+        // Bumped to 60s because the alt-user cookie path can take longer
+        // (extra Okta introspect → token → userinfo → user PUT round-trips
+        // before /login redirects to /measures).
+        waitForEither(60000).then((state) => {
             cy.log(`${logPrefix}: UI state after first wait: ${state}`);
 
             if (state === 'landing') {
@@ -262,26 +265,45 @@ export class OktaLogin {
             }
 
             // state === 'timeout'
-            // Cookie-based auth likely failed. The app may be mid-redirect
-            // (e.g. briefly hit /measures then bounced to /login).
-            // We need to get to the login form and enter credentials.
-            cy.log(`${logPrefix}: Timed out detecting UI state. Falling back to form-based login...`);
-
-            // Clear cookies since the cookie-based token was rejected
-            cy.clearAllCookies();
-            cy.clearLocalStorage();
+            // Cookie-based auth likely failed OR the redirect chain just hadn't
+            // finished yet. Re-probe after navigating to /login. Important: do
+            // NOT clear cookies up-front — if the cookie auth actually did work
+            // we'd be throwing away a valid session and forcing form login,
+            // which then fails because /login auto-redirects to /measures.
+            cy.log(`${logPrefix}: Timed out detecting UI state. Re-probing after /login navigation...`);
 
             // Re-register UMLS intercept before navigating — previous alias
             // may have been consumed by earlier page loads.
             cy.intercept('GET', '/api/vsac/umls-credentials/status').as('umls');
 
-            // Navigate directly to /login (with retry on network errors)
+            // Navigate directly to /login (with retry on network errors).
+            // If cookies are still valid, the app will bounce to /measures.
             cy.visitWithRetry('/login', { onBeforeLoad: (win) => win.sessionStorage.clear() });
 
-            // Wait for the login form to appear with a generous timeout
-            cy.get(selectors.username, { timeout: 60000 }).should('be.visible').then(() => {
-                cy.log(`${logPrefix}: Login form visible after fallback — performing form-based login.`);
-                doFormLogin();
+            waitForEither(60000).then((state2) => {
+                cy.log(`${logPrefix}: UI state after fallback wait: ${state2}`);
+
+                if (state2 === 'landing') {
+                    // Cookie auth completed during the fallback — we're in.
+                    return;
+                }
+
+                if (state2 === 'login') {
+                    cy.log(`${logPrefix}: Login form visible after fallback — performing form-based login.`);
+                    doFormLogin();
+                    return;
+                }
+
+                // Still neither: cookie was truly rejected and form never showed.
+                // Last resort: clear cookies and force the form to render.
+                cy.log(`${logPrefix}: Still no UI state. Clearing cookies and forcing form login.`);
+                cy.clearAllCookies();
+                cy.clearLocalStorage();
+                cy.intercept('GET', '/api/vsac/umls-credentials/status').as('umls');
+                cy.visitWithRetry('/login', { onBeforeLoad: (win) => win.sessionStorage.clear() });
+                cy.get(selectors.username, { timeout: 60000 }).should('be.visible').then(() => {
+                    doFormLogin();
+                });
             });
         });
 

--- a/cypress/e2e/WebInterface/Measure/Measure Group/CreateMeasureGroup.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/CreateMeasureGroup.cy.ts
@@ -88,7 +88,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         Utilities.setMeasureGroupType()
 
@@ -109,7 +109,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save population definition with scoring unit
@@ -137,7 +137,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         })
         cy.get(MeasureGroupPage.measureScoringSelect).should('contain.text', 'Cohort')
         cy.get(MeasureGroupPage.initialPopulationSelect).should('contain.text', 'Initial Population')
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[role="textbox"]').should('contain.text', 'MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).should('contain.text', 'MeasureGroup Description value')
         cy.get(MeasureGroupPage.ucumScoringUnitSelect).should('contain.value', 'mL')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('contain.text', 'Process')
     })
@@ -170,7 +170,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save population definition with scoring unit
@@ -182,7 +182,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).click()
@@ -241,7 +241,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save population definition with scoring unit
@@ -309,7 +309,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         Utilities.setMeasureGroupType()
 
@@ -352,7 +352,7 @@ describe('Validate Measure Group -- scoring and populations', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         Utilities.setMeasureGroupType()
 
@@ -407,7 +407,7 @@ describe('Validate Population Basis', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         Utilities.setMeasureGroupType()
 
@@ -446,7 +446,7 @@ describe('Validate Population Basis', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         Utilities.setMeasureGroupType()
 

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureGroupTabs.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureGroupTabs.cy.ts
@@ -75,7 +75,7 @@ describe('Validating Population tabs', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
         cy.get(MeasureGroupPage.rateAggregation).clear()
         cy.get(MeasureGroupPage.rateAggregation).type('{selectAll}{backspace}Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
@@ -108,8 +108,8 @@ describe('Validating Population tabs', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab and their recently updated values
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.html', '<p>Typed some value for Rate Aggregation text area field</p>')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.html', '<p>Typed some value for Rate Aggregation text area field</p>')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('exist').should('be.visible')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Increased score indicates improvement')
 
@@ -133,8 +133,8 @@ describe('Validating Population tabs', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab and their recently updated values
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.html', '<p>Typed some value for Rate Aggregation text area field</p>')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.html', '<p>Typed some value for Rate Aggregation text area field</p>')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('exist').should('be.visible')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Increased score indicates improvement')
 
@@ -237,7 +237,7 @@ describe('Validating Population tabs', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the 3 fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
         cy.get(MeasureGroupPage.rateAggregation).clear()
         cy.get(MeasureGroupPage.rateAggregation).type('{selectAll}{backspace}')
         cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
@@ -274,7 +274,7 @@ describe('Validating Population tabs', () => {
 
 
         //assert that all fields appear on the reporting tab and are blank / without a selected value
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
         cy.get(MeasureGroupPage.rateAggregation).should('not.contain.text')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('exist').should('be.visible')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Select Improvement Notation')
@@ -328,7 +328,7 @@ describe('Validating Reporting tabs', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert expected fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
         cy.get(MeasureGroupPage.rateAggregation).should('not.contain.text')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('exist').should('be.visible')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Increased score indicates improvement')
@@ -352,7 +352,7 @@ describe('Validating Reporting tabs', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the three fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.rateAggregation).should('have.attr', 'contenteditable', 'true')
         cy.get(MeasureGroupPage.rateAggregation).should('not.contain.text')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('exist').should('be.visible')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Increased score indicates improvement')

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
@@ -146,7 +146,7 @@ describe('Measure Observations', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
@@ -205,7 +205,7 @@ describe('Measure Observations', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save Measure Group
@@ -452,7 +452,7 @@ describe('Measure Observations and Stratification -- non-owner tests', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
@@ -599,7 +599,7 @@ describe('Measure Observation - Expected Values', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
@@ -674,7 +674,7 @@ describe('Measure Observation - Expected Values', () => {
         cy.get(MeasureGroupPage.reportingTab).click()
 
         //assert the two fields that should appear in the Reporting tab
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save Measure Group

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasurePopulations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasurePopulations.cy.ts
@@ -81,7 +81,7 @@ describe('Measure Populations', () => {
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringRatio)
 
         //measure group description
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Measure Populations for Ratio Measure
         cy.get(MeasureGroupPage.popBasis).should('exist')
@@ -102,7 +102,7 @@ describe('Measure Populations', () => {
 
         //assert the two fields that should appear in the Reporting tab
         cy.get(MeasureGroupPage.rateAggregation).should('exist').should('be.visible')
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save population definition with scoring unit
@@ -153,7 +153,7 @@ describe('Measure Populations', () => {
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCV)
 
         //measure group description
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Measure Populations for Ratio Measure
         cy.get(MeasureGroupPage.popBasis).should('exist')
@@ -174,7 +174,7 @@ describe('Measure Populations', () => {
 
         //assert the two fields that should appear in the Reporting tab
         cy.get(MeasureGroupPage.rateAggregation).should('exist').should('be.visible')
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         //save population definition with scoring unit
@@ -198,7 +198,7 @@ describe('Measure Populations', () => {
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCV)
 
         //measure group description
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Measure Populations for Ratio Measure
         cy.get(MeasureGroupPage.popBasis).should('exist')

--- a/cypress/e2e/WebInterface/Measure/Measure Group/UpdateMeasureGroup.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/UpdateMeasureGroup.cy.ts
@@ -57,7 +57,7 @@ describe('Validate Measure Group', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //Measure group description
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //select a group type
         Utilities.setMeasureGroupType()
@@ -80,7 +80,7 @@ describe('Validate Measure Group', () => {
 
         //assert the two fields that should appear in the Reporting tab
         cy.get(MeasureGroupPage.rateAggregation).should('exist').should('be.visible')
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
@@ -141,7 +141,7 @@ describe('Validate Measure Group', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //Measure group description
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //select a group type
         Utilities.setMeasureGroupType()
@@ -164,7 +164,7 @@ describe('Validate Measure Group', () => {
 
         //assert the two fields that should appear in the Reporting tab
         cy.get(MeasureGroupPage.rateAggregation).should('exist').should('be.visible')
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
@@ -211,7 +211,7 @@ describe('Validate Measure Group', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //Measure group description
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //select a group type
         Utilities.setMeasureGroupType()
@@ -234,7 +234,7 @@ describe('Validate Measure Group', () => {
 
         //assert the two fields that should appear in the Reporting tab
         cy.get(MeasureGroupPage.rateAggregation).should('exist').should('be.visible')
-        cy.get(MeasureGroupPage.rateAggregation).find('[contenteditable]').type('Typed some value for Rate Aggregation text area field')
+        cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
@@ -299,7 +299,7 @@ describe('Adding an Initial Population to group -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -328,7 +328,7 @@ describe('Adding an Initial Population to group -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -353,7 +353,7 @@ describe('Adding an Initial Population to group -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -374,7 +374,7 @@ describe('Adding an Initial Population to group -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -406,7 +406,7 @@ describe('Adding an Initial Population to group -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -489,7 +489,7 @@ describe('Delete second Initial Population -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -529,7 +529,7 @@ describe('Delete second Initial Population -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -550,7 +550,7 @@ describe('Delete second Initial Population -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')
@@ -601,7 +601,7 @@ describe('Delete second Initial Population -- Ratio score only', () => {
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //fill in a description value
-        cy.get(MeasureGroupPage.measureGroupDescriptionBox).find('[contenteditable]').type('MeasureGroup Description value')
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).type('MeasureGroup Description value')
 
         //Add Second Initial Population
         cy.get(MeasureGroupPage.addSecondInitialPopulationLink).should('exist')

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
@@ -149,9 +149,9 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.rateAggregation).type('Aggregation')
 
         //Add Improvement Notation --'Increased score indicates improvement'
-        cy.get(MeasureGroupPage.improvementNotationDescText).find('[role="textbox"]').should('have.attr', 'contenteditable', 'false')
+        cy.get(MeasureGroupPage.improvementNotationDescText).should('have.attr', 'contenteditable', 'false')
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
-        cy.get(MeasureGroupPage.improvementNotationDescText).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.improvementNotationDescText).should('have.attr', 'contenteditable', 'true')
 
         //save population definition with scoring unit
         cy.get(MeasureGroupPage.measureReportingSaveBtn).should('be.visible')
@@ -176,7 +176,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
 
         //Add Improvement Notation --'Decreased score indicates improvement'
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Decreased score indicates improvement')
-        cy.get(MeasureGroupPage.improvementNotationDescText).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.improvementNotationDescText).should('have.attr', 'contenteditable', 'true')
 
         //save population definition with scoring unit
         cy.get(MeasureGroupPage.measureReportingSaveBtn).should('be.visible')
@@ -201,7 +201,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
 
         //Add Improvement Notation --'Other'
         Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Other')
-        cy.get(MeasureGroupPage.improvementNotationDescText).find('[role="textbox"]').should('have.attr', 'contenteditable', 'true')
+        cy.get(MeasureGroupPage.improvementNotationDescText).should('have.attr', 'contenteditable', 'true')
 
         Utilities.waitForElementDisabled(MeasureGroupPage.measureReportingSaveBtn, 30000)
 


### PR DESCRIPTION

The app's rich-text editor was refactored: the element with
data-testid="*-rich-text-editor-content" is now itself the contenteditable
(div.tiptap.ProseMirror), not a wrapper around <div role="textbox"
contenteditable>. The old ".find('[contenteditable]')" / ".find('[role=
\"textbox\"]')" chains and a few wrapper-level selectors timed out or
landed on the non-typeable toolbar div, producing 30+ failures across
the Measure Group specs (MeasureGroupTabs, CreateMeasureGroup,
MeasurePopulations, MeasureObservations, UpdateMeasureGroup,
QDMPopulationCriteriaPage) and CreateMeasureValidations.

Selector fixes:
 - EditMeasurePage.measureGenericFieldRTETextBox now points at the
   inner "genericField-rich-text-editor-content" element so cy.type()
   has a typeable target (was the outer button-group wrapper).
 - MeasureGroupPage.improvementNotationDescText / improvementNotationDescQiCore
   now point at "improvementNotationDescription-rich-text-editor-content"
   (the wrapper sometimes resolved to the toolbar, causing intermittent
   "requires a valid typeable element" errors).
 - Stripped 48 obsolete .find('[contenteditable]') / .find('[role=
   "textbox"]') chains across the 6 specs above; assertions like
   should('have.attr','contenteditable','true') and should('contain.text')
   continue to work directly against the new content element.

OktaLogin.runLoginFlow hardening (fixes flaky AltLogin "Expected to find
[id=\"input28\"]" timeouts in MeasureObservations non-owner tests):
 - First waitForEither budget bumped from 35s -> 60s to absorb the
   slower alt-user redirect chain (extra introspect/token/userinfo
   round-trips before /login redirects to /measures).
 - Fallback path no longer pre-clears cookies and no longer assumes the
   Okta form will be present. It now re-runs waitForEither after
   visit('/login'); if the page lands on /measures (cookie auth
   completed during fallback) we accept it. Cookie clear + forced form
   login is reserved as a last resort when both probes truly time out.