### PR TITLE
fix: 3 tests with multiple action center actions

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -160,7 +160,7 @@ export class MeasuresPage {
         if (measureNumber > 0) {
             filePath = 'cypress/fixtures/' + currentUser + '/measureId' + measureNumber
         }
-        cy.log('File path is ' + filePath)
+
         cy.readFile(filePath).should('exist').then((fileContents) => {
             cy.log('File contents is ' + fileContents)
             Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"] > [class="px-1"] > [type="checkbox"]', 60000)
@@ -298,6 +298,8 @@ export class MeasuresPage {
         }
     }
 
+    // in sequences where we have back-to-back actions in the action center, this function is needed to re-check after the 1st action
+    // as of 5/20/26 we seem to be carrying the visual of the 1st check forward, but Madie does not actually register the check as real
     public static selectMeasure(measureNumber?: number): void {
         const currentUser = Cypress.env('selectedUser')
 

--- a/cypress/e2e/Services/Measure Service/ViewHumanReadable.cy.ts
+++ b/cypress/e2e/Services/Measure Service/ViewHumanReadable.cy.ts
@@ -247,7 +247,6 @@ describe('Measure Service: View Human readable for Versioned QDM Measure', () =>
 
 describe('Measure Human Readable comparison', () => {
 
-
     beforeEach('Create Measure and Set Access Token', () => {
 
         OktaLogin.setupUserSession(false)
@@ -260,7 +259,6 @@ describe('Measure Human Readable comparison', () => {
         newMeasureName = 'TestMeasureE' + Date.now() + randVal
         newCQLLibraryName = 'TestCqlE' + Date.now() + randVal
         let firstVersionedMeasureName = 'FirstVersioned' + newMeasureName + Date.now()
-        cy.wait(2000)
         let secondVersionedMeasureName = 'SecondVersioned' + newMeasureName + Date.now()
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCQLLibraryName, measureCQL)
@@ -293,6 +291,7 @@ describe('Measure Human Readable comparison', () => {
         cy.log('Version Created Successfully')
 
         //Add Draft to Versioned Measure
+        MeasuresPage.selectMeasure()
         MeasuresPage.actionCenter('draft', 0, actionOptions)
         cy.intercept('/api/measures/*/draft').as('drafted')
         cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(firstVersionedMeasureName)
@@ -323,6 +322,7 @@ describe('Measure Human Readable comparison', () => {
         cy.log('Version Created Successfully')
 
         //Add Draft to Versioned Measure
+        MeasuresPage.selectMeasure(1)
         MeasuresPage.actionCenter('draft', 1, actionOptions)
         cy.intercept('/api/measures/*/draft').as('drafted')
         cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(secondVersionedMeasureName + "Dif")

--- a/cypress/e2e/WebInterface/Measure/Comprare Versions/CompareMeasureVersions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Comprare Versions/CompareMeasureVersions.cy.ts
@@ -62,6 +62,7 @@ describe('Compare Measure Versions', () => {
         cy.log('Version Created Successfully')
 
         //Add Draft to Versioned Measure
+        MeasuresPage.selectMeasure()
         MeasuresPage.actionCenter('draft')
         cy.intercept('/api/measures/*/draft').as('drafted')
         cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(updatedMeasureName)

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/MeasureTransfer.cy.ts
@@ -55,6 +55,7 @@ describe('Measure Transfer - Measure set transfer & Non-owner checks', () => {
         cy.log('Version Created Successfully')
 
         //Draft the Versioned Measure
+        MeasuresPage.selectMeasure()
         MeasuresPage.actionCenter('draft')
         cy.intercept('/api/measures/*/draft').as('drafted')
         cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(randomMeasureName)


### PR DESCRIPTION
Fixes
ViewHumanReadable.cy.ts
CompareMeasureVersions.cy.ts
MeasureTranfer.cy.ts

These tests (and others coming in future PRs) are contain sequences where there are multiple actions triggered in the action center in a row.
It appears that after the 1st action, the measure retains its check in the UI - but Madie the web app does not recognize these "phantom checks".

To fix these affected tests, we can insert a .selectMeasure() before the 2nd action to ensure that we are actually re-applying the check.