### PR TITLE
Add failure trend summaries for Cypress reruns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -161,6 +161,7 @@ pipeline {
           node scripts/extract-failure-details.js \
             ${WORKSPACE}/failures-${BUILD_NUMBER}.txt \
             ${WORKSPACE}/failure-details-${BUILD_NUMBER}.txt \
+            ${WORKSPACE}/failure-summary-${BUILD_NUMBER}.json \
             "Initial run failures"
         '''
 
@@ -183,6 +184,8 @@ pipeline {
           : > ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
           printf 'Rerun #1 failures\\n\\nNo rerun performed.\\n' > ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt
           printf 'Rerun #2 failures\\n\\nNo rerun performed.\\n' > ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt
+          printf '{"runLabel":"Rerun #1 failures","failedSpecCount":0,"failedTestCount":0,"failureTypes":{},"topErrorSignatures":[],"failures":[]}\\n' > ${WORKSPACE}/failure-summary-rerun1-${BUILD_NUMBER}.json
+          printf '{"runLabel":"Rerun #2 failures","failedSpecCount":0,"failedTestCount":0,"failureTypes":{},"topErrorSignatures":[],"failures":[]}\\n' > ${WORKSPACE}/failure-summary-rerun2-${BUILD_NUMBER}.json
         '''
       }
     }
@@ -244,6 +247,7 @@ pipeline {
           node scripts/extract-failure-details.js \
             ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt \
             ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt \
+            ${WORKSPACE}/failure-summary-rerun1-${BUILD_NUMBER}.json \
             "Rerun #1 failures"
 
           if ls ${WORKSPACE}/cypress/results/*.json >/dev/null 2>&1; then
@@ -254,6 +258,7 @@ pipeline {
             echo "WARNING: No mochawesome JSON for rerun #1 (possible crash). Carrying forward previous failures."
             cp ${WORKSPACE}/failures-${BUILD_NUMBER}.txt ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt
             cp ${WORKSPACE}/failure-details-${BUILD_NUMBER}.txt ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt
+            cp ${WORKSPACE}/failure-summary-${BUILD_NUMBER}.json ${WORKSPACE}/failure-summary-rerun1-${BUILD_NUMBER}.json
             : > ${WORKSPACE}/mochawesome-rerun1-${BUILD_NUMBER}.tar.gz || true
           fi
 
@@ -288,6 +293,7 @@ pipeline {
           node scripts/extract-failure-details.js \
             ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt \
             ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt \
+            ${WORKSPACE}/failure-summary-rerun2-${BUILD_NUMBER}.json \
             "Rerun #2 failures"
 
           if ls ${WORKSPACE}/cypress/results/*.json >/dev/null 2>&1; then
@@ -298,6 +304,7 @@ pipeline {
             echo "WARNING: No mochawesome JSON for rerun #2 (possible crash). Carrying forward previous failures."
             cp ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt
             cp ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt
+            cp ${WORKSPACE}/failure-summary-rerun1-${BUILD_NUMBER}.json ${WORKSPACE}/failure-summary-rerun2-${BUILD_NUMBER}.json
             : > ${WORKSPACE}/mochawesome-rerun2-${BUILD_NUMBER}.tar.gz || true
           fi
         '''
@@ -313,7 +320,16 @@ pipeline {
         }
       }
       steps {
-        archiveArtifacts artifacts: "mochawesome-initial-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun1-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun2-${env.BUILD_NUMBER}.tar.gz, failures-${env.BUILD_NUMBER}.txt, failures-rerun1-${env.BUILD_NUMBER}.txt, failures-rerun2-${env.BUILD_NUMBER}.txt, failure-details-${env.BUILD_NUMBER}.txt, failure-details-rerun1-${env.BUILD_NUMBER}.txt, failure-details-rerun2-${env.BUILD_NUMBER}.txt", onlyIfSuccessful: false
+        sh '''
+          cd ${WORKSPACE}
+          node scripts/summarize-failure-runs.js \
+            ${WORKSPACE}/failure-summary-${BUILD_NUMBER}.json \
+            ${WORKSPACE}/failure-summary-rerun1-${BUILD_NUMBER}.json \
+            ${WORKSPACE}/failure-summary-rerun2-${BUILD_NUMBER}.json \
+            ${WORKSPACE}/failure-trend-${BUILD_NUMBER}.json \
+            ${WORKSPACE}/failure-trend-${BUILD_NUMBER}.md
+        '''
+        archiveArtifacts artifacts: "mochawesome-initial-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun1-${env.BUILD_NUMBER}.tar.gz, mochawesome-rerun2-${env.BUILD_NUMBER}.tar.gz, failures-${env.BUILD_NUMBER}.txt, failures-rerun1-${env.BUILD_NUMBER}.txt, failures-rerun2-${env.BUILD_NUMBER}.txt, failure-details-${env.BUILD_NUMBER}.txt, failure-details-rerun1-${env.BUILD_NUMBER}.txt, failure-details-rerun2-${env.BUILD_NUMBER}.txt, failure-trend-${env.BUILD_NUMBER}.json, failure-trend-${env.BUILD_NUMBER}.md", onlyIfSuccessful: false
       }
     }
   }
@@ -348,6 +364,7 @@ pipeline {
           String urlDetailsInit = "${env.BUILD_URL}artifact/failure-details-${bn}.txt"
           String urlDetailsR1   = "${env.BUILD_URL}artifact/failure-details-rerun1-${bn}.txt"
           String urlDetailsR2   = "${env.BUILD_URL}artifact/failure-details-rerun2-${bn}.txt"
+          String urlTrend       = "${env.BUILD_URL}artifact/failure-trend-${bn}.md"
 
           String msg = """\
 ${passed ? "All test cases passed" : "Failures remain after 2nd rerun"}
@@ -367,6 +384,9 @@ Failure details:
 • initial: ${urlDetailsInit}
 • rerun1 : ${urlDetailsR1}
 • rerun2 : ${urlDetailsR2}
+
+Failure trend:
+• summary: ${urlTrend}
 
 ${env.JOB_NAME} #${bn} (<${env.BUILD_URL}Open>)
 """.stripIndent()

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
 		"impl:ui:smoketests:report": "npm run delete:reports; npm run delete:mochawesome; npm run impl:ui:smoketests; npm run combine:reports; npm run generateOne:report",
 		"impl:extract:failures": "node scripts/extract-failures.js",
 		"extract:failure-details": "node scripts/extract-failure-details.js",
+		"summarize:failure-runs": "node scripts/summarize-failure-runs.js",
 		"windows:delete:mochawesome": "del mochawesome.json",
 		"windows:delete:reports": "del .\\cypress\\results\\*.json",
 		"windows:cypress:run": "cypress run --env configFile=dev --spec .\\cypress\\e2e\\**\\*",

--- a/scripts/extract-failure-details.js
+++ b/scripts/extract-failure-details.js
@@ -2,7 +2,7 @@
  * Extract failing Cypress spec files and human-readable failing test details.
  *
  * Usage:
- *   node scripts/extract-failure-details.js spec-output-file details-output-file [run-label]
+ *   node scripts/extract-failure-details.js spec-output-file details-output-file [summary-json-file] [run-label]
  *
  * The spec output keeps the existing pipeline contract: one failed spec path
  * per line, suitable for rerunning whole files. The details output is for
@@ -15,10 +15,16 @@ const path = require('path')
 
 const specOutputFile = process.argv[2]
 const detailsOutputFile = process.argv[3]
-const runLabel = process.argv[4] || 'Cypress failures'
+const maybeSummaryJsonFile = process.argv[4]
+const hasSummaryOutput = Boolean(
+  maybeSummaryJsonFile &&
+  maybeSummaryJsonFile.endsWith('.json')
+)
+const summaryJsonFile = hasSummaryOutput ? maybeSummaryJsonFile : null
+const runLabel = (hasSummaryOutput ? process.argv[5] : process.argv[4]) || 'Cypress failures'
 
 if (!specOutputFile || !detailsOutputFile) {
-  console.error('Usage: node scripts/extract-failure-details.js spec-output-file details-output-file [run-label]')
+  console.error('Usage: node scripts/extract-failure-details.js spec-output-file details-output-file [summary-json-file] [run-label]')
   process.exit(1)
 }
 
@@ -29,6 +35,7 @@ const allowedOutputDirs = [rootDir]
 
 const resolvedSpecOutputFile = resolveOutputPath(specOutputFile)
 const resolvedDetailsOutputFile = resolveOutputPath(detailsOutputFile)
+const resolvedSummaryJsonFile = summaryJsonFile ? resolveOutputPath(summaryJsonFile) : null
 
 const failedSpecs = new Set()
 const failures = []
@@ -66,12 +73,16 @@ function ensureParentDir(filePath) {
 function writeOutputs() {
   ensureParentDir(resolvedSpecOutputFile)
   ensureParentDir(resolvedDetailsOutputFile)
+  if (resolvedSummaryJsonFile) {
+    ensureParentDir(resolvedSummaryJsonFile)
+  }
 
   const specs = Array.from(failedSpecs)
   fs.writeFileSync(resolvedSpecOutputFile, specs.join('\n') + (specs.length ? '\n' : ''))
 
   if (!failures.length) {
     fs.writeFileSync(resolvedDetailsOutputFile, `${runLabel}\n\nNo failing tests found.\n`)
+    writeSummaryOutputs(specs)
     return
   }
 
@@ -92,6 +103,7 @@ function writeOutputs() {
   }
 
   fs.writeFileSync(resolvedDetailsOutputFile, lines.join('\n'))
+  writeSummaryOutputs(specs)
 }
 
 function firstErrorLine(err) {
@@ -120,6 +132,109 @@ function addFailure(file, title, err) {
 
   seenFailures.add(key)
   failures.push({ file, title: failureTitle, error })
+}
+
+function classifyFailure(error) {
+  if (!error) {
+    return 'Unknown'
+  }
+
+  if (error.includes('No users available') || error.includes('SessionLogin') || error.includes('Okta')) {
+    return 'Authentication or session'
+  }
+
+  if (error.includes('cy.request() failed') || error.includes('status code') || error.includes('ECONNREFUSED') || error.includes('ETIMEDOUT')) {
+    return 'API or network'
+  }
+
+  if (error.includes('Expected to find element') || error.includes('never found it')) {
+    return 'Element not found'
+  }
+
+  if (error.includes('Timed out retrying')) {
+    return 'Timeout'
+  }
+
+  if (error.includes('cy.click() failed because the page updated')) {
+    return 'DOM update during click'
+  }
+
+  if (error.includes('Special character sequence')) {
+    return 'Cypress typing error'
+  }
+
+  if (error.includes('AssertionError')) {
+    return 'Assertion failure'
+  }
+
+  if (error.includes('CypressError')) {
+    return 'Cypress command error'
+  }
+
+  return 'Unclassified'
+}
+
+function normalizeErrorSignature(error) {
+  if (!error) {
+    return 'No error message captured'
+  }
+
+  return error
+    .replace(/after \d+ms/g, 'after <duration>ms')
+    .replace(/#mui-\d+/g, '#mui-<id>')
+    .replace(/[0-9a-f]{8}-[0-9a-f-]{27,}/gi, '<uuid>')
+    .replace(/\b\d{10,}\b/g, '<number>')
+}
+
+function countBy(items, getKey) {
+  return items.reduce((counts, item) => {
+    const key = getKey(item)
+    counts[key] = (counts[key] || 0) + 1
+    return counts
+  }, {})
+}
+
+function topCounts(counts, limit = 10) {
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([value, count]) => ({ value, count }))
+}
+
+function buildSummary(specs) {
+  const enrichedFailures = failures.map(failure => {
+    const errorType = classifyFailure(failure.error)
+    const errorSignature = normalizeErrorSignature(failure.error)
+    return {
+      file: failure.file,
+      title: failure.title,
+      errorType,
+      errorSignature,
+      error: failure.error
+    }
+  })
+
+  const failureTypes = countBy(enrichedFailures, failure => failure.errorType)
+  const errorSignatures = countBy(enrichedFailures, failure => failure.errorSignature)
+
+  return {
+    runLabel,
+    generatedAt: new Date().toISOString(),
+    failedSpecCount: specs.length,
+    failedTestCount: enrichedFailures.length,
+    failureTypes,
+    topErrorSignatures: topCounts(errorSignatures),
+    failures: enrichedFailures
+  }
+}
+
+function writeSummaryOutputs(specs) {
+  if (!resolvedSummaryJsonFile) {
+    return
+  }
+
+  const summary = buildSummary(specs)
+  fs.writeFileSync(resolvedSummaryJsonFile, JSON.stringify(summary, null, 2) + '\n')
 }
 
 function isFailed(item) {

--- a/scripts/summarize-failure-runs.js
+++ b/scripts/summarize-failure-runs.js
@@ -1,0 +1,241 @@
+/**
+ * Compare initial and rerun failure summaries to identify flaky and persistent failures.
+ *
+ * Usage:
+ *   node scripts/summarize-failure-runs.js initial-summary.json rerun1-summary.json rerun2-summary.json trend-json-file trend-md-file
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+const initialSummaryFile = process.argv[2]
+const rerun1SummaryFile = process.argv[3]
+const rerun2SummaryFile = process.argv[4]
+const trendJsonFile = process.argv[5]
+const trendMdFile = process.argv[6]
+
+if (!initialSummaryFile || !rerun1SummaryFile || !rerun2SummaryFile || !trendJsonFile || !trendMdFile) {
+  console.error('Usage: node scripts/summarize-failure-runs.js initial-summary.json rerun1-summary.json rerun2-summary.json trend-json-file trend-md-file')
+  process.exit(1)
+}
+
+const rootDir = path.resolve(__dirname, '..')
+
+const resolvedInitialSummaryFile = resolveWorkspacePath(initialSummaryFile)
+const resolvedRerun1SummaryFile = resolveWorkspacePath(rerun1SummaryFile)
+const resolvedRerun2SummaryFile = resolveWorkspacePath(rerun2SummaryFile)
+const resolvedTrendJsonFile = resolveWorkspacePath(trendJsonFile)
+const resolvedTrendMdFile = resolveWorkspacePath(trendMdFile)
+
+function isInsideDir(filePath, dirPath) {
+  const relativePath = path.relative(dirPath, filePath)
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+}
+
+function resolveWorkspacePath(filePath) {
+  const resolvedPath = path.resolve(filePath)
+
+  if (!isInsideDir(resolvedPath, rootDir)) {
+    throw new Error(`Path must be inside the workspace: ${filePath}`)
+  }
+
+  return resolvedPath
+}
+
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+}
+
+function readSummary(filePath, fallbackLabel) {
+  if (!fs.existsSync(filePath)) {
+    return emptySummary(fallbackLabel)
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8').trim()
+  if (!content) {
+    return emptySummary(fallbackLabel)
+  }
+
+  const summary = JSON.parse(content)
+  return {
+    runLabel: summary.runLabel || fallbackLabel,
+    failedSpecCount: summary.failedSpecCount || 0,
+    failedTestCount: summary.failedTestCount || 0,
+    failureTypes: summary.failureTypes || {},
+    topErrorSignatures: summary.topErrorSignatures || [],
+    failures: Array.isArray(summary.failures) ? summary.failures : []
+  }
+}
+
+function emptySummary(runLabel) {
+  return {
+    runLabel,
+    failedSpecCount: 0,
+    failedTestCount: 0,
+    failureTypes: {},
+    topErrorSignatures: [],
+    failures: []
+  }
+}
+
+function failureKey(failure) {
+  return `${failure.file}\u0000${failure.title}`
+}
+
+function mapFailures(summary) {
+  return new Map(summary.failures.map(failure => [failureKey(failure), failure]))
+}
+
+function countBy(items, getKey) {
+  return items.reduce((counts, item) => {
+    const key = getKey(item)
+    counts[key] = (counts[key] || 0) + 1
+    return counts
+  }, {})
+}
+
+function topCounts(counts, limit = 10) {
+  return Object.entries(counts)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, limit)
+    .map(([value, count]) => ({ value, count }))
+}
+
+function buildTrend(initialSummary, rerun1Summary, rerun2Summary) {
+  const initialFailures = mapFailures(initialSummary)
+  const rerun1Failures = mapFailures(rerun1Summary)
+  const rerun2Failures = mapFailures(rerun2Summary)
+  const allKeys = new Set([...initialFailures.keys(), ...rerun1Failures.keys(), ...rerun2Failures.keys()])
+  const classifiedFailures = []
+
+  for (const key of allKeys) {
+    const initial = initialFailures.get(key)
+    const rerun1 = rerun1Failures.get(key)
+    const rerun2 = rerun2Failures.get(key)
+    const representative = rerun2 || rerun1 || initial
+
+    classifiedFailures.push({
+      file: representative.file,
+      title: representative.title,
+      errorType: representative.errorType || 'Unknown',
+      errorSignature: representative.errorSignature || representative.error || 'No error message captured',
+      status: classifyRunStatus(Boolean(initial), Boolean(rerun1), Boolean(rerun2)),
+      failedInitial: Boolean(initial),
+      failedRerun1: Boolean(rerun1),
+      failedRerun2: Boolean(rerun2)
+    })
+  }
+
+  const statusCounts = countBy(classifiedFailures, failure => failure.status)
+  const persistentFailures = classifiedFailures.filter(failure => failure.status === 'Persistent failure')
+  const flakyFailures = classifiedFailures.filter(failure => failure.status.startsWith('Flaky'))
+  const newRerunFailures = classifiedFailures.filter(failure => failure.status === 'New rerun failure')
+
+  return {
+    generatedAt: new Date().toISOString(),
+    counts: {
+      initialFailedSpecs: initialSummary.failedSpecCount,
+      initialFailedTests: initialSummary.failedTestCount,
+      rerun1FailedSpecs: rerun1Summary.failedSpecCount,
+      rerun1FailedTests: rerun1Summary.failedTestCount,
+      rerun2FailedSpecs: rerun2Summary.failedSpecCount,
+      rerun2FailedTests: rerun2Summary.failedTestCount,
+      flakyFailures: flakyFailures.length,
+      persistentFailures: persistentFailures.length,
+      newRerunFailures: newRerunFailures.length
+    },
+    statusCounts,
+    topPersistentErrorTypes: topCounts(countBy(persistentFailures, failure => failure.errorType)),
+    topFlakyErrorTypes: topCounts(countBy(flakyFailures, failure => failure.errorType)),
+    classifiedFailures
+  }
+}
+
+function classifyRunStatus(failedInitial, failedRerun1, failedRerun2) {
+  if (failedInitial && failedRerun1 && failedRerun2) {
+    return 'Persistent failure'
+  }
+
+  if (failedInitial && !failedRerun1 && !failedRerun2) {
+    return 'Flaky - passed after rerun #1'
+  }
+
+  if (failedInitial && failedRerun1 && !failedRerun2) {
+    return 'Flaky - passed after rerun #2'
+  }
+
+  if (!failedInitial && (failedRerun1 || failedRerun2)) {
+    return 'New rerun failure'
+  }
+
+  return 'Intermittent rerun failure'
+}
+
+function renderTrendMarkdown(trend) {
+  const lines = [
+    '# Failure Trend Summary',
+    '',
+    '## Counts',
+    `- Initial failed specs: ${trend.counts.initialFailedSpecs}`,
+    `- Initial failed tests/hooks: ${trend.counts.initialFailedTests}`,
+    `- Rerun #1 failed specs: ${trend.counts.rerun1FailedSpecs}`,
+    `- Rerun #1 failed tests/hooks: ${trend.counts.rerun1FailedTests}`,
+    `- Rerun #2 failed specs: ${trend.counts.rerun2FailedSpecs}`,
+    `- Rerun #2 failed tests/hooks: ${trend.counts.rerun2FailedTests}`,
+    `- Flaky failures: ${trend.counts.flakyFailures}`,
+    `- Persistent failures: ${trend.counts.persistentFailures}`,
+    `- New rerun failures: ${trend.counts.newRerunFailures}`,
+    '',
+    '## Status Counts'
+  ]
+
+  const statusCounts = Object.entries(trend.statusCounts)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+
+  if (!statusCounts.length) {
+    lines.push('- None')
+  } else {
+    for (const [status, count] of statusCounts) {
+      lines.push(`- ${status}: ${count}`)
+    }
+  }
+
+  lines.push('', '## Persistent Failures')
+  appendFailures(lines, trend.classifiedFailures.filter(failure => failure.status === 'Persistent failure'))
+
+  lines.push('', '## Flaky Failures')
+  appendFailures(lines, trend.classifiedFailures.filter(failure => failure.status.startsWith('Flaky')))
+
+  lines.push('', '## New Rerun Failures')
+  appendFailures(lines, trend.classifiedFailures.filter(failure => failure.status === 'New rerun failure'))
+
+  return `${lines.join('\n')}\n`
+}
+
+function appendFailures(lines, failures) {
+  if (!failures.length) {
+    lines.push('- None')
+    return
+  }
+
+  for (const failure of failures) {
+    lines.push(`- ${failure.file}`)
+    lines.push(`  - ${failure.title}`)
+    lines.push(`  - Status: ${failure.status}`)
+    lines.push(`  - Type: ${failure.errorType}`)
+  }
+}
+
+const initialSummary = readSummary(resolvedInitialSummaryFile, 'Initial run failures')
+const rerun1Summary = readSummary(resolvedRerun1SummaryFile, 'Rerun #1 failures')
+const rerun2Summary = readSummary(resolvedRerun2SummaryFile, 'Rerun #2 failures')
+const trend = buildTrend(initialSummary, rerun1Summary, rerun2Summary)
+
+ensureParentDir(resolvedTrendJsonFile)
+ensureParentDir(resolvedTrendMdFile)
+
+fs.writeFileSync(resolvedTrendJsonFile, JSON.stringify(trend, null, 2) + '\n')
+fs.writeFileSync(resolvedTrendMdFile, renderTrendMarkdown(trend))
+
+console.log(`Wrote failure trend JSON -> ${resolvedTrendJsonFile}`)
+console.log(`Wrote failure trend Markdown -> ${resolvedTrendMdFile}`)


### PR DESCRIPTION
## Summary
- Add structured failure summaries from Mochawesome output without changing existing Cypress rerun behavior
- Generate a final failure trend report comparing initial run, rerun #1, and rerun #2
- Classify failures as flaky, persistent, new rerun failures, or intermittent rerun failures
- Add failure type grouping for common patterns like timeout, element not found, assertion failure, API/network, auth/session, and Cypress command errors
- Archive final `failure-trend-<build>.md` and `failure-trend-<build>.json` alongside existing failure detail artifacts

## Reporting Behavior
- Existing `failures-*.txt` files still drive spec-level reruns
- Existing `failure-details-*.txt` files remain available for exact failed test names/errors
- New per-run summary JSON files are internal Jenkins scratch files only
- Final archived trend artifacts are:
  - `failure-trend-<build>.md`
  - `failure-trend-<build>.json`

## Local Validation
- `node --check scripts/extract-failure-details.js`
- `node --check scripts/summarize-failure-runs.js`
- `npm run compile`
- `git diff --check origin/master..HEAD`
- package JSON/lockfile parse check

## Notes
- Allure changes were removed from this PR
- Mochawesome remains the source for failure extraction
- Cypress tests were not rewritten