### PR TITLE
fix: corrected typos in CQL

### DIFF
--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/MODataTypeError.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/MODataTypeError.cy.ts
@@ -13,7 +13,7 @@ let measureCQL = 'library MOError1690893365906 version \'0.0.000\'\n\n' +
     'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n\n' +
     'valueset "Admit Inpatient": \'urn:oid:2.16.840.1.113762.1.4.1111.164\'\n' +
     'valueset "Decision to Admit to Hospital Inpatient": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.295\'\n' +
-    'valueset "Emergency Department Evaluation": \'urn:oid:2.16.840.1.113762.1.4.1111.163\ \n' +
+    'valueset "Emergency Department Evaluation": \'urn:oid:2.16.840.1.113762.1.4.1111.163\'\n' +
     'valueset "Emergency Department Visit": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.292\'\n' +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "Hospital Settings": \'urn:oid:2.16.840.1.113762.1.4.1111.126\'\n' +

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CreateUpdateQDMTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CreateUpdateQDMTestCase.cy.ts
@@ -36,7 +36,7 @@ const measureCQLPatient = 'library ICFQDMTEST000001 version \'0.0.000\'\n\n' +
     'valueset "Bilateral Mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1005\'\n' +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "History of bilateral mastectomy": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1068\'\n' +
-    'valueset "Mammography": \'urn:oid:2.16.840.1.113883.3.464.1003.108.12.1018\ \n' +
+    'valueset "Mammography": \'urn:oid:2.16.840.1.113883.3.464.1003.108.12.1018\'\n' +
     'valueset "Outpatient": \'urn:oid:2.16.840.1.113883.3.464.1003.101.12.1087\'\n' +
     'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
     'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
@@ -140,7 +140,6 @@ describe('Create and Update QDM Test Case', () => {
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         OktaLogin.Login()
-
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -241,7 +240,6 @@ describe('Create and Update QDM Test Case', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test Case Updated Successfully')
-
     })
 })
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecuteTestCasesByNonMeasureOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecuteTestCasesByNonMeasureOwner.cy.ts
@@ -8,16 +8,15 @@ import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
 import { LandingPage } from "../../../../../Shared/LandingPage"
 import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
 import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
-import { Toasts } from "../../../../../Shared/Toasts"
 import { QiCore4Cql } from "../../../../../Shared/FHIRMeasuresCQL"
 
 const measureName = 'ETCByNonOwner' + Date.now()
 const CqlLibraryName = 'ETCByNonOwnerLib' + Date.now()
 const testCaseTitle = 'test case title'
+const testCaseSeries = 'SBTestSeries'
 const testCaseDescription = 'DENOMFail' + Date.now()
 const validTestCaseJson = TestCaseJson.TestCaseJson_Valid
 const warningTestCaseJson = TestCaseJson.TestCaseJson_with_warnings
-const testCaseSeries = 'SBTestSeries'
 const measureCQLPFTests = QiCore4Cql.reduced_CQL_Multiple_Populations
 
 describe('Ability to run valid test cases whether or not the user is the owner of the measure or if the measure has not been shared with the user', () => {


### PR DESCRIPTION
MODataTypeError
CreateUpdateQDMTestCase
corrected a typo in both of the tests CQL. During the last round of updates for these 2, both missed a closing ' in the CQL
and caused cascading errors.

Whitespace updates for ExecuteTestCasesByNonMeasureOwner.