### PR TITLE
Fix build 232 manual rerun handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,11 @@ pipeline {
       description: 'Choose the Test script to run',
       name: 'TEST_SCRIPT'
     )
+    text(
+      name: 'MANUAL_SPEC_LIST',
+      defaultValue: '',
+      description: 'Optional newline-separated Cypress spec files. Use with test:specific:files:parallel to create test-files.txt at runtime.'
+    )
     choice(name: 'BUILD_CONTAINER', description: 'Rebuild Cypress Container?', choices: ['no','yes'])
   }
 
@@ -153,6 +158,15 @@ pipeline {
             cd ${WORKSPACE}
             # Per-run report: start clean
             npm run delete:reports
+            if [ -n "${MANUAL_SPEC_LIST:-}" ]; then
+              echo "Writing MANUAL_SPEC_LIST to ${WORKSPACE}/test-files.txt"
+              printf '%s\\n' "${MANUAL_SPEC_LIST}" \
+                | tr -d '\\r' \
+                | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;/^$/d' \
+                > ${WORKSPACE}/test-files.txt
+              echo "Manual spec list contains $(wc -l < ${WORKSPACE}/test-files.txt) spec(s):"
+              cat ${WORKSPACE}/test-files.txt
+            fi
             set +e
             timeout 8h npm run "$TEST_SCRIPT"
             TEST_STATUS=$?

--- a/cypress/support/failedTestFilter.ts
+++ b/cypress/support/failedTestFilter.ts
@@ -100,14 +100,22 @@ if (failedTestTitles.size) {
 
   const wrapIt = (itFn: any) => {
     const wrapped = function (title: string, fn?: Mocha.Func) {
-      const runnable = failedTestTitles.has(fullTitle(title)) ? itFn : itFn.skip
-      return runnable(title, fn)
+      const shouldRun = failedTestTitles.has(fullTitle(title))
+      const test = itFn(title, shouldRun ? fn : undefined)
+      if (!shouldRun) {
+        test.pending = true
+      }
+      return test
     }
 
     wrapped.only = itFn.only
       ? function (title: string, fn?: Mocha.Func) {
-          const runnable = failedTestTitles.has(fullTitle(title)) ? itFn.only : itFn.skip
-          return runnable(title, fn)
+          const shouldRun = failedTestTitles.has(fullTitle(title))
+          const test = itFn.only(title, shouldRun ? fn : undefined)
+          if (!shouldRun) {
+            test.pending = true
+          }
+          return test
         }
       : undefined
     wrapped.skip = itFn.skip ? itFn.skip.bind(itFn) : undefined


### PR DESCRIPTION
## Summary

Adds follow-up fixes from build 232 to make manual failed-spec reruns reliable and fix targeted rerun crashes in Cypress 15.

## Changes

- Add a `MANUAL_SPEC_LIST` Jenkins text parameter.
- Write `MANUAL_SPEC_LIST` into `test-files.txt` at runtime when provided.
- Log the manual spec count and file list before Cypress starts.
- Fix targeted failed-test reruns by avoiding Cypress 15 recursion from `it.skip`.
- Mark non-targeted tests as pending instead of invoking `it.skip`.

## Why

Build 232 only ran 7 specs instead of the expected 94 because the pipeline used the `test-files.txt` available in the workspace/container. This change lets us paste the intended failed spec list directly into Jenkins so the runtime list is explicit and verifiable.

The reruns also failed with `Maximum call stack size exceeded` before executing the targeted failed tests. The filter now avoids that Cypress 15 recursion path.

## Validation

- `npm run compile`
- `git diff --check`