### PR TITLE
fix: keep TS happy, make follow up changes

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -73,17 +73,16 @@ export class CreateMeasurePage {
         //saving measureID to file to use later
         cy.wait('@' + alias).then(({ response }) => {
             const currentUser = Cypress.env('selectedUser')
-            expect(response.statusCode).to.eq(201)
-            cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-            cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-            cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
+            expect(response?.statusCode).to.eq(201)
+            cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+            cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
+            cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
         })
     }
 
     public static clickCreateDraftButton(): void {
         const currentUser = Cypress.env('selectedUser')
         cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureID) => {
-
 
             let alias = 'draft' + (Date.now() + 1).toString()
             //setup for grabbing the measure create call
@@ -94,25 +93,29 @@ export class CreateMeasurePage {
             //saving measureID to file to use later
             cy.wait('@' + alias).then(({ response }) => {
                 const currentUser = Cypress.env('selectedUser')
-                expect(response.statusCode).to.eq(201)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
+                expect(response?.statusCode).to.eq(201)
+                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
             })
         })
-
     }
 
     public static CreateMeasure(measureName: string, CqlLibraryName: string, model: SupportedModels, mpStartDate?: string, mpEndDate?: string): void {
 
         const now = require('dayjs')
+        let startDate = '', endDate = ''
 
-        if (mpStartDate === undefined) {
-            mpStartDate = now().subtract('1', 'year').format('MM/DD/YYYY')
+        if (!mpStartDate) {
+            startDate = now().subtract('1', 'year').format('MM/DD/YYYY')
+        }else {
+            startDate = mpStartDate
         }
 
-        if (mpEndDate === undefined) {
-            mpEndDate = now().format('MM/DD/YYYY')
+        if (!mpEndDate) {
+            endDate = now().format('MM/DD/YYYY')
+        } else {
+            endDate = mpEndDate
         }
-        Utilities.waitForElementVisible(LandingPage.newMeasureButton, 30000)
+
         Utilities.waitForElementEnabled(LandingPage.newMeasureButton, 30000)
         cy.get(LandingPage.newMeasureButton).wait(2000).click()
         cy.get(this.measureNameTextbox).type(measureName)
@@ -121,8 +124,8 @@ export class CreateMeasurePage {
         cy.get(this.eCQMAbbreviatedTitleTextbox).type('eCQMTitle01')
         cy.get(this.cqlLibraryNameTextbox).type(CqlLibraryName)
 
-        cy.get(CreateMeasurePage.measurementPeriodStartDate).type(mpStartDate)
-        cy.get(CreateMeasurePage.measurementPeriodEndDate).type(mpEndDate)
+        cy.get(CreateMeasurePage.measurementPeriodStartDate).type(startDate)
+        cy.get(CreateMeasurePage.measurementPeriodEndDate).type(endDate)
 
         this.clickCreateMeasureButton()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
@@ -135,15 +138,20 @@ export class CreateMeasurePage {
     public static CreateCompositeMeasure(measureName: string, CqlLibraryName: string, model: SupportedCompositeModels, mpStartDate?: string, mpEndDate?: string): void {
 
         const now = require('dayjs')
+        let startDate = '', endDate = ''
 
-        if (mpStartDate === undefined) {
-            mpStartDate = now().subtract('1', 'year').format('MM/DD/YYYY')
+        if (!mpStartDate) {
+            startDate = now().subtract('1', 'year').format('MM/DD/YYYY')
+        }else {
+            startDate = mpStartDate
         }
 
-        if (mpEndDate === undefined) {
-            mpEndDate = now().format('MM/DD/YYYY')
+        if (!mpEndDate) {
+            endDate = now().format('MM/DD/YYYY')
+        } else {
+            endDate = mpEndDate
         }
-        Utilities.waitForElementVisible(LandingPage.newMeasureButton, 30000)
+
         Utilities.waitForElementEnabled(LandingPage.newMeasureButton, 30000)
         cy.get(LandingPage.newMeasureButton).wait(2000).click()
         cy.get(this.measureNameTextbox).type(measureName)
@@ -153,8 +161,8 @@ export class CreateMeasurePage {
         cy.get(this.eCQMAbbreviatedTitleTextbox).type('eCQMTitle01')
         cy.get(this.cqlLibraryNameTextbox).type(CqlLibraryName)
 
-        cy.get(CreateMeasurePage.measurementPeriodStartDate).type(mpStartDate)
-        cy.get(CreateMeasurePage.measurementPeriodEndDate).type(mpEndDate)
+        cy.get(CreateMeasurePage.measurementPeriodStartDate).type(startDate)
+        cy.get(CreateMeasurePage.measurementPeriodEndDate).type(endDate)
 
         this.clickCreateMeasureButton()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
@@ -165,7 +173,7 @@ export class CreateMeasurePage {
     }
 
     public static CreateQICoreMeasureAPI(measureName: string, CqlLibraryName: string, measureCQL?: string,
-        measureNumber?: number, altUser?: boolean, mpStartDate?: string, mpEndDate?: string, compositeValue?: boolean /*CreateMeasureOptions?: CreateMeasureOptions*/): string {
+        measureNumber?: number, altUser?: boolean, mpStartDate?: string, mpEndDate?: string, compositeValue?: boolean): string {
 
         const now = require('dayjs')
         let user = ''
@@ -202,7 +210,7 @@ export class CreateMeasurePage {
                 failOnStatusCode: false,
                 url: '/api/measure?addDefaultCQL=false',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 },
                 method: 'POST',
                 body: {
@@ -211,11 +219,11 @@ export class CreateMeasurePage {
                     'model': 'QI-Core v4.1.1',
                     'createdBy': user,
                     "ecqmTitle": ecqmTitle,
-                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z"/* || CreateMeasureOptions.mpStartDate + "T00:00:00.000Z"*/,
-                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z" /*|| CreateMeasureOptions.mpEndDate + "T00:00:00.000Z"*/,
+                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
+                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
                     'versionId': uuidv4(),
                     'measureSetId': uuidv4(),
-                    'cql': measureCQL /*|| CreateMeasureOptions.measureCql*/,
+                    'cql': measureCQL,
                     'elmJson': elmJson,
                     "testCaseConfiguration": {
                         "id": null,
@@ -275,8 +283,8 @@ export class CreateMeasurePage {
                 }
             }).then((response) => {
 
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
+                expect(response?.status).to.eql(201)
+                expect(response?.body.id).to.be.exist
 
                 let currentUser = ''
                 if (altUser) {
@@ -287,29 +295,24 @@ export class CreateMeasurePage {
                 }
 
                 if (measureNumber > 0) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response.body.versionId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response.body.measureSetId)
-                    cy.log(currentUser + ' MeasureSetId is ' + response.body.measureSetId)
-
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response?.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response?.body.measureSetId)
+                    cy.log(currentUser + ' MeasureSetId is ' + response?.body.measureSetId)
                 }
                 else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    cy.log(currentUser + ' MeasureSetId is ' + response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                    cy.log(currentUser + ' MeasureSetId is ' + response?.body.measureSetId)
                 }
-
             })
         })
         return user
     }
 
     public static CreateQICoreMeasureAPIWithSimpleDesc(measureName: string, CqlLibraryName: string, measureCQL?: string,
-        measureNumber?: number, altUser?: boolean, mpStartDate?: string, mpEndDate?: string, /*CreateMeasureOptions?: CreateMeasureOptions*/): string {
-
-        const currentUser = Cypress.env('selectedUser')
-        const currentAltUser = Cypress.env('selectedAltUser')
+        measureNumber?: number, altUser?: boolean, mpStartDate?: string, mpEndDate?: string): string {
 
         let user = ''
         const now = require('dayjs')
@@ -341,7 +344,7 @@ export class CreateMeasurePage {
                 failOnStatusCode: false,
                 url: '/api/measure?addDefaultCQL=false',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 },
                 method: 'POST',
                 body: {
@@ -350,11 +353,11 @@ export class CreateMeasurePage {
                     'model': 'QI-Core v4.1.1',
                     'createdBy': user,
                     "ecqmTitle": ecqmTitle,
-                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z"/* || CreateMeasureOptions.mpStartDate + "T00:00:00.000Z"*/,
-                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z" /*|| CreateMeasureOptions.mpEndDate + "T00:00:00.000Z"*/,
+                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
+                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
                     'versionId': uuidv4(),
                     'measureSetId': uuidv4(),
-                    'cql': measureCQL /*|| CreateMeasureOptions.measureCql*/,
+                    'cql': measureCQL,
                     'elmJson': elmJson,
                     "testCaseConfiguration": {
                         "id": null,
@@ -413,8 +416,8 @@ export class CreateMeasurePage {
                 }
             }).then((response) => {
 
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
+                expect(response?.status).to.eql(201)
+                expect(response?.body.id).to.be.exist
 
                 let currentUser = ''
                 if (altUser) {
@@ -425,26 +428,25 @@ export class CreateMeasurePage {
                 }
 
                 if (measureNumber > 0) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response.body.versionId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response.body.measureSetId)
-                    cy.log('MeasureSetId is ' + response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response?.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response?.body.measureSetId)
+                    cy.log('MeasureSetId is ' + response?.body.measureSetId)
 
                 }
                 else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    cy.log('MeasureSetId is ' + response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                    cy.log('MeasureSetId is ' + response?.body.measureSetId)
                 }
-
             })
         })
         return user
     }
 
     public static CreateQICoreMeasureAPIWithNoMeasureDesc(measureName: string, CqlLibraryName: string, measureCQL?: string,
-        measureNumber?: number, altUser?: boolean, mpStartDate?: string, mpEndDate?: string, /*CreateMeasureOptions?: CreateMeasureOptions*/): string {
+        measureNumber?: number, altUser?: boolean, mpStartDate?: string, mpEndDate?: string): string {
 
         let user = ''
         const now = require('dayjs')
@@ -476,7 +478,7 @@ export class CreateMeasurePage {
                 failOnStatusCode: false,
                 url: '/api/measure?addDefaultCQL=false',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 },
                 method: 'POST',
                 body: {
@@ -485,11 +487,11 @@ export class CreateMeasurePage {
                     'model': 'QI-Core v4.1.1',
                     'createdBy': user,
                     "ecqmTitle": ecqmTitle,
-                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z"/* || CreateMeasureOptions.mpStartDate + "T00:00:00.000Z"*/,
-                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z" /*|| CreateMeasureOptions.mpEndDate + "T00:00:00.000Z"*/,
+                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
+                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
                     'versionId': uuidv4(),
                     'measureSetId': uuidv4(),
-                    'cql': measureCQL /*|| CreateMeasureOptions.measureCql*/,
+                    'cql': measureCQL,
                     'elmJson': elmJson,
                     "testCaseConfiguration": {
                         "id": null,
@@ -497,7 +499,6 @@ export class CreateMeasurePage {
                     },
                     'measureMetaData': {
                         "guidance": "<p>this is a meta guidance (usage) value -- for the 'Clinical Usage' field</p>",
-                        //"description": "<p>Description</p><table class=\"rich-text-table\" style=\"min-width: 75px\"><colgroup><col style=\"min-width: 25px\"><col style=\"min-width: 25px\"><col style=\"min-width: 25px\"></colgroup><tbody><tr><th colspan=\"1\" rowspan=\"1\"><p>TEST1</p></th><th colspan=\"1\" rowspan=\"1\"><p>TEST2</p></th><th colspan=\"1\" rowspan=\"1\"><p>TEST3</p></th></tr><tr><td colspan=\"1\" rowspan=\"1\"><p></p></td><td colspan=\"1\" rowspan=\"1\"><p></p></td><td colspan=\"1\" rowspan=\"1\"><ol><li><p>line1</p></li><li><p>line2</p></li><li><p>line3</p></li></ol></td></tr><tr><td colspan=\"1\" rowspan=\"1\"><p>TESTING</p></td><td colspan=\"1\" rowspan=\"1\"><p></p></td><td colspan=\"1\" rowspan=\"1\"><p></p></td></tr></tbody></table><p><strong><em><u>This is another test</u></em></strong></p>",
                         "purpose": "<p>this is a meta purpose value</p>",
                         "measureDefinitions": [
                             {
@@ -548,8 +549,8 @@ export class CreateMeasurePage {
                 }
             }).then((response) => {
 
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
+                expect(response?.status).to.eql(201)
+                expect(response?.body.id).to.be.exist
 
                 let currentUser = ''
                 if (altUser) {
@@ -560,19 +561,18 @@ export class CreateMeasurePage {
                 }
 
                 if (measureNumber > 0) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response.body.versionId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response.body.measureSetId)
-                    cy.log('MeasureSetId is ' + response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response?.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response?.body.measureSetId)
+                    cy.log('MeasureSetId is ' + response?.body.measureSetId)
 
                 }
                 else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    cy.log('MeasureSetId is ' + response.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                    cy.log('MeasureSetId is ' + response?.body.measureSetId)
                 }
-
             })
         })
         return user
@@ -613,7 +613,7 @@ export class CreateMeasurePage {
             cy.request({
                 url: '/api/measure?addDefaultCQL=false',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 },
                 method: 'POST',
                 body: {
@@ -658,8 +658,8 @@ export class CreateMeasurePage {
                 }
             }).then((response) => {
 
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
+                expect(response?.status).to.eql(201)
+                expect(response?.body.id).to.be.exist
 
                 let currentUser = ''
                 if (altUser) {
@@ -670,21 +670,20 @@ export class CreateMeasurePage {
                 }
 
                 if (((twoMeasures === false) || (twoMeasures === undefined) || (twoMeasures === null)) && (measureNumber > 0)) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response?.body.versionId)
                 }
                 else if (((twoMeasures === false) || (twoMeasures === undefined) || (twoMeasures === null)) && (measureNumber === 0)) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
                 }
                 else if ((twoMeasures === true) && (measureNumber === 0)) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId2', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId2', response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId2', response.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId2', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId2', response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId2', response?.body.versionId)
                 }
-
             })
         })
         cy.log(user)
@@ -692,8 +691,6 @@ export class CreateMeasurePage {
     }
 
     public static CreateQDMMeasureWithBaseConfigurationFieldsAPI(CreateMeasureOptions: CreateMeasureOptions): string {
-
-        const currentUser = Cypress.env('selectedUser')
 
         let user = ''
         let altUser = false
@@ -728,7 +725,7 @@ export class CreateMeasurePage {
                 failOnStatusCode: false,
                 url: '/api/measure?addDefaultCQL=false',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 },
                 method: 'POST',
                 body: {
@@ -772,8 +769,8 @@ export class CreateMeasurePage {
                 }
             }).then((response) => {
 
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
+                expect(response?.status).to.eql(201)
+                expect(response?.body.id).to.be.exist
 
                 let currentUser = ''
                 if (CreateMeasureOptions.altUser) {
@@ -783,16 +780,16 @@ export class CreateMeasurePage {
                     currentUser = Cypress.env('selectedUser')
                 }
 
-                if (CreateMeasureOptions.measureNumber > 0) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + CreateMeasureOptions.measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + CreateMeasureOptions.measureNumber, response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + CreateMeasureOptions.measureNumber, response.body.versionId)
+                if (CreateMeasureOptions.measureNumber! > 0) {
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + CreateMeasureOptions.measureNumber, response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + CreateMeasureOptions.measureNumber, response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + CreateMeasureOptions.measureNumber, response?.body.versionId)
 
                 }
                 else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
                 }
 
             })
@@ -892,7 +889,7 @@ export class CreateMeasurePage {
             cy.request({
                 url: '/api/measure?addDefaultCQL=false',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 },
                 method: 'POST',
                 body: {
@@ -922,8 +919,8 @@ export class CreateMeasurePage {
                 }
             }).then((response) => {
 
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
+                expect(response?.status).to.eql(201)
+                expect(response?.body.id).to.be.exist
 
                 if (altUser) {
                     currentUser = Cypress.env('selectedAltUser')
@@ -933,14 +930,14 @@ export class CreateMeasurePage {
                 }
 
                 if (measureNumber > 0) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response?.body.versionId)
                 }
                 else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                    cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
                 }
             })
         })
@@ -949,7 +946,7 @@ export class CreateMeasurePage {
     }
 
     public static CloneMeasureAPI(existingId: string, newName: string, newLibrraryName: string, overrideOptions?: CreateMeasureOptions) {
-        let measureNumber, useAltUser = false
+        let measureNumber: number, useAltUser = false
 
         if (overrideOptions && overrideOptions.altUser) {
             useAltUser = true
@@ -968,10 +965,10 @@ export class CreateMeasurePage {
                 url: '/api/measures/' + existingId,
                 method: 'GET',
                 headers: {
-                    authorization: 'Bearer ' + accessToken.value
+                    authorization: 'Bearer ' + accessToken?.value
                 }
             }).then((response) => {
-                const clonedMeasure = response.body as Measure
+                const clonedMeasure = response?.body as Measure
 
                 // clear out data required to be fresh
                 clonedMeasure.measureName = newName
@@ -992,24 +989,24 @@ export class CreateMeasurePage {
                 cy.request({
                     url: '/api/measure?addDefaultCQL=false',
                     headers: {
-                        authorization: 'Bearer ' + accessToken.value
+                        authorization: 'Bearer ' + accessToken?.value
                     },
                     method: 'POST',
                     body: clonedMeasure
                 }).then((response) => {
                     let currentUser = Cypress.env('selectedUser')
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
+                    expect(response?.status).to.eql(201)
+                    expect(response?.body.id).to.be.exist
 
                     if (measureNumber > 0) {
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response.body.id)
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response.body.measureSetId)
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response.body.versionId)
+                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId' + measureNumber, response?.body.id)
+                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId' + measureNumber, response?.body.measureSetId)
+                        cy.writeFile('cypress/fixtures/' + currentUser + '/versionId' + measureNumber, response?.body.versionId)
                     }
                     else {
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
+                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response?.body.id)
+                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response?.body.measureSetId)
+                        cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response?.body.versionId)
                     }
                 })
             })

--- a/cypress/Shared/OktaLogin.ts
+++ b/cypress/Shared/OktaLogin.ts
@@ -1,16 +1,13 @@
 import { Environment } from "./Environment"
 import { LandingPage } from "./LandingPage"
 import { umlsLoginForm } from "./umlsLoginForm"
-import { Utilities } from "./Utilities"
 import { Header } from "./Header"
 
-//MADiE OKTA Login Class
 export class OktaLogin {
 
-    //Commented locators are for the new Okta Login page
-    public static readonly usernameInput = '[id="input28"]' //'#okta-signin-username'
-    public static readonly passwordInput = '[id="input36"]' //'#okta-signin-password'
-    public static readonly signInButton = '[class="button button-primary"]' //'#okta-signin-submit'
+    public static readonly usernameInput = '[id="input28"]'
+    public static readonly passwordInput = '[id="input36"]'
+    public static readonly signInButton = '[class="button button-primary"]'
 
     public static readonly needHelpButton = 'a[data-se="needhelp"]'
     public static readonly forgotPassword = '[data-se="forgot-password"]'

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateNewMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateNewMeasure.cy.ts
@@ -1,9 +1,8 @@
 import { OktaLogin } from "../../../Shared/OktaLogin"
-import {CreateMeasurePage, SupportedModels} from "../../../Shared/CreateMeasurePage"
+import { CreateMeasurePage, SupportedModels } from "../../../Shared/CreateMeasurePage"
 import { MeasuresPage } from "../../../Shared/MeasuresPage"
 import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
 import { Utilities } from "../../../Shared/Utilities"
-import { Header } from "../../../Shared/Header"
 
 let measureName = ''
 let CqlLibraryName = ''
@@ -18,24 +17,7 @@ describe('Create New Measure', () => {
 
     afterEach('Cleanup and Logout', () => {
 
-        Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 5000)
-        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
-        Utilities.waitForElementVisible(EditMeasurePage.editMeasureDeleteActionBtn, 5000)
-        cy.get(EditMeasurePage.editMeasureDeleteActionBtn).click()
-        Utilities.waitForElementVisible(EditMeasurePage.deleteMeasureConfirmationButton, 5000)
-        cy.get(EditMeasurePage.deleteMeasureConfirmationButton).click()
-        Utilities.waitForElementVisible(EditMeasurePage.successMessage, 5000)
-        cy.get(EditMeasurePage.successMessage).should('contain.text', "Measure successfully deleted")
-
-        //Verify the deleted measure on My Measures page list
-        cy.get(Header.measures).click()
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
-        cy.get(MeasuresPage.measureListTitles).should('not.contain', measureName)
-
-        //Navigate to All Measures tab
-        cy.get(MeasuresPage.allMeasuresTab).click()
-        //Verify the deleted measure on All Measures page list
-        cy.get(MeasuresPage.measureListTitles).should('not.contain', measureName)
+        Utilities.deleteMeasure()
     })
 
     it('Create QI Core 4.1.1 Measure', () => {
@@ -44,7 +26,6 @@ describe('Create New Measure', () => {
         CqlLibraryName = 'QICore4TestLibrary' + Date.now()
 
         CreateMeasurePage.CreateMeasure(measureName, CqlLibraryName, SupportedModels.qiCore4)
-        cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit')
 
@@ -61,7 +42,6 @@ describe('Create New Measure', () => {
         CqlLibraryName = 'QDMTestLibrary' + Date.now()
 
         CreateMeasurePage.CreateMeasure(measureName, CqlLibraryName, SupportedModels.QDM)
-        cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit')
 
@@ -78,8 +58,6 @@ describe('Create New Measure', () => {
         CqlLibraryName = 'QICore6TestLibrary' + Date.now()
 
         CreateMeasurePage.CreateMeasure(measureName, CqlLibraryName, SupportedModels.qiCore6)
-
-        cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit')
 


### PR DESCRIPTION
General cleanup of comments & TS compiler issues for CreateMeasurePage and OktaLogin.
As much as is easily possible.

Follow up changes made to CreateNewMeasure tests afterwards.