### PR TITLE
fix: correct moveToEnd, other minor process points

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -203,11 +203,13 @@ export class MeasuresPage {
                 cy.get('[data-testid="export-action-btn"]').click()
 
                 if (exportForPublish) {
-                    Utilities.waitForElementVisible(MeasuresPage.exportPublishingOption, 60000)
-                    cy.get(MeasuresPage.exportPublishingOption).should('contain.text', 'Export for Publishing').click()
+                    Utilities.waitForElementVisible(MeasuresPage.exportPublishingOption, 15000)
+                    cy.get(MeasuresPage.exportPublishingOption).should('contain.text', 'Export for Publishing')
+                    cy.get(MeasuresPage.exportPublishingOption).click()
                 } else {
-                    Utilities.waitForElementVisible(MeasuresPage.exportNonPublishingOption, 60000)
-                    cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
+                    Utilities.waitForElementVisible(MeasuresPage.exportNonPublishingOption, 15000)
+                    cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export')
+                    cy.get(MeasuresPage.exportNonPublishingOption).click()
                 }
 
                 cy.get(MeasuresPage.exportingDialog).should('exist').should('be.visible')

--- a/cypress/e2e/Services/Measure Service/MeasureBundle.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureBundle.cy.ts
@@ -989,7 +989,7 @@ describe('Measure bundle end point returns Supplemental data elements and Risk a
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
         cy.get(EditMeasurePage.cqlEditorTextBox).type(measureCQL)
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)

--- a/cypress/e2e/WebInterface/Measure/Comprare Versions/CompareMeasureVersions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Comprare Versions/CompareMeasureVersions.cy.ts
@@ -28,7 +28,7 @@ describe('Compare Measure Versions', () => {
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
@@ -37,7 +37,6 @@ describe('Compare Measure Versions', () => {
 
     afterEach('Log out and Clean up', () => {
 
-        OktaLogin.UILogout()
         Utilities.deleteVersionedMeasure(measureData.ecqmTitle, measureData.cqlLibraryName)
         Utilities.deleteMeasure(undefined, undefined, false, false, 1)
     })

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/AdminMeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/AdminMeasureTransfer.cy.ts
@@ -25,7 +25,7 @@ describe('Measure Transfer performed by Admin user', () => {
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
@@ -34,7 +34,7 @@ describe('Measure Transfer - Measure set transfer & Non-owner checks', () => {
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{end} {enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEncounter600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEncounter600.cy.ts
@@ -38,7 +38,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{end}{enter}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         cy.get(Header.mainMadiePageButton).click()


### PR DESCRIPTION
Removes possibility of random chance failures on these tests.

Updated the incorrect use of {end} to be the correct {moveToEnd} for Cypress typing actions.
Split some commands out to eliminate chance errors from .should().click() - the .should() is intended to be terminal for a command.
