### PR TITLE
Add shared Prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules
+cypress/results
+cypress/screenshots
+cypress/videos
+lighthouse-report
+mochawesome-report
+runner-results
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "singleQuote": true,
+    "semi": false,
+    "printWidth": 120,
+    "tabWidth": 4,
+    "trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,34 @@ npx cypress verify
 
 You should see a success message with the Cypress version.
 
+### Code Formatting
+
+This project uses Prettier for shared code formatting. Prettier is installed as a project dev dependency, so no global Prettier install is required after running `npm install`. The Prettier configuration is committed to the repo so command-line formatting and IDE formatting use the same rules.
+
+Format one or more files:
+
+```bash
+npm run format -- cypress/e2e/path/to/file.cy.ts
+```
+
+Check whether one or more files already match the shared formatting:
+
+```bash
+npm run format:check -- cypress/e2e/path/to/file.cy.ts
+```
+
+Prettier formats the entire file passed to it. To keep PR diffs focused, format the files you are already changing unless the team agrees on a dedicated formatting-only PR.
+
+#### VS Code Users
+
+Install the Prettier extension and enable `prettier.requireConfig` so Prettier only runs in projects that have a repo-level config.
+
+```json
+{
+    "prettier.requireConfig": true
+}
+```
+
 ---
 
 ## 5. Configure Environment Variables

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
 				"cypress-real-events": "^1.15.0",
 				"mochawesome": "^7.1.3",
 				"mochawesome-merge": "^5.1.0",
+				"prettier": "3.8.5",
 				"typescript": "^5.9.3"
 			},
 			"engines": {
@@ -4224,6 +4225,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.8.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.5.tgz",
+			"integrity": "sha512-zxcTTCedNGJM4R8sj/Cq/F0W/c4iE0afWBcBwMTRtw4WHYP9TWkYjdiH3npPRUYsXQCPR0hTU9yjovOu+E6EQA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
 		"test:specific:files:parallel": "node -e \"const fs=require('fs');const {spawnSync}=require('child_process');const list='test-files.txt';if(!fs.existsSync(list)){console.error('Missing spec list file:',list);process.exit(1);}const specs=fs.readFileSync(list,'utf8').split(/\\r?\\n/).map(s=>s.trim()).filter(Boolean);if(!specs.length){console.error('Spec list is empty after reading',list);process.exit(1);}const npx=process.platform==='win32'?'npx.cmd':'npx';const args=['cypress-parallel','-s','cy:run:test:headed','-t','3','--spec',...specs,'-p','cypress/parallel-reporter-config.json'];console.log('cypress-parallel args:', args.join(' '));const res=spawnSync(npx,args,{stdio:'inherit',env:{...process.env,NO_COLOR:'1'}});process.exit(res.status||0);\"",
 		"dev:specific:files:parallel": "node -e \"const fs=require('fs');const {spawnSync}=require('child_process');const list='test-files.txt';if(!fs.existsSync(list)){console.error('Missing spec list file:',list);process.exit(1);}const specs=fs.readFileSync(list,'utf8').split(/\\r?\\n/).map(s=>s.trim()).filter(Boolean);if(!specs.length){console.error('Spec list is empty after reading',list);process.exit(1);}const npx=process.platform==='win32'?'npx.cmd':'npx';const args=['cypress-parallel','-s','cy:run:dev:headed','-t','3','--spec',...specs,'-p','cypress/parallel-reporter-config.json'];console.log('cypress-parallel args:', args.join(' '));const res=spawnSync(npx,args,{stdio:'inherit',env:{...process.env,NO_COLOR:'1'}});process.exit(res.status||0);\"",
 		"compile": "tsc --noEmit",
+		"format": "prettier --write",
+		"format:check": "prettier --check",
 		"combine:reports": "npx mochawesome-merge 'cypress/results/*.json' > mochawesome.json",
 		"generateOne:report": "npx marge mochawesome.json",
 		"delete:mochawesome": "rm mochawesome.json",
@@ -111,6 +113,7 @@
 		"cypress-real-events": "^1.15.0",
 		"mochawesome": "^7.1.3",
 		"mochawesome-merge": "^5.1.0",
+		"prettier": "3.8.5",
 		"typescript": "^5.9.3"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary

Adds Prettier as a shared repo-level formatting tool so the team can use the same formatting rules from the command line or IDE.

## Changes

- Added Prettier as a pinned dev dependency
- Added `.prettierrc` with shared formatting settings
- Added `.prettierignore` for generated/output folders
- Added `format` and `format:check` npm scripts
- Documented usage in the README

## How To Use

Format a specific file:

```bash
npm run format -- cypress/e2e/path/to/file.cy.ts
```

Check whether a specific file already matches Prettier formatting:
```bash
npm run format:check -- cypress/e2e/path/to/file.cy.ts
```
You can also pass multiple files:

```bash
npm run format -- file1.ts file2.ts
```