### PR TITLE
Add CI failure detail artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,25 +155,13 @@ pipeline {
           '''
         }
 
-        // Initial failures list
+        // Initial failures list and human-readable failure details
         sh '''
           cd ${WORKSPACE}
-          case "${TEST_SCRIPT}" in
-            impl:*)
-              echo "IMPL mode: extracting failures from mochawesome reports..."
-              node -e "const fs=require('fs'),path=require('path');const out=process.argv[1],dir=path.join('cypress','results');if(!fs.existsSync(dir)){fs.writeFileSync(out,'');process.exit(0);}const failed=new Set();fs.readdirSync(dir).filter(f=>f.endsWith('.json')).forEach(f=>{try{const j=JSON.parse(fs.readFileSync(path.join(dir,f),'utf8'));if(j.stats&&j.stats.failures>0){const s=j.results&&j.results[0]&&(j.results[0].fullFile||j.results[0].file);if(s)failed.add(s);}}catch(e){}});const arr=[...failed];fs.writeFileSync(out,arr.length?arr.join(String.fromCharCode(10))+String.fromCharCode(10):'');console.log('Extracted '+arr.length+' failing spec(s)');arr.forEach(s=>console.log('  - '+s));" ${WORKSPACE}/failures-${BUILD_NUMBER}.txt
-              ;;
-            *)
-              if ls ${WORKSPACE}/runner-results/*.json >/dev/null 2>&1; then
-                cat ${WORKSPACE}/runner-results/*.json \
-                  | jq -r 'select(.failures > 0) | .file' \
-                  | sed '/^null$/d' \
-                  > ${WORKSPACE}/failures-${BUILD_NUMBER}.txt
-              else
-                : > ${WORKSPACE}/failures-${BUILD_NUMBER}.txt
-              fi
-              ;;
-          esac
+          node scripts/extract-failure-details.js \
+            ${WORKSPACE}/failures-${BUILD_NUMBER}.txt \
+            ${WORKSPACE}/failure-details-${BUILD_NUMBER}.txt \
+            "Initial run failures"
         '''
 
         // Initial per-run Mochawesome bundle
@@ -193,6 +181,8 @@ pipeline {
         sh '''
           : > ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt
           : > ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
+          printf 'Rerun #1 failures\\n\\nNo rerun performed.\\n' > ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt
+          printf 'Rerun #2 failures\\n\\nNo rerun performed.\\n' > ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt
         '''
       }
     }
@@ -250,22 +240,11 @@ pipeline {
               ;;
           esac
 
-          # Extract failures from rerun #1
-          case "${TEST_SCRIPT}" in
-            impl:*)
-              node -e "const fs=require('fs'),path=require('path');const out=process.argv[1],dir=path.join('cypress','results');if(!fs.existsSync(dir)){fs.writeFileSync(out,'');process.exit(0);}const failed=new Set();fs.readdirSync(dir).filter(f=>f.endsWith('.json')).forEach(f=>{try{const j=JSON.parse(fs.readFileSync(path.join(dir,f),'utf8'));if(j.stats&&j.stats.failures>0){const s=j.results&&j.results[0]&&(j.results[0].fullFile||j.results[0].file);if(s)failed.add(s);}}catch(e){}});const arr=[...failed];fs.writeFileSync(out,arr.length?arr.join(String.fromCharCode(10))+String.fromCharCode(10):'');console.log('Extracted '+arr.length+' failing spec(s)');" ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt
-              ;;
-            *)
-              if ls ${WORKSPACE}/runner-results/*.json >/dev/null 2>&1; then
-                cat ${WORKSPACE}/runner-results/*.json \
-                  | jq -r 'select(.failures > 0) | .file' \
-                  | sed '/^null$/d' \
-                  > ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt
-              else
-                : > ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt
-              fi
-              ;;
-          esac
+          # Extract failures and human-readable failure details from rerun #1
+          node scripts/extract-failure-details.js \
+            ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt \
+            ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt \
+            "Rerun #1 failures"
 
           if ls ${WORKSPACE}/cypress/results/*.json >/dev/null 2>&1; then
             npm run combine:reports
@@ -274,6 +253,7 @@ pipeline {
           else
             echo "WARNING: No mochawesome JSON for rerun #1 (possible crash). Carrying forward previous failures."
             cp ${WORKSPACE}/failures-${BUILD_NUMBER}.txt ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt
+            cp ${WORKSPACE}/failure-details-${BUILD_NUMBER}.txt ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt
             : > ${WORKSPACE}/mochawesome-rerun1-${BUILD_NUMBER}.tar.gz || true
           fi
 
@@ -304,22 +284,11 @@ pipeline {
               ;;
           esac
 
-          # Extract failures from rerun #2
-          case "${TEST_SCRIPT}" in
-            impl:*)
-              node -e "const fs=require('fs'),path=require('path');const out=process.argv[1],dir=path.join('cypress','results');if(!fs.existsSync(dir)){fs.writeFileSync(out,'');process.exit(0);}const failed=new Set();fs.readdirSync(dir).filter(f=>f.endsWith('.json')).forEach(f=>{try{const j=JSON.parse(fs.readFileSync(path.join(dir,f),'utf8'));if(j.stats&&j.stats.failures>0){const s=j.results&&j.results[0]&&(j.results[0].fullFile||j.results[0].file);if(s)failed.add(s);}}catch(e){}});const arr=[...failed];fs.writeFileSync(out,arr.length?arr.join(String.fromCharCode(10))+String.fromCharCode(10):'');console.log('Extracted '+arr.length+' failing spec(s)');" ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
-              ;;
-            *)
-              if ls ${WORKSPACE}/runner-results/*.json >/dev/null 2>&1; then
-                cat ${WORKSPACE}/runner-results/*.json \
-                  | jq -r 'select(.failures > 0) | .file' \
-                  | sed '/^null$/d' \
-                  > ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
-              else
-                : > ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
-              fi
-              ;;
-          esac
+          # Extract failures and human-readable failure details from rerun #2
+          node scripts/extract-failure-details.js \
+            ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt \
+            ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt \
+            "Rerun #2 failures"
 
           if ls ${WORKSPACE}/cypress/results/*.json >/dev/null 2>&1; then
             npm run combine:reports
@@ -328,6 +297,7 @@ pipeline {
           else
             echo "WARNING: No mochawesome JSON for rerun #2 (possible crash). Carrying forward previous failures."
             cp ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
+            cp ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt
             : > ${WORKSPACE}/mochawesome-rerun2-${BUILD_NUMBER}.tar.gz || true
           fi
         '''
@@ -343,7 +313,7 @@ pipeline {
         }
       }
       steps {
-        archiveArtifacts artifacts: "mochawesome-initial-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun1-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun2-${env.BUILD_NUMBER}.tar.gz, failures-${env.BUILD_NUMBER}.txt, failures-rerun1-${env.BUILD_NUMBER}.txt, failures-rerun2-${env.BUILD_NUMBER}.txt", onlyIfSuccessful: false
+        archiveArtifacts artifacts: "mochawesome-initial-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun1-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun2-${env.BUILD_NUMBER}.tar.gz, failures-${env.BUILD_NUMBER}.txt, failures-rerun1-${env.BUILD_NUMBER}.txt, failures-rerun2-${env.BUILD_NUMBER}.txt, failure-details-${env.BUILD_NUMBER}.txt, failure-details-rerun1-${env.BUILD_NUMBER}.txt, failure-details-rerun2-${env.BUILD_NUMBER}.txt", onlyIfSuccessful: false
       }
     }
   }
@@ -375,6 +345,9 @@ pipeline {
           String urlInit = "${env.BUILD_URL}artifact/mochawesome-initial-${bn}.tar.gz"
           String urlR1   = "${env.BUILD_URL}artifact/mochawesome-rerun1-${bn}.tar.gz"
           String urlR2   = "${env.BUILD_URL}artifact/mochawesome-rerun2-${bn}.tar.gz"
+          String urlDetailsInit = "${env.BUILD_URL}artifact/failure-details-${bn}.txt"
+          String urlDetailsR1   = "${env.BUILD_URL}artifact/failure-details-rerun1-${bn}.txt"
+          String urlDetailsR2   = "${env.BUILD_URL}artifact/failure-details-rerun2-${bn}.txt"
 
           String msg = """\
 ${passed ? "All test cases passed" : "Failures remain after 2nd rerun"}
@@ -389,6 +362,11 @@ Reports:
 • initial: ${urlInit}
 • rerun1 : ${urlR1}
 • rerun2 : ${urlR2}
+
+Failure details:
+• initial: ${urlDetailsInit}
+• rerun1 : ${urlDetailsR1}
+• rerun2 : ${urlDetailsR2}
 
 ${env.JOB_NAME} #${bn} (<${env.BUILD_URL}Open>)
 """.stripIndent()

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"test:ui:smoketests:report": "npm run delete:reports; npm run delete:mochawesome; npm run test:ui:smoketests; npm run combine:reports; npm run generateOne:report",
 		"impl:ui:smoketests:report": "npm run delete:reports; npm run delete:mochawesome; npm run impl:ui:smoketests; npm run combine:reports; npm run generateOne:report",
 		"impl:extract:failures": "node scripts/extract-failures.js",
+		"extract:failure-details": "node scripts/extract-failure-details.js",
 		"windows:delete:mochawesome": "del mochawesome.json",
 		"windows:delete:reports": "del .\\cypress\\results\\*.json",
 		"windows:cypress:run": "cypress run --env configFile=dev --spec .\\cypress\\e2e\\**\\*",

--- a/scripts/extract-failure-details.js
+++ b/scripts/extract-failure-details.js
@@ -2,7 +2,7 @@
  * Extract failing Cypress spec files and human-readable failing test details.
  *
  * Usage:
- *   node scripts/extract-failure-details.js <spec-output-file> <details-output-file> [run-label]
+ *   node scripts/extract-failure-details.js spec-output-file details-output-file [run-label]
  *
  * The spec output keeps the existing pipeline contract: one failed spec path
  * per line, suitable for rerunning whole files. The details output is for
@@ -18,31 +18,60 @@ const detailsOutputFile = process.argv[3]
 const runLabel = process.argv[4] || 'Cypress failures'
 
 if (!specOutputFile || !detailsOutputFile) {
-  console.error('Usage: node scripts/extract-failure-details.js <spec-output-file> <details-output-file> [run-label]')
+  console.error('Usage: node scripts/extract-failure-details.js spec-output-file details-output-file [run-label]')
   process.exit(1)
 }
 
 const rootDir = path.resolve(__dirname, '..')
 const mochawesomeDir = path.join(rootDir, 'cypress', 'results')
 const runnerResultsDir = path.join(rootDir, 'runner-results')
+const allowedOutputDirs = [rootDir]
+
+const resolvedSpecOutputFile = resolveOutputPath(specOutputFile)
+const resolvedDetailsOutputFile = resolveOutputPath(detailsOutputFile)
 
 const failedSpecs = new Set()
 const failures = []
 const seenFailures = new Set()
 
+function isInsideDir(filePath, dirPath) {
+  const relativePath = path.relative(dirPath, filePath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+}
+
+function resolveOutputPath(filePath) {
+  const resolvedPath = path.resolve(filePath)
+
+  if (!allowedOutputDirs.some(dirPath => isInsideDir(resolvedPath, dirPath))) {
+    throw new Error(`Output path must be inside the workspace: ${filePath}`)
+  }
+
+  return resolvedPath
+}
+
+function resolveJsonPath(baseDir, fileName) {
+  const resolvedPath = path.resolve(baseDir, fileName)
+
+  if (!fileName.endsWith('.json') || path.basename(fileName) !== fileName || !isInsideDir(resolvedPath, baseDir)) {
+    throw new Error(`Unexpected report file path: ${fileName}`)
+  }
+
+  return resolvedPath
+}
+
 function ensureParentDir(filePath) {
-  fs.mkdirSync(path.dirname(path.resolve(filePath)), { recursive: true })
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
 }
 
 function writeOutputs() {
-  ensureParentDir(specOutputFile)
-  ensureParentDir(detailsOutputFile)
+  ensureParentDir(resolvedSpecOutputFile)
+  ensureParentDir(resolvedDetailsOutputFile)
 
   const specs = Array.from(failedSpecs)
-  fs.writeFileSync(specOutputFile, specs.join('\n') + (specs.length ? '\n' : ''))
+  fs.writeFileSync(resolvedSpecOutputFile, specs.join('\n') + (specs.length ? '\n' : ''))
 
   if (!failures.length) {
-    fs.writeFileSync(detailsOutputFile, `${runLabel}\n\nNo failing tests found.\n`)
+    fs.writeFileSync(resolvedDetailsOutputFile, `${runLabel}\n\nNo failing tests found.\n`)
     return
   }
 
@@ -62,7 +91,7 @@ function writeOutputs() {
     lines.push('')
   }
 
-  fs.writeFileSync(detailsOutputFile, lines.join('\n'))
+  fs.writeFileSync(resolvedDetailsOutputFile, lines.join('\n'))
 }
 
 function firstErrorLine(err) {
@@ -139,7 +168,7 @@ function extractFromMochawesome() {
   for (const jsonFile of jsonFiles) {
     let report
     try {
-      report = JSON.parse(fs.readFileSync(path.join(mochawesomeDir, jsonFile), 'utf8'))
+      report = JSON.parse(fs.readFileSync(resolveJsonPath(mochawesomeDir, jsonFile), 'utf8'))
     } catch (err) {
       console.warn(`WARNING: Could not parse ${jsonFile}: ${err.message}`)
       continue
@@ -198,7 +227,7 @@ function extractFallbackFromRunnerResults() {
   for (const jsonFile of jsonFiles) {
     let report
     try {
-      report = JSON.parse(fs.readFileSync(path.join(runnerResultsDir, jsonFile), 'utf8'))
+      report = JSON.parse(fs.readFileSync(resolveJsonPath(runnerResultsDir, jsonFile), 'utf8'))
     } catch (err) {
       console.warn(`WARNING: Could not parse ${jsonFile}: ${err.message}`)
       continue
@@ -217,5 +246,5 @@ if (!hadMochawesome) {
 
 writeOutputs()
 
-console.log(`Extracted ${failedSpecs.size} failing spec(s) -> ${specOutputFile}`)
-console.log(`Wrote failure details -> ${detailsOutputFile}`)
+console.log(`Extracted ${failedSpecs.size} failing spec(s) -> ${resolvedSpecOutputFile}`)
+console.log(`Wrote failure details -> ${resolvedDetailsOutputFile}`)

--- a/scripts/extract-failure-details.js
+++ b/scripts/extract-failure-details.js
@@ -1,0 +1,221 @@
+/**
+ * Extract failing Cypress spec files and human-readable failing test details.
+ *
+ * Usage:
+ *   node scripts/extract-failure-details.js <spec-output-file> <details-output-file> [run-label]
+ *
+ * The spec output keeps the existing pipeline contract: one failed spec path
+ * per line, suitable for rerunning whole files. The details output is for
+ * people: it groups failures by spec and includes the failing test or hook
+ * title plus the first captured error line.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const specOutputFile = process.argv[2]
+const detailsOutputFile = process.argv[3]
+const runLabel = process.argv[4] || 'Cypress failures'
+
+if (!specOutputFile || !detailsOutputFile) {
+  console.error('Usage: node scripts/extract-failure-details.js <spec-output-file> <details-output-file> [run-label]')
+  process.exit(1)
+}
+
+const rootDir = path.resolve(__dirname, '..')
+const mochawesomeDir = path.join(rootDir, 'cypress', 'results')
+const runnerResultsDir = path.join(rootDir, 'runner-results')
+
+const failedSpecs = new Set()
+const failures = []
+const seenFailures = new Set()
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(path.resolve(filePath)), { recursive: true })
+}
+
+function writeOutputs() {
+  ensureParentDir(specOutputFile)
+  ensureParentDir(detailsOutputFile)
+
+  const specs = Array.from(failedSpecs)
+  fs.writeFileSync(specOutputFile, specs.join('\n') + (specs.length ? '\n' : ''))
+
+  if (!failures.length) {
+    fs.writeFileSync(detailsOutputFile, `${runLabel}\n\nNo failing tests found.\n`)
+    return
+  }
+
+  const lines = [runLabel, '']
+  let currentFile = null
+
+  for (const failure of failures) {
+    if (failure.file !== currentFile) {
+      currentFile = failure.file
+      lines.push(failure.file)
+    }
+
+    lines.push(`  - ${failure.title}`)
+    if (failure.error) {
+      lines.push(`    ${failure.error}`)
+    }
+    lines.push('')
+  }
+
+  fs.writeFileSync(detailsOutputFile, lines.join('\n'))
+}
+
+function firstErrorLine(err) {
+  if (!err) {
+    return ''
+  }
+
+  const message = err.message || err.estack || err.stack || String(err)
+  return String(message).split(/\r?\n/).map(line => line.trim()).find(Boolean) || ''
+}
+
+function addFailure(file, title, err) {
+  if (!file) {
+    return
+  }
+
+  const failureTitle = title || 'Unknown failing test or hook'
+  const error = firstErrorLine(err)
+  const key = `${file}\u0000${failureTitle}\u0000${error}`
+
+  failedSpecs.add(file)
+
+  if (seenFailures.has(key)) {
+    return
+  }
+
+  seenFailures.add(key)
+  failures.push({ file, title: failureTitle, error })
+}
+
+function isFailed(item) {
+  return Boolean(item && (item.fail === true || item.state === 'failed'))
+}
+
+function hookTitle(hook) {
+  const title = hook.fullTitle || hook.title || 'Unknown hook'
+  return title.startsWith('Hook:') ? title : `Hook: ${title}`
+}
+
+function walkSuite(suite, specFile) {
+  for (const hook of suite.beforeHooks || []) {
+    if (isFailed(hook)) {
+      addFailure(specFile, hookTitle(hook), hook.err)
+    }
+  }
+
+  for (const test of suite.tests || []) {
+    if (isFailed(test)) {
+      addFailure(specFile, test.fullTitle || test.title, test.err)
+    }
+  }
+
+  for (const childSuite of suite.suites || []) {
+    walkSuite(childSuite, specFile)
+  }
+
+  for (const hook of suite.afterHooks || []) {
+    if (isFailed(hook)) {
+      addFailure(specFile, hookTitle(hook), hook.err)
+    }
+  }
+}
+
+function extractFromMochawesome() {
+  if (!fs.existsSync(mochawesomeDir)) {
+    return false
+  }
+
+  const jsonFiles = fs.readdirSync(mochawesomeDir).filter(file => file.endsWith('.json'))
+  if (!jsonFiles.length) {
+    return false
+  }
+
+  for (const jsonFile of jsonFiles) {
+    let report
+    try {
+      report = JSON.parse(fs.readFileSync(path.join(mochawesomeDir, jsonFile), 'utf8'))
+    } catch (err) {
+      console.warn(`WARNING: Could not parse ${jsonFile}: ${err.message}`)
+      continue
+    }
+
+    for (const result of report.results || []) {
+      const specFile = result.fullFile || result.file
+      const failuresBeforeResult = failures.length
+
+      for (const hook of result.beforeHooks || []) {
+        if (isFailed(hook)) {
+          addFailure(specFile, hookTitle(hook), hook.err)
+        }
+      }
+
+      for (const test of result.tests || []) {
+        if (isFailed(test)) {
+          addFailure(specFile, test.fullTitle || test.title, test.err)
+        }
+      }
+
+      for (const suite of result.suites || []) {
+        walkSuite(suite, specFile)
+      }
+
+      for (const hook of result.afterHooks || []) {
+        if (isFailed(hook)) {
+          addFailure(specFile, hookTitle(hook), hook.err)
+        }
+      }
+
+      if (specFile && report.stats && report.stats.failures > 0) {
+        failedSpecs.add(specFile)
+
+        if (failures.length === failuresBeforeResult) {
+          addFailure(
+            specFile,
+            'Failure details unavailable from Mochawesome test nodes. See Mochawesome report or Cypress console output.',
+            ''
+          )
+        }
+      }
+    }
+  }
+
+  return true
+}
+
+function extractFallbackFromRunnerResults() {
+  if (!fs.existsSync(runnerResultsDir)) {
+    return
+  }
+
+  const jsonFiles = fs.readdirSync(runnerResultsDir).filter(file => file.endsWith('.json'))
+
+  for (const jsonFile of jsonFiles) {
+    let report
+    try {
+      report = JSON.parse(fs.readFileSync(path.join(runnerResultsDir, jsonFile), 'utf8'))
+    } catch (err) {
+      console.warn(`WARNING: Could not parse ${jsonFile}: ${err.message}`)
+      continue
+    }
+
+    if (report.failures > 0 && report.file) {
+      addFailure(report.file, 'Failure details unavailable from runner-results JSON. See Mochawesome report or Cypress console output.', '')
+    }
+  }
+}
+
+const hadMochawesome = extractFromMochawesome()
+if (!hadMochawesome) {
+  extractFallbackFromRunnerResults()
+}
+
+writeOutputs()
+
+console.log(`Extracted ${failedSpecs.size} failing spec(s) -> ${specOutputFile}`)
+console.log(`Wrote failure details -> ${detailsOutputFile}`)


### PR DESCRIPTION
## Summary
- Add a reusable Cypress failure detail extractor that reads Mochawesome JSON and preserves the existing spec-level rerun list
- Archive human-readable failure detail artifacts for the initial run and both reruns
- Include Slack links to the new failure detail artifacts so failed test names are easier to find

## Local validation
- `node --check scripts/extract-failure-details.js`
- `npm run extract:failure-details -- /tmp/madie-failures-npm.txt /tmp/madie-failure-details-npm.txt "NPM extractor check"`
- `git diff --check -- Jenkinsfile package.json scripts/extract-failure-details.js`
- `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package.json ok')"`

## Notes
- Jenkins should continue rerunning whole failed spec files using `failures-*.txt`
- The new `failure-details-*.txt` artifacts are additive and intended for debugging exact failed test names locally

Examples of 
<img width="923" height="380" alt="image" src="https://github.com/user-attachments/assets/16b47869-4c50-4e70-81b6-a3d29b8222f7" />

<img width="2629" height="1166" alt="image" src="https://github.com/user-attachments/assets/92e5fca7-ca8d-4592-89cc-301c4ee4eef4" />
