### PR TITLE
fix: remove 1 use of SDE

### DIFF
--- a/cypress/fixtures/MismatchCql/Qicore4MeasureQicore6Lib.txt
+++ b/cypress/fixtures/MismatchCql/Qicore4MeasureQicore6Lib.txt
@@ -5,8 +5,7 @@ using QICore version '4.1.1'
 include CQMCommon version '2.2.000' called CQMCommon
 include FHIRHelpers version '4.4.000' called FHIRHelpers
 include QICoreCommon version '2.1.000' called QICoreCommon
-include SupplementalDataElements version '3.5.000' called SDE
-include SupplementalDataElements version '4.0.000' called Elements
+include SupplementalDataElements version '4.0.000' called SDE
 
 parameter "Measurement Period" Interval<DateTime>
 


### PR DESCRIPTION
In 1 scenario of file MeasureLibraryMismatch.cy.ts this file is used to enter CQL.
We are expecting a specific error to appear, and 2 entries for the SDE library is masking the expected error & causing an error like "Library SupplementalDataElements is used twice" instead.