### PR TITLE
fix: remove several find() to fix EMAM

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibrarySharing.cy.ts
@@ -29,7 +29,6 @@ describe('CQL Library Sharing', () => {
 
     afterEach('LogOut', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteLibrary(newCQLLibraryName)
     })
 
@@ -97,7 +96,6 @@ describe('CQL Library Sharing - Multiple instances', () => {
 
     afterEach('LogOut', () => {
 
-        
         Utilities.deleteLibrary(randomCQLLibraryName)
     })
 
@@ -169,7 +167,6 @@ describe('Remove user\'s share access from a library', () => {
         OktaLogin.setupUserSession(false)
         harpUserALT = OktaLogin.getUser(true)
 
-
         CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
 
         // initial share to harpUserAlt
@@ -178,7 +175,6 @@ describe('Remove user\'s share access from a library', () => {
 
     afterEach('Log out and Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteLibrary(newCQLLibraryName)
     })
 
@@ -227,7 +223,6 @@ describe('Share CQL Library using Action Center buttons', () => {
 
     afterEach('LogOut', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteLibrary(newCQLLibraryName)
     })
 
@@ -296,7 +291,6 @@ describe('Share CQL Library using Action Center buttons', () => {
 
         cy.get(CQLLibrariesPage.saveUserBtn).click()
         cy.get(CQLLibraryPage.genericSuccessMessage).should('contain.text', 'The Library(s) were successfully shared.')
-
     })
 
     it('Action centre share button disabled for Non Library Owner', () => {
@@ -357,7 +351,6 @@ describe('Share CQL Library using Action Center buttons - Multiple instances', (
 
     afterEach('LogOut', () => {
 
-        
         OktaLogin.setupUserSession(false)
         Utilities.deleteLibrary(updatedCQLLibraryName, false)
     })

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureAddMetaData.cy.ts
@@ -61,25 +61,25 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear().type(description)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(description)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
 
         //Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear().type(copyright)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(copyright)
         cy.get(EditMeasurePage.measureCopyrightSaveButton).click()
         cy.get(EditMeasurePage.measureCopyrightSuccessMessage).should('be.visible')
 
         //Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear().type(disclaimer)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(disclaimer)
         cy.get(EditMeasurePage.measureDisclaimerSaveButton).click()
         cy.get(EditMeasurePage.measureDisclaimerSuccessMessage).should('be.visible')
 
         //Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear().type(rationale)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(rationale)
         cy.get(EditMeasurePage.measureRationaleSaveButton).click()
         cy.get(EditMeasurePage.measureRationaleSuccessMessage).should('be.visible')
 
@@ -103,8 +103,7 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Purpose
         cy.get(EditMeasurePage.leftPanelPurpose).click()
-        Utilities.waitForElementVisible(EditMeasurePage.measureGenericFieldRTETextBox, 50000)
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.measureRTEPurposeContentField).type('This is a purpose.')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('This is a purpose.')
         cy.get(EditMeasurePage.measurePurposeSaveBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.measurePurposeSavedMsg, 50000)
         cy.get(EditMeasurePage.measurePurposeSavedMsg).should('contain.text', 'Measure Purpose Information Saved Successfully')
@@ -113,13 +112,13 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear().type(guidance)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type(guidance)
         cy.get(EditMeasurePage.measureGuidanceSaveButton).click()
         cy.get(EditMeasurePage.measureGuidanceSuccessMessage).should('be.visible')
 
         //Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear().type(clinicalRecommendation)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(clinicalRecommendation)
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
@@ -179,15 +178,15 @@ describe('Edit Measure: Add Meta Data', () => {
 
         //Purpose
         cy.get(EditMeasurePage.leftPanelPurpose).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.measureRTEPurposeContentField).should('contain.text', 'This is a purpose.')
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.measureRTEPurposeContentField).clear().type('This is a purpose updated.')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', 'This is a purpose.')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('This is a purpose updated.')
         cy.get(EditMeasurePage.measurePurposeSaveBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.measurePurposeSavedMsg, 50000)
         cy.get(EditMeasurePage.measurePurposeSavedMsg).should('contain.text', 'Measure Purpose Information Saved Successfully')
         Utilities.waitForElementToNotExist(EditMeasurePage.measurePurposeSavedMsg, 50000)
-        cy.reload()
+
         Utilities.waitForElementVisible(EditMeasurePage.measureGenericFieldRTETextBox, 50000)
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.measureRTEPurposeContentField).should('contain.text', 'This is a purpose updated.')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('contain.text', 'This is a purpose updated.')
         cy.log('Measure Purpose updated successfully')
 
         //guidance


### PR DESCRIPTION
Fixes EditMeasureAddMetaData
Remove many instances of .find() that are no longer valid. We formerly relied on these as a compound locator strategy but recent changes to the RTE have rescoped the data-testid's & made the extra find() no longer necessary.
Also removed a couple wait statements from the same test that are not needed.

No functional changes made to CQLLibrarySharing.
Only whitespace & removal of UILogout() that are not needed.
