### PR TITLE
fix: change selector for library share

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -77,6 +77,7 @@ export class CQLLibraryPage {
     public static readonly actionCenterVersion = '[data-testid="VersionLibrary"]'
     public static readonly actionCenterDraft = '[data-testid="DraftLibrary"]'
     public static readonly actionCenterShare = '[data-testid="ShareLibrary"]'
+    public static readonly actionCenterSecondaryShare = '[data-testid="Share/Unshare"]' // in case we need both
     public static readonly actionCenterTransfer = '[data-testid="Transfer"]'
     public static readonly actionCenterHistory = '[data-testid="History"]'
 

--- a/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibrarySharing.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQL Library Sharing And Unsharing/CQLLibrarySharing.cy.ts
@@ -19,7 +19,7 @@ describe('CQL Library Sharing', () => {
 
     beforeEach('Create CQL Library', () => {
 
-        CQLLibraryName = 'LibrarySharing' + Date.now()
+        CQLLibraryName = 'LibrarySharing1' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
         CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
@@ -82,7 +82,7 @@ describe('CQL Library Sharing - Multiple instances', () => {
 
     beforeEach('Create CQL Library', () => {
 
-        CQLLibraryName = 'LibrarySharing' + Date.now()
+        CQLLibraryName = 'LibrarySharing2' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
         CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })
@@ -211,7 +211,7 @@ describe('Share CQL Library using Action Center buttons', () => {
 
     beforeEach('Create CQL Library', () => {
 
-        CQLLibraryName = 'LibrarySharing' + Date.now()
+        CQLLibraryName = 'LibrarySharing3' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
         CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4)
@@ -292,6 +292,7 @@ describe('Share CQL Library using Action Center buttons', () => {
 
         //Login as Alt User
         OktaLogin.AltLogin()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 30000)
 
         //Navigate to All Libraries tab
         cy.get(Header.cqlLibraryTab).click().wait(2000)
@@ -334,7 +335,7 @@ describe('Share CQL Library using Action Center buttons - Multiple instances', (
 
     beforeEach('Create CQL Library', () => {
 
-        CQLLibraryName = 'LibrarySharing' + Date.now()
+        CQLLibraryName = 'LibrarySharing4' + Date.now()
         harpUserALT = OktaLogin.getUser(true)
 
         CQLLibraryPage.createLibraryAPI(CQLLibraryName, SupportedModels.qiCore4, { cql: validCql })


### PR DESCRIPTION
Fixes CQLLibrarySharing.cy.ts

Updates a selector to a new value.
I am adding the older selector as actionCenterSecondaryShare because I feel like we might be seeing different values in different scenarios.