### PR TITLE
fix: re-scope rte, address library versions

### DIFF
--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore411.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore411.cy.ts
@@ -87,34 +87,30 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type('{selectAll}{backspace}')
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).wait(500).type(QDMdescription).wait(2000)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type('{selectAll}{backspace}')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).wait(500).type(QDMdescription).wait(2000)
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
 
         //Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMcopyright)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(QDMcopyright)
         cy.get(EditMeasurePage.measureCopyrightSaveButton).click()
         cy.get(EditMeasurePage.measureCopyrightSuccessMessage).should('be.visible')
 
         //Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMdisclaimer)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(QDMdisclaimer)
         cy.get(EditMeasurePage.measureDisclaimerSaveButton).click()
         cy.get(EditMeasurePage.measureDisclaimerSuccessMessage).should('be.visible')
 
         //Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMrationale)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(QDMrationale)
         cy.get(EditMeasurePage.measureRationaleSaveButton).click()
         cy.get(EditMeasurePage.measureRationaleSuccessMessage).should('be.visible')
 
@@ -142,17 +138,15 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMguidance)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(QDMguidance)
         cy.get(EditMeasurePage.measureGuidanceSaveButton).click()
         cy.get(EditMeasurePage.measureGuidanceSuccessMessage).should('be.visible')
 
         //Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).clear()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).type(QDMclinicalRecommendation)
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).type(QDMclinicalRecommendation)
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
@@ -220,27 +214,23 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMdescription + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMdescription + '</p>')
 
         //Confirm Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMcopyright + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMcopyright + '</p>')
 
         //Confirm Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMdisclaimer + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMdisclaimer + '</p>')
 
         //Confirm Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMrationale + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMrationale + '</p>')
 
         //Confirm Steward & Developers
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()
@@ -254,15 +244,13 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMguidance + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMguidance + '</p>')
 
         //Confirm Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMclinicalRecommendation + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMclinicalRecommendation + '</p>')
     })
 })
 

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore600.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore600.cy.ts
@@ -152,11 +152,6 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
@@ -220,23 +215,19 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMdescription + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMdescription + '</p>')
 
         //Confirm Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMcopyright + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMcopyright + '</p>')
 
         //Confirm Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMdisclaimer + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMdisclaimer + '</p>')
 
         //Confirm Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMrationale + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMrationale + '</p>')
 
         //Confirm Steward & Developers
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()
@@ -250,13 +241,11 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMguidance + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMguidance + '</p>')
 
         //Confirm Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).focus()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).find(EditMeasurePage.RTEContentField).should('have.html', '<p>' + QDMclinicalRecommendation + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMclinicalRecommendation + '</p>')
     })
 })
 

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMLibraryIncludes.cy.ts
@@ -86,7 +86,9 @@ describe('QDM Library Includes fields', () => {
             .find('[class="growing-div open"]').find(CQLEditorPage.librarySearchTable)
             .find('[data-testid="library-results-tbl"]')
             .find('[data-testid="library-results-table-body"]')
-            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / ApplyVTEQDM10.0.000yahu1257View / ApplyVTEQDM9.1.000yahu1257View / ApplyVTEQDM9.0.000yahu1257View / ApplyVTEQDM8.3.000yahu1257View / Apply')
+            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / Apply')
+        cy.get('[data-testid*="edit-button"]').should('have.length', 5)
+        
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()
@@ -112,7 +114,8 @@ describe('QDM Library Includes fields', () => {
             .find(CQLEditorPage.librarySearchTable)
             .find('[data-testid="library-results-tbl"]')
             .find('[data-testid="library-results-table-body"]')
-            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / ApplyVTEQDM10.0.000yahu1257View / ApplyVTEQDM9.1.000yahu1257View / ApplyVTEQDM9.0.000yahu1257View / ApplyVTEQDM8.3.000yahu1257View / Apply')
+            .should('include.text', 'UATVTEQDM0.1.000yahu1257View / Apply')
+        cy.get('[data-testid*="edit-button"]').should('have.length', 5)
 
         //Apply Library to CQL
         cy.get('[data-testid="edit-button-0"]').click()


### PR DESCRIPTION
Fixes QDMLibraryIncludes
Adjust expected values for library versions available. Changed from long exact list to only looking for title & count.

Both MeasureAssociationMetaData tests
Similar to many PRs yesterday. Removed many instances of .find() used to scope selectors.
Removed a handful of extra or duplicate steps that were not needed.