### PR TITLE
Refactor eliminate create apicql library with valid cql

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -77,7 +77,7 @@ export class CQLLibraryPage {
     public static readonly actionCenterVersion = '[data-testid="VersionLibrary"]'
     public static readonly actionCenterDraft = '[data-testid="DraftLibrary"]'
     public static readonly actionCenterShare = '[data-testid="ShareLibrary"]'
-    public static readonly actionCenterTransfer = '[data-testid="Transfer"]' //'[data-testid="Youcannottransferalibraryyoudonotown."]' 
+    public static readonly actionCenterTransfer = '[data-testid="Transfer"]'
     public static readonly actionCenterHistory = '[data-testid="History"]'
 
     //CQL Editor
@@ -169,8 +169,7 @@ export class CQLLibraryPage {
                     "librarySetId": uuidv4(),
                     "description": "description",
                     "publisher": CQLLibraryPublisher,
-                    'cql': cql//,
-                    //"programUseContext": { "code": "a", "display": "b", "codeSystem": "c" }
+                    'cql': cql
                 }
             }).then((response) => {
                 let currentUser = Cypress.env('selectedUser')
@@ -181,56 +180,6 @@ export class CQLLibraryPage {
                 {
                     currentUser = Cypress.env('selectedAltUser')
                 }
-                if (twoLibraries === true) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId2', response.body.id)
-                }
-                else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId', response.body.id)
-                }
-
-            })
-        })
-        return user
-    }
-
-    public static createAPICQLLibraryWithValidCQL(CqlLibraryName: string, CQLLibraryPublisher: string, twoLibraries?: boolean, altUser?: boolean): string {
-        const currentUser = Cypress.env('selectedUser')
-
-        let user = ''
-
-        if (altUser === undefined || altUser === null)
-        {
-            altUser = false
-        }
-
-        user = OktaLogin.setupUserSession(altUser)
-
-        //Create New CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                method: 'POST',
-                body: {
-                    'cqlLibraryName': CqlLibraryName,
-                    'model': 'QI-Core v4.1.1',
-                    'cql': "library SupplementalDataElementsQICore4 version '2.0.0'\n" +
-                        "\n" +
-                        "using QICore version '4.1.1'\n" +
-                        'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-                        "valueset \"ONC Administrative Sex\": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1'\n" +
-                        "context Patient",
-                    "librarySetId": uuidv4(),
-                    "description": "description",
-                    "publisher": CQLLibraryPublisher,
-                    'createdBy': user
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
-                expect(response.body.cqlLibraryName).to.eql(CqlLibraryName)
                 if (twoLibraries === true) {
                     cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId2', response.body.id)
                 }

--- a/cypress/Shared/LibraryCQL.ts
+++ b/cypress/Shared/LibraryCQL.ts
@@ -1,29 +1,20 @@
 export class LibraryCQL {
-    public static readonly validCQL4QDMLib = 'library PalliativeCareExclusionECQMQDM version \'1.0.000\'\n' +
-        '    \n' +
-        'using QDM version \'5.6\'\n' +
-        '\n' +
-        'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n' +
-        '\n' +
-        'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\' \n' +
-        '\n' +
-        'valueset "Palliative Care Diagnosis": \'urn:oid:2.16.840.1.113883.3.464.1003.1167\' \n' +
-        'valueset "Palliative Care Encounter": \'urn:oid:2.16.840.1.113883.3.464.1003.101.12.1090\' \n' +
-        'valueset "Palliative Care Intervention": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1135\' \n' +
-        '\n' +
-        'code "Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)": \'71007-9\' from "LOINC" display \'Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)\'\n' +
-        '\n' +
-        'parameter "Measurement Period" Interval<DateTime>\n' +
-        '\n' +
-        'context Patient\n' +
-        '\n' +
+    public static readonly validCQL4QDMLib = 'library PalliativeCareExclusionECQMQDM version \'1.0.000\'\n\n' +
+        'using QDM version \'5.6\'\n\n' +
+        'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n\n' +
+        'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\'\n\n' +
+        'valueset "Palliative Care Diagnosis": \'urn:oid:2.16.840.1.113883.3.464.1003.1167\'\n' +
+        'valueset "Palliative Care Encounter": \'urn:oid:2.16.840.1.113883.3.464.1003.101.12.1090\'\n' +
+        'valueset "Palliative Care Intervention": \'urn:oid:2.16.840.1.113883.3.464.1003.198.12.1135\'\n\n' +
+        'code "Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)": \'71007-9\' from "LOINC" display \'Functional Assessment of Chronic Illness Therapy - Palliative Care Questionnaire (FACIT-Pal)\'\n\n' +
+        'parameter "Measurement Period" Interval<DateTime>\n\n' +
+        'context Patient\n\n' +
         'define "Has Palliative Care in the Measurement Period":\n' +
         '  true'
 
-    public static readonly validCQL4QICORELib = "library SupplementalDataElementsQICore4 version '2.0.0'\n" +
-        "\n" +
-        "using QICore version '4.1.1'\n" +
-        "\n" +
+    public static readonly validCQL4QICORELib = "library SupplementalDataElementsQICore4 version '2.0.0'\n\n" +
+        "using QICore version '4.1.1'\n\n" +
+        "include FHIRHelpers version '4.1.000' called FHIRHelpers\n\n" +
         "valueset \"ONC Administrative Sex\": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1'"
 
     public static readonly invalidFhir4Lib = "library TESTMEASURE0000000003 version '0.0.000'\nusing FHIR version '4.0.1'\n" +
@@ -31,6 +22,4 @@ export class LibraryCQL {
         "include MATGlobalCommonFunctionsFHIR4 version '6.1.000' called Global\nparameter \"Measurement Period\" Interval<DateTimeTest>\n" +
         "context Patient\ndefine \"SDE Ethnicity\":\nSDE.\"SDE Ethnicity\"\ndefine \"SDE Payer\":\nSDE.\"SDE Payer\"\ndefine \"SDE Race\":\n" +
         "SDE.\"SDE Race\"\ndefine \"SDE Sex\":\nSDE.\"SDE Sex\""
-
-
-    }
+}

--- a/cypress/e2e/Services/CQL Library Service/VersionAndDraftCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/VersionAndDraftCQL-Library.cy.ts
@@ -2,17 +2,18 @@ import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { SupportedModels } from "../../../Shared/CreateMeasurePage"
 import { v4 as uuidv4 } from 'uuid'
 import { LibraryCQL } from "../../../Shared/LibraryCQL"
-import {OktaLogin} from "../../../Shared/OktaLogin"
+import { OktaLogin } from "../../../Shared/OktaLogin"
 
+let harpUser = ''
+let harpUserALT = ''
 let CqlLibraryOne = ''
 let CqlLibraryTwo = ''
 let updatedCqlLibraryName = 'UpdatedTestLibrary' + Date.now()
-let harpUser = ''
-let harpUserALT = ''
 const model = 'QI-Core v4.1.1'
 const CQLLibraryPublisher = 'SemanticBits'
 const versionNumber = '1.0.000'
 const invalidLibraryCql = LibraryCQL.invalidFhir4Lib
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('Version and Draft CQL Library', () => {
 
@@ -26,11 +27,11 @@ describe('Version and Draft CQL Library', () => {
 
         //Create CQL Library with Regular User
         CqlLibraryOne = 'TestLibrary1' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
 
         //Create Measure with Alternate User
         CqlLibraryTwo = 'TestLibrary2' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryTwo, CQLLibraryPublisher, true, true)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryTwo, SupportedModels.qiCore4, { cql: validCql, libraryNumber: 2, altUser: true })
     })
 
     it('Add Version to the CQL Library', () => {
@@ -127,7 +128,6 @@ describe('Version and Draft CQL Library', () => {
                     headers: {
                         authorization: 'Bearer ' + accessToken?.value
                     }
-
                 }).then((response) => {
                     expect(response.status).to.eql(403)
                     expect(response.body.message).to.eql('User ' + harpUserALT + ' cannot modify resource CQL Library with id: ' + cqlLibraryId)
@@ -145,7 +145,7 @@ describe('Draft and Version Validations', () => {
         harpUserALT = OktaLogin.getUser(true)
 
         CqlLibraryOne = 'TestLibraryOne' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
     })
 
     it('Verify the CQL Library updates are restricted after Version is created', () => {
@@ -208,7 +208,7 @@ describe('Version CQL Library without CQL', () => {
         harpUserALT = OktaLogin.getUser(true)
 
         CqlLibraryOne = 'CQLLibraryWithoutCQL' + Date.now()
-        CQLLibraryPage.createCQLLibraryAPI(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4)
     })
 
     it('User can not version CQL Library if there is no CQL', () => {
@@ -264,4 +264,3 @@ describe('Version CQL Library with invalid CQL', () => {
         })
     })
 })
-

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibrarySharing.cy.ts
@@ -4,32 +4,30 @@ import { CQLLibraryPage, EditLibraryActions } from "../../../../Shared/CQLLibrar
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
-const CQLLibraryName = 'LibrarySharing' + Date.now()
-const randValue = (Math.floor((Math.random() * 1000) + 1))
-const randomCQLLibraryName = 'LibrarySharingDraft' + randValue + 5
-const CQLLibraryPublisher = 'SemanticBits'
+const now = Date.now()
+const randomCQLLibraryName = 'LibrarySharingDraft' + now
+const updatedCQLLibraryName = 'NewNameForLibrarySharing' + now
 const versionNumber = '1.0.000'
-let newCQLLibraryName = ''
-let updatedCQLLibraryName = ''
+const validCql = LibraryCQL.validCQL4QICORELib
 let harpUserALT = ''
+let CQLLibraryName = ''
 
 describe('CQL Library Sharing', () => {
 
     beforeEach('Create CQL Library', () => {
 
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        newCQLLibraryName = CQLLibraryName + randValue + randValue + 1
-        updatedCQLLibraryName = CQLLibraryName + randValue + 'SomeUpdate' + 9
-
-        CQLLibraryPage.createCQLLibraryAPI(newCQLLibraryName, CQLLibraryPublisher)
-
+        CQLLibraryName = 'LibrarySharing' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
+
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
     })
 
     afterEach('LogOut', () => {
 
-        Utilities.deleteLibrary(newCQLLibraryName)
+        Utilities.deleteLibrary()
     })
 
     it('Verify CQL Library can be edited by the shared user', () => {
@@ -84,23 +82,22 @@ describe('CQL Library Sharing - Multiple instances', () => {
 
     beforeEach('Create CQL Library', () => {
 
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        newCQLLibraryName = CQLLibraryName + randValue + randValue + 5
-
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(newCQLLibraryName, CQLLibraryPublisher)
-
+        CQLLibraryName = 'LibrarySharing' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
-        OktaLogin.Login()
-        cy.get(Header.cqlLibraryTab).click()
+
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
     })
 
     afterEach('LogOut', () => {
 
-        Utilities.deleteLibrary(randomCQLLibraryName)
+        Utilities.deleteLibrary()
     })
 
     it('Verify all instances in the Library set (Version and Draft) are Shared to the new owner', () => {
         const currentUser = Cypress.env('selectedUser')
+
+        OktaLogin.Login()
+        cy.get(Header.cqlLibraryTab).click()
 
         //Version the CQL Library
         CQLLibrariesPage.cqlLibraryActionCenter("version")
@@ -142,7 +139,6 @@ describe('CQL Library Sharing - Multiple instances', () => {
         cy.log('Draft Created Successfully')
         //Share Library with ALT User
 
-        OktaLogin.setupUserSession(false)
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
 
         //Login as ALT User
@@ -156,7 +152,11 @@ describe('CQL Library Sharing - Multiple instances', () => {
         CQLLibrariesPage.validateCQLLibraryName(randomCQLLibraryName) //fail here 
         //Click on Expand button to view Versioned Library
         cy.get('[data-testid="cqlLibrary-button-0_expandArrow"]').click()
-        cy.get('[data-testid="table-body"]').should('contain', newCQLLibraryName)
+        cy.get('[data-testid="table-body"]').should('contain', CQLLibraryName)
+
+        // return to list so library unlocks
+        cy.get(Header.cqlLibraryTab).click()
+        Utilities.waitForElementVisible(CQLLibraryPage.libraryListTitles, 15000)
     })
 })
 
@@ -164,10 +164,10 @@ describe('Remove user\'s share access from a library', () => {
 
     beforeEach('Create library and Set Access Token', () => {
 
-        OktaLogin.setupUserSession(false)
+        CQLLibraryName = 'LibrarySharing' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
-        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
 
         // initial share to harpUserAlt
         Utilities.setSharePermissions(MadieObject.Library, PermissionActions.GRANT, harpUserALT)
@@ -175,7 +175,7 @@ describe('Remove user\'s share access from a library', () => {
 
     afterEach('Log out and Clean up', () => {
 
-        Utilities.deleteLibrary(newCQLLibraryName)
+        Utilities.deleteLibrary()
     })
 
     it('After removing access, user can no longer edit the library', () => {
@@ -211,19 +211,15 @@ describe('Share CQL Library using Action Center buttons', () => {
 
     beforeEach('Create CQL Library', () => {
 
-        OktaLogin.setupUserSession(false)
+        CQLLibraryName = 'LibrarySharing' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        newCQLLibraryName = CQLLibraryName + randValue + randValue + 1
-        updatedCQLLibraryName = CQLLibraryName + randValue + 5
-
-        CQLLibraryPage.createCQLLibraryAPI(newCQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
     })
 
     afterEach('LogOut', () => {
 
-        Utilities.deleteLibrary(newCQLLibraryName)
+        Utilities.deleteLibrary()
     })
 
     it('Verify CQL Library owner can share Library from Action centre share button and shared user is able to edit Library', () => {
@@ -277,7 +273,6 @@ describe('Share CQL Library using Action Center buttons', () => {
         OktaLogin.Login()
 
         //Navigate to CQL Library Page
-        cy.get(Header.cqlLibraryTab).click()
         CQLLibrariesPage.clickEditforCreatedLibrary()
 
         //Share Library with ALT user
@@ -339,20 +334,15 @@ describe('Share CQL Library using Action Center buttons - Multiple instances', (
 
     beforeEach('Create CQL Library', () => {
 
-        OktaLogin.setupUserSession(false)
+        CQLLibraryName = 'LibrarySharing' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
-        newCQLLibraryName = CQLLibraryName + randValue + randValue + 1
-        updatedCQLLibraryName = CQLLibraryName + randValue + 5
-
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(newCQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
     })
 
     afterEach('LogOut', () => {
 
-        OktaLogin.setupUserSession(false)
-        Utilities.deleteLibrary(updatedCQLLibraryName, false)
+        Utilities.deleteLibrary()
     })
 
     it('Verify all instances of the CQL Library (Version and Draft) are shared to the user', () => {
@@ -373,7 +363,7 @@ describe('Share CQL Library using Action Center buttons - Multiple instances', (
         cy.get(CQLLibrariesPage.createVersionContinueButton).should('be.visible')
         cy.get(CQLLibrariesPage.createVersionContinueButton).click()
         cy.get(CQLLibrariesPage.VersionDraftMsgs).should('contain.text', 'New version of CQL Library is Successfully created')
-        CQLLibrariesPage.validateVersionNumber(newCQLLibraryName, versionNumber)
+        CQLLibrariesPage.validateVersionNumber(CQLLibraryName, versionNumber)
         cy.log('Version Created Successfully')
 
         //Add Draft to Versioned Library
@@ -429,6 +419,6 @@ describe('Share CQL Library using Action Center buttons - Multiple instances', (
         cy.get('[data-testid="cqlLibrary-button-0_cqlLibraryName"]').should('contain.text', updatedCQLLibraryName)
         //Click on Expand button to view Versioned Library
         cy.get('[data-testid="cqlLibrary-button-0_expandArrow"]').click()
-        cy.get('[data-testid="table-body"]').should('contain.text', newCQLLibraryName)
+        cy.get('[data-testid="table-body"]').should('contain.text', CQLLibraryName)
     })
 })

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibraryUnsharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibraryUnsharing.cy.ts
@@ -4,11 +4,13 @@ import { Header } from "../../../../Shared/Header"
 import { OktaLogin } from "../../../../Shared/OktaLogin"
 import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
-let CQLLibraryName = ''
-let CQLLibraryPublisher = 'SemanticBits'
 let harpUserALT = ''
+let CQLLibraryName = ''
 let updatedCQLLibraryName = ''
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('Unshare CQL Library using Action Center buttons', () => {
 
@@ -18,7 +20,7 @@ describe('Unshare CQL Library using Action Center buttons', () => {
         OktaLogin.setupUserSession(false)
         harpUserALT = OktaLogin.getUser(true)
 
-        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
     })
 
     it('Verify CQL Library owner can unshare Library from Libraries page Action centre share button', () => {
@@ -161,7 +163,7 @@ describe('Unshare CQL Library using Action Center buttons - Multiple instances',
         OktaLogin.setupUserSession(false)
         harpUserALT = OktaLogin.getUser(true)
 
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
     })
 
     it('Verify all instances of the CQL Library (Version and Draft) are unshared from the user', () => {

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/CQLLibraryTransfer.cy.ts
@@ -4,11 +4,13 @@ import { CQLLibraryPage, EditLibraryActions } from "../../../../Shared/CQLLibrar
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
 let CQLLibraryName = ''
 let harpUserALT = ''
-const CQLLibraryPublisher = 'SemanticBits'
 const versionNumber = '1.0.000'
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('CQL Library Transfer', () => {
 
@@ -16,7 +18,7 @@ describe('CQL Library Transfer', () => {
 
         CQLLibraryName = 'TransferLibrary' + Date.now()
 
-        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
 
         harpUserALT = OktaLogin.getUser(true)
     })
@@ -95,8 +97,8 @@ describe('CQL Library Transfer - Action Centre buttons', () => {
 
         CQLLibraryName = 'ACTransferLibrary' + Date.now()
 
-        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
-        OktaLogin.setupUserSession(false)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
+
         harpUserALT = OktaLogin.getUser(true)
     })
 
@@ -258,7 +260,7 @@ describe('CQL Library Transfer - Multiple instances', () => {
 
         CQLLibraryName = 'TransferMultipleLibraries' + Date.now()
 
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
 
         OktaLogin.Login()
         cy.get(Header.cqlLibraryTab).click()

--- a/cypress/e2e/WebInterface/CQL Library/CQLLibraryHistory/LibraryHistory.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQLLibraryHistory/LibraryHistory.cy.ts
@@ -3,12 +3,14 @@ import { Utilities } from "../../../../Shared/Utilities"
 import { CQLLibraryPage, EditLibraryActions } from "../../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { Header } from "../../../../Shared/Header"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
 let CQLLibraryName = ''
-let CQLLibraryPublisher = 'SemanticBits'
 let harpUserALT = ''
 let harpUser = ''
 let updatedCQLLibraryName = ''
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('Library History - Create, Update, Sharing and Unsharing Actions', () => {
 
@@ -19,7 +21,7 @@ describe('Library History - Create, Update, Sharing and Unsharing Actions', () =
         harpUser = OktaLogin.getUser(false)
         harpUserALT = OktaLogin.getUser(true)
 
-        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
         OktaLogin.Login()
     })
 
@@ -102,7 +104,7 @@ describe('Library History - Version and Draft actions', () => {
 
         updatedCQLLibraryName = CQLLibraryName + 'Updated'
 
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
         OktaLogin.Login()
     })
 
@@ -155,7 +157,7 @@ describe('Library History - Transfer action', () => {
 
         updatedCQLLibraryName = CQLLibraryName + 'Updated'
 
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CQLLibraryName, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
     })
 
     it('Verify that Transfer Library action is recorded in Library History', () => {

--- a/cypress/e2e/WebInterface/CQL Library/CompareLibraryVersions/CompareLibraryVersions.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CompareLibraryVersions/CompareLibraryVersions.cy.ts
@@ -4,22 +4,25 @@ import { Header } from "../../../../Shared/Header"
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { Utilities } from "../../../../Shared/Utilities"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
 let CqlLibraryOne: string
-const CQLLibraryPublisher = 'SemanticBits'
 const versionNumber = '1.0.000'
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('CompareLibraryVersions', () => {
 
     beforeEach('Create CQL Library and Login', () => {
 
         CqlLibraryOne = 'CompareLibraryVersion' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
         CQLLibraryPage.versionLibraryAPI(versionNumber)
     })
+    
     afterEach('Logout and Clean up CQL Libraries', () => {
 
-        OktaLogin.UILogout()
+        //manually captured cqlLibrary2 as part of the test
         Utilities.deleteLibrary(CqlLibraryOne, false, 2)
     })
 

--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddDraftToVersionedCQLLibrary.cy.ts
@@ -5,18 +5,19 @@ import { Header } from "../../../../Shared/Header"
 import { Utilities } from "../../../../Shared/Utilities"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
 let CqlLibraryOne: string
-const CQLLibraryPublisher = 'SemanticBits'
 const versionNumber = '1.0.000'
-
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('Action Center Buttons - Add Draft to CQL Library', () => {
 
     beforeEach('Create CQL Library and Login', () => {
 
         CqlLibraryOne = 'DraftingLibrary' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
         CQLLibraryPage.versionLibraryAPI(versionNumber)
     })
 

--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddVersionToCQLLibrary.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/AddVersionToCQLLibrary.cy.ts
@@ -4,17 +4,19 @@ import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { Header } from "../../../../Shared/Header"
 import { Utilities } from "../../../../Shared/Utilities"
 import { MeasuresPage } from "../../../../Shared/MeasuresPage"
+import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
+import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
 let CqlLibraryOne: string
-let CQLLibraryPublisher = 'SemanticBits'
-let versionNumber = '1.0.000'
+const versionNumber = '1.0.000'
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('Action Center Buttons - Add Version to CQL Library', () => {
 
     beforeEach('Create CQL Library and Login', () => {
 
         CqlLibraryOne = 'AddLibraryVersion' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
         OktaLogin.Login()
     })
 

--- a/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/DraftAndVersionValidations.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/VersionAndDraft/DraftAndVersionValidations.cy.ts
@@ -3,34 +3,33 @@ import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
 import { CQLLibrariesPage } from "../../../../Shared/CQLLibrariesPage"
 import { Header } from "../../../../Shared/Header"
 import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage";
 import { SupportedModels } from "../../../../Shared/CreateMeasurePage"
 import { LibraryCQL } from "../../../../Shared/LibraryCQL"
 
 let CqlLibraryOne = ''
 let CqlLibraryOther = ''
 let updatedCqlLibraryName = ''
-let CQLLibraryPublisher = 'SemanticBits'
+const versionNumber = '1.0.000'
 const invalidLibraryCql = LibraryCQL.invalidFhir4Lib
+const validCql = LibraryCQL.validCQL4QICORELib
 
 describe('Action Center Buttons - Draft and Version Validations', () => {
 
     before('Create CQL Library for duplicate name test', () => {
         //create a single use CQL Library with invalid CQL (used for duplicate-name draft test)
         CqlLibraryOther = 'Another' + Date.now()
-        CQLLibraryPage.createLibraryAPI(CqlLibraryOther, SupportedModels.qiCore4, { publisher: CQLLibraryPublisher, cql: invalidLibraryCql, cqlErrors: true})
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOther, SupportedModels.qiCore4, { cql: invalidLibraryCql, cqlErrors: true })
     })
 
     beforeEach('Create CQL Library and Login', () => {
         //create a fresh CQL Library with valid CQL for versioning
         CqlLibraryOne = 'VersionLib' + Date.now()
-        CQLLibraryPage.createAPICQLLibraryWithValidCQL(CqlLibraryOne, CQLLibraryPublisher)
+        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
         OktaLogin.SessionLogin()
     })
 
     it('User cannot create a draft of a draft that already exists, while the version is still open', () => {
 
-        let versionNumber = '1.0.000'
         updatedCqlLibraryName = 'UpdatedCQLLibraryOne' + Date.now()
 
         cy.get(Header.cqlLibraryTab).click()
@@ -56,7 +55,6 @@ describe('Action Center Buttons - Draft and Version Validations', () => {
 
     it('Verify the CQL Library updates are restricted after Version is created', () => {
 
-        let versionNumber = '1.0.000'
         updatedCqlLibraryName = 'UpdatedCQLLibraryOne' + Date.now()
 
         cy.get(Header.cqlLibraryTab).click()
@@ -72,8 +70,6 @@ describe('Action Center Buttons - Draft and Version Validations', () => {
     })
 
     it('Draft cannot be saved with a name that exists for a different library', () => {
-
-        let versionNumber = '1.0.000'
 
         cy.get(Header.cqlLibraryTab).click()
         CQLLibrariesPage.cqlLibraryActionCenter('version')
@@ -103,7 +99,7 @@ describe('Action Center Buttons - Draft and Version Validations', () => {
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.visible')
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).should('be.enabled')
         cy.get(CQLLibraryPage.updateCQLLibraryBtn).click()
-        CQLEditorPage.validateSuccessfulCQLUpdate(true)
+        Utilities.waitForElementDisabled(CQLLibraryPage.updateCQLLibraryBtn, 15000)
 
         cy.get(Header.cqlLibraryTab).click()
         CQLLibrariesPage.cqlLibraryActionCenter('version')


### PR DESCRIPTION
Main goal: eliminate all use of createAPICQLLibraryWithValidCQL() from tests.
Replace it with a configured version of createLibraryAPI().

We do not need dedicated functions with hardcoded values like createAPICQLLibraryWithValidCQL() when we can achieve the same state within Madie using a general function like createLibraryAPI() and adding the correct config for each test.

Other minor changes:
Condensed whitespace, removed unneeded comments or old values saved as comments, formatting, removed randomization strategy in some tests & replaced with dynamic timestamps.