### PR TITLE
Fix clone payload and Cypress alias typings

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -130,12 +130,13 @@ export class CQLLibraryPage {
     public static clickCreateLibraryButton(): void {
         const currentUser = Cypress.env('selectedUser')
         let alias = 'library' + (Date.now().valueOf() + 1).toString()
+        const libraryAlias: `@${string}` = `@${alias}`
         //setup for grabbing the measure create call
         cy.intercept('POST', '/api/cql-libraries').as(alias)
 
         cy.get(this.saveCQLLibraryBtn).click()
         //saving measureID to file to use later
-        cy.wait('@' + alias).then(({ response }) => {
+        cy.wait(libraryAlias).then(({ response }) => {
             expect(response?.statusCode).to.eq(201)
             cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId', response?.body.id)
         })

--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -976,18 +976,18 @@ export class CreateMeasurePage {
                     authorization: 'Bearer ' + accessToken?.value
                 }
             }).then((response) => {
-                const clonedMeasure = response?.body as Measure
+                const clonedMeasure = response?.body as Partial<Measure>
 
                 // clear out data required to be fresh
                 clonedMeasure.measureName = newName
                 clonedMeasure.cqlLibraryName = newLibrraryName
                 clonedMeasure.measureSetId = uuidv4()
                 clonedMeasure.versionId = uuidv4()
-                clonedMeasure.measureSet = null
-                clonedMeasure.createdAt = null
-                clonedMeasure.createdBy = null
-                clonedMeasure.lastModifiedAt = null
-                clonedMeasure.lastModifiedBy = null
+                delete clonedMeasure.measureSet
+                delete clonedMeasure.createdAt
+                delete clonedMeasure.createdBy
+                delete clonedMeasure.lastModifiedAt
+                delete clonedMeasure.lastModifiedBy
 
                 // example of changing data for new measure
                 if (overrideOptions && overrideOptions.ecqmTitle) {

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -794,7 +794,7 @@ export class TestCasesPage {
     // Try the autocomplete option-click path (uncomment the freeSolo fallback if needed)
     this.commitSeriesViaOptionClick(this.createTestCaseGroupInput, updatedTestCaseSeries, {
       // If options come from API, intercept before typing and pass the alias here:
-      // searchAlias: 'seriesSearch'
+      // searchAlias: '@seriesSearch'
     })
     // Fallback if your field is freeSolo/plain input:
     // this.commitSeriesFreeSolo(this.createTestCaseGroupInput, updatedTestCaseSeries);
@@ -852,7 +852,7 @@ export class TestCasesPage {
     opts: {
       listboxSelector?: string
       optionSelector?: string
-      searchAlias?: string | null
+      searchAlias?: `@${string}` | null
     } = {},
   ) {
     const {


### PR DESCRIPTION
## Summary
- Updated `CreateMeasurePage.CloneMeasureAPI()` to delete server-owned clone fields instead of setting them to `null`.
- Fixed Cypress alias typing in `CQLLibraryPage.clickCreateLibraryButton()`.
- Fixed Cypress alias typing for the optional `searchAlias` in `TestCasesPage`.

## Testing
- Ran `npx tsc --noEmit` successfully.
- Note: command still prints the existing zscaler cert warning, but exits successfully.