### PR TITLE
fix: resolve scoping of RTE fields

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -158,6 +158,7 @@ export class EditMeasurePage {
     //Measure MetaData
 
     //RTE field button(s)
+    public static readonly readOnlyRTEBlock = '[class="rich-text-editor_read_only"]'
     public static readonly RTEContentField = '[data-testid="genericField-rich-text-editor-content"]'
     public static readonly RTEFieldToolbar = '[data-testid="genericField-rich-text-editor-toolbar"]'
     public static readonly rteToolBar = '[data-testid="rich-text-editor-toolbar"]'
@@ -274,7 +275,7 @@ export class EditMeasurePage {
                 cy.wait(1000)
 
                 cy.get('#new-version').invoke('val').then(value => {
-                    cy.get(MeasuresPage.confirmMeasureVersionNumber).type(value.toString())
+                    cy.get(MeasuresPage.confirmMeasureVersionNumber).type(value!.toString())
                 })
 
                 cy.get(MeasuresPage.measureVersionContinueBtn).click()

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureOwnershipValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/EditMeasureOwnershipValidations.cy.ts
@@ -8,22 +8,22 @@ import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { LandingPage } from "../../../../Shared/LandingPage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { Header } from "../../../../Shared/Header"
 
-let measureCQL = MeasureCQL.ICFCleanTest_CQL
-let measureName = 'TestMeasure' + Date.now()
-let cqlLibraryName = 'TestLibrary' + Date.now()
+const measureCQL = MeasureCQL.ICFCleanTest_CQL
+const measureName = 'EMOwnershipValidations' + Date.now()
+const cqlLibraryName = 'EMOwnershipValidationsLib' + Date.now()
 
-let TCSeries = 'SBTestSeries'
-let TCTitle = 'test case title'
-let TCDescription = 'DENOMFail1651609688032'
+const TCSeries = 'SBTestSeries'
+const TCTitle = 'test case title'
+const TCDescription = 'DENOMFail1651609688032'
 
 describe('Read only for measure, measure group, and test cases that user does not own', () => {
 
     beforeEach('Create Measure, Measure Group, and Test Case with alt userLogin', () => {
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL, undefined, true)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, true, 'Surgical Absence of Cervix', '', '', 'Surgical Absence of Cervix', '', 'Surgical Absence of Cervix', 'Procedure')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0, true, 'Surgical Absence of Cervix', '', '', 'Surgical Absence of Cervix', '', 'Surgical Absence of Cervix', 'Procedure')
         TestCasesPage.CreateTestCaseAPI(TCTitle, TCSeries, TCDescription, '', false, false, true)
         OktaLogin.AltLogin()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
@@ -35,7 +35,8 @@ describe('Read only for measure, measure group, and test cases that user does no
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
-        cy.get(Header.mainMadiePageButton).click()
+        OktaLogin.SessionLogin()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
     })
 
     afterEach('Logout and clean up', () => {
@@ -44,10 +45,6 @@ describe('Read only for measure, measure group, and test cases that user does no
     })
 
     it('Measure fields on detail page are not editable', () => {
-
-        //page loads
-        cy.location('pathname', { timeout: 60000 }).should('include', '/measures')
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
 
         //navigate to the all measures tab
         cy.get(LandingPage.allMeasuresTab).should('be.visible')
@@ -71,23 +68,23 @@ describe('Read only for measure, measure group, and test cases that user does no
 
         cy.get(EditMeasurePage.leftPanelDescription).should('be.visible')
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[data-testid="genericField-value"]').should('exist')
+        cy.get(EditMeasurePage.readOnlyRTEBlock).should('be.visible')
 
         cy.get(EditMeasurePage.leftPanelCopyright).should('be.visible')
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.readOnlyRTEBlock).should('be.visible')
 
         cy.get(EditMeasurePage.leftPanelDisclaimer).should('be.visible')
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.readOnlyRTEBlock).should('be.visible')
 
         cy.get(EditMeasurePage.leftPanelRationale).should('be.visible')
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.readOnlyRTEBlock).should('be.visible')
 
         cy.get(EditMeasurePage.leftPanelGuidance).should('be.visible')
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find('[class="rich-text-editor_read_only"]').should('exist')
+        cy.get(EditMeasurePage.readOnlyRTEBlock).should('be.visible')
 
         cy.get(EditMeasurePage.leftPanelQiCoreDefinition).should('be.visible')
         cy.get(EditMeasurePage.leftPanelQiCoreDefinition).click()
@@ -95,8 +92,6 @@ describe('Read only for measure, measure group, and test cases that user does no
     })
 
     it('CQL value on the measure CQL Editor tab cannot be changed', () => {
-
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
 
         //navigate to the all measures tab
         cy.get(LandingPage.allMeasuresTab).should('be.visible')
@@ -111,52 +106,12 @@ describe('Read only for measure, measure group, and test cases that user does no
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('Test for ownership')
 
-        // ToDo: check this
-        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).eq(null)
-    })
-
-    it('Test Cases are read / view only', () => {
-        // since altUser created the measure & tc
-        let currentUser = Cypress.env('selectedAltUser')
-        
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
-
-        //navigate to the all measures tab
-        cy.get(LandingPage.allMeasuresTab).should('be.visible')
-        cy.get(LandingPage.allMeasuresTab).click()
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
-
-        //edit the measure that was not created by logged-in user
-        MeasuresPage.actionCenter('edit', undefined, { altUser: true })
-
-        //confirm that the test case tab is available and click on it
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
-
-        TestCasesPage.checkTestCase(1)
-        cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId').should('exist').then((fileContents) => {
-
-            //confirm that view button for test case is available and click on the view button
-            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').should('have.text', 'View')
-            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').should('be.visible')
-            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').should('be.enabled')
-            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').click()
-        })
-
-        //confirm that the text boxes, for the test case fields are not visible
-        cy.get(TestCasesPage.detailsTab).click()
-        //<textarea rows="1" readonly="" id="test-case-title" placeholder="Test Case Title" name="title" style="color: rgb(51, 51, 51); font-family: Rubik; font-size: 14px; font-style: normal; font-weight: 400; line-height: 24px; border: none; resize: none; padding: 0px; outline: none; box-shadow: none; height: 24px; overflow: hidden;">test case title</textarea>
-        cy.get('[id="test-case-title"]').should('have.attr', 'readonly', 'readonly')
-        cy.get(TestCasesPage.testCaseDescriptionTextBox).should('have.attr', 'readonly', 'readonly')
-        cy.get(TestCasesPage.createTestCaseGroupInput).should('have.attr', 'readonly', 'readonly')
+        cy.get('[class="ace_tooltip ace_dark ace-monokai"]').should('have.text', 'Editing is disabled')
+        cy.get(EditMeasurePage.saveButton).should('not.exist')
     })
 
     it('Fields on Measure Group page are not editable', () => {
 
-        //page loads
-        cy.location('pathname', { timeout: 60000 }).should('include', '/measures')
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
-
         //navigate to the all measures tab
         cy.get(LandingPage.allMeasuresTab).should('be.visible')
         cy.get(LandingPage.allMeasuresTab).click()
@@ -164,6 +119,7 @@ describe('Read only for measure, measure group, and test cases that user does no
 
         //edit the measure that was not created by logged-in user
         MeasuresPage.actionCenter('edit', undefined, { altUser: true })
+        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         //Verify that the Add Population Criteria button is not shown
@@ -198,5 +154,39 @@ describe('Read only for measure, measure group, and test cases that user does no
         cy.get(MeasureGroupPage.reportingTab).click()
         cy.get('[data-testid="rich-text-editor-content"]').should('not.exist')
         cy.get(MeasureGroupPage.improvementNotationSelect).should('have.attr', 'readonly', 'readonly')
+    })
+
+    it('Test Cases are read / view only', () => {
+        // since altUser created the measure & tc
+        let ownerAccount = Cypress.env('selectedAltUser')
+
+        //navigate to the all measures tab
+        cy.get(LandingPage.allMeasuresTab).should('be.visible')
+        cy.get(LandingPage.allMeasuresTab).click()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
+
+        //edit the measure that was not created by logged-in user
+        MeasuresPage.actionCenter('edit', undefined, { altUser: true })
+
+        //confirm that the test case tab is available and click on it
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
+
+        TestCasesPage.checkTestCase(1)
+        cy.readFile('cypress/fixtures/' + ownerAccount + '/testCaseId').should('exist').then((fileContents) => {
+
+            //confirm that view button for test case is available and click on the view button
+            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').should('have.text', 'View')
+            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').should('be.visible')
+            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').should('be.enabled')
+            cy.get('[data-testid=view-edit-test-case-button-' + fileContents + ']').click()
+        })
+
+        //confirm that the text boxes, for the test case fields are not visible
+        cy.get(TestCasesPage.detailsTab).click()
+        //<textarea rows="1" readonly="" id="test-case-title" placeholder="Test Case Title" name="title" style="color: rgb(51, 51, 51); font-family: Rubik; font-size: 14px; font-style: normal; font-weight: 400; line-height: 24px; border: none; resize: none; padding: 0px; outline: none; box-shadow: none; height: 24px; overflow: hidden;">test case title</textarea>
+        cy.get('[id="test-case-title"]').should('have.attr', 'readonly', 'readonly')
+        cy.get(TestCasesPage.testCaseDescriptionTextBox).should('have.attr', 'readonly', 'readonly')
+        cy.get(TestCasesPage.createTestCaseGroupInput).should('have.attr', 'readonly', 'readonly')
     })
 })

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/RTEField.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/RTEField.cy.ts
@@ -5,23 +5,16 @@ import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { Utilities } from "../../../../Shared/Utilities"
 import { QiCore4Cql } from "../../../../Shared/FHIRMeasuresCQL"
 
-
-let randValue = (Math.floor((Math.random() * 1000) + 1))
-let newCqlLibraryName = ''
-let newMeasureName = ''
-
 describe('Edit Measure: Add content to an Rich Text field and use formatting buttons', () => {
 
     beforeEach('Login', () => {
-        randValue = (Math.floor((Math.random() * 1000) + 1))
+
         const now = Date.now()
         const measureName = 'MeasureDefs' + now
         const CqlLibraryName = 'MeasureDefsLib' + now
         const measureCQL = QiCore4Cql.ICFTest_CQL.replace('EXM124v7QICore4', measureName)
-        newMeasureName = measureName + randValue
-        newCqlLibraryName = CqlLibraryName + randValue + 2
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
 
         OktaLogin.Login()
     })
@@ -40,15 +33,14 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}{backspace}')
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(description)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('{selectAll}{backspace}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(description)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).should('be.enabled').click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
         //apply RTE field formatting
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{selectAll}')
         cy.get(EditMeasurePage.frmtBoldBtn).click()
         cy.get(EditMeasurePage.frmtItalicizeBtn).click()
         cy.get(EditMeasurePage.frmtUnderlineBtn).click()
@@ -59,7 +51,7 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
         //confirm html formatting that is in the field
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<ol><li><p><strong><em><del><u>description</u></del></em></strong></p></li></ol>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<ol><li><p><strong><em><del><u>description</u></del></em></strong></p></li></ol>')
     })
 
     it('Verify the entry, undo, redo, bulletted list, embedded table, save and the resulting HTML text formatting that in the RTE field', () => {
@@ -71,31 +63,30 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}{backspace}')
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(description)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('{selectAll}{backspace}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(description)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).should('be.enabled').click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
         //apply RTE field formatting
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}')
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtBoldBtn).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtItalicizeBtn).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtUnderlineBtn).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtStrikeThroughBtn).click({ force: true })
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click({ force: true })
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p><strong><em><del><u>description</u></del></em></strong></p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{selectAll}')
+        cy.get(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtBoldBtn).click()
+        cy.get(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtItalicizeBtn).click()
+        cy.get(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtUnderlineBtn).click()
+        cy.get(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.frmtStrikeThroughBtn).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p><strong><em><del><u>description</u></del></em></strong></p>')
 
         //undo
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.unDoBtn).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click({ force: true })
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p><strong><em><u>description</u></em></strong></p>')
+        cy.get(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.unDoBtn).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p><strong><em><u>description</u></em></strong></p>')
 
         //redo
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.reDoBtn).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click({ force: true })
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p><strong><em><del><u>description</u></del></em></strong></p>')
+        cy.get(EditMeasurePage.RTEFieldToolbar).find(EditMeasurePage.reDoBtn).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p><strong><em><del><u>description</u></del></em></strong></p>')
 
         //bulletted list
         cy.get(EditMeasurePage.bulletedListBtn).click()
@@ -116,7 +107,7 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).invoke('html').then((html) => {
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).invoke('html').then((html) => {
             // The bulleted list wraps content in <ul><li> and the table may also be inside a list item
             expect(html).to.contain('<strong><em><del><u>description</u></del></em></strong>')
             expect(html).to.contain('tableWrapper')
@@ -127,15 +118,12 @@ describe('Edit Measure: Add content to an Rich Text field and use formatting but
 describe('Edit Measure: Add embedded table to Rich Text field and use the various buttons to manage the table', () => {
 
     beforeEach('Login', () => {
-        randValue = (Math.floor((Math.random() * 1000) + 1))
         const now = Date.now()
         const measureName = 'MeasureDefs' + now
         const CqlLibraryName = 'MeasureDefsLib' + now
         const measureCQL = QiCore4Cql.ICFTest_CQL.replace('EXM124v7QICore4', measureName)
-        newMeasureName = measureName + randValue
-        newCqlLibraryName = CqlLibraryName + randValue + 2
 
-        CreateMeasurePage.CreateQICoreMeasureAPIWithNoMeasureDesc(newMeasureName, newCqlLibraryName, measureCQL)
+        CreateMeasurePage.CreateQICoreMeasureAPIWithNoMeasureDesc(measureName, CqlLibraryName, measureCQL)
 
         OktaLogin.Login()
     })
@@ -165,7 +153,7 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<div class="tableWrapper"><table style="min-width: 75px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<div class="tableWrapper"><table style="min-width: 75px;"><colgroup><col style="min-width: 25px;"><col style="min-width: 25px;"><col style="min-width: 25px;"></colgroup><tbody><tr><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th><th colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></th></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr><tr><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td><td colspan="1" rowspan="1"><p><br class="ProseMirror-trailingBreak"></p></td></tr></tbody></table></div>')
 
         //add row above, row below, column left, column right and confirm
         cy.get(EditMeasurePage.embdTableAddRowAboveBtn).click()
@@ -178,7 +166,7 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).invoke('html').then((html) => {
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).invoke('html').then((html) => {
             // Verify the table has the expected number of rows (5: 1 header + 2 original + 1 above + 1 below)
             expect(html).to.contain('tableWrapper')
             const rowCount = (html.match(/<tr>/g) || []).length
@@ -193,8 +181,8 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.embdTableRemoveRowBtn).click()
         cy.get(EditMeasurePage.embdTableRemoveColBtn).click()
         cy.get(EditMeasurePage.embdTableRemoveColBtn).click({ force: true })
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click({ force: true })
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).invoke('html').then((html) => {
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click({ force: true })
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).invoke('html').then((html) => {
             expect(html).to.contain('tableWrapper')
             // Verify table was reduced: should have 3 rows and 3 columns (started with 5 each, removed 2 of each)
             const rowCount = (html.match(/<tr>/g) || []).length
@@ -211,6 +199,6 @@ describe('Edit Measure: Add embedded table to Rich Text field and use the variou
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
         Utilities.waitForElementToNotExist(EditMeasurePage.measureDescriptionSuccessMessage, 190000)
 
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p><br class="ProseMirror-trailingBreak"></p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p><br class="ProseMirror-trailingBreak"></p>')
     })
 })


### PR DESCRIPTION
Fixes EditMeasureOwnershipValidations
Re-scope selectors to correctly pick up readonly version of editor, and upgrade check to is.visible.
Corrected CQL check that was impossible to fail - this is now a real test.
Re-ordered checks to match Madie layout.

Fixed RTEField
Removed randomization strategy that was not needed.
Removed extra naming variables as part of randomization, also not needed.
Similar to other changes, change scope of selectors & removed all the unneeded .find()