### PR TITLE
Fix regression test failures

### DIFF
--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore411.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore411.cy.ts
@@ -1,15 +1,15 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let measureCQLPFTests = MeasureCQL.CQL_Populations
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 let QDMdescription = 'QDM description'
@@ -30,9 +30,7 @@ let measureQDM = ''
 
 //Utilizing Qi Core 4.1.1
 describe('Measure Association: Transferring meta data and CMS ID from QDM to QI Core measure, using Qi Core 4.1.1', () => {
-
     beforeEach('Create Measure', () => {
-
         //Create New QDM Measure
         measureQDM = 'QDMMeasure' + Date.now() + randValue + 8 + randValue
 
@@ -47,14 +45,31 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create new QI Core measure
         measureQICore = 'QICoreMeasure' + Date.now() + randValue + 4 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPIWithSimpleDesc(measureQICore, measureQICore, measureCQLPFTests, 2)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(2, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            2,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
 
         OktaLogin.Login()
 
@@ -78,7 +93,10 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.measurementInformationSaveButton).click()
         cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('exist')
         cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('be.visible')
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
         //measure period start and end dates
         cy.get(EditMeasurePage.leftPanelModelAndMeasurementPeriod).click()
@@ -118,7 +136,12 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()
 
         //select a value for Steward
-        cy.get(EditMeasurePage.measureStewardDrpDwn).should('exist').should('be.visible').click().clear().type(QDMsteward)
+        cy.get(EditMeasurePage.measureStewardDrpDwn)
+            .should('exist')
+            .should('be.visible')
+            .click()
+            .clear()
+            .type(QDMsteward)
         cy.get(EditMeasurePage.measureStewardDrpDwnOption).click()
 
         //select a value for Developers
@@ -150,41 +173,38 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Log Out', () => {
-
         OktaLogin.UILogout()
     })
 
-    it('Association: QDM -> Qi Core measure: Copying meta data and CMS Id from QDM - to - QI Core measure; also validating the \'are you sure\' modal / dialog window', () => {
-
+    it("Association: QDM -> Qi Core measure: Copying meta data and CMS Id from QDM - to - QI Core measure; also validating the 'are you sure' modal / dialog window", () => {
         MeasuresPage.actionCenter('associatemeasure')
 
         cy.get(EditMeasurePage.associateCmsIdDialog).should('include.text', 'MeasureVersionModelCMS ID')
-        cy.get('[id="associate-cms-id-dialog"]').should('include.text', 'Associate CMS ID will copy the CMS ID from your QDM measure to your QI-Core measure. To copy QDM metadata to the QI-Core measure as well please select the checkbox below.')
+        cy.get('[id="associate-cms-id-dialog"]').should(
+            'include.text',
+            'Associate CMS ID will copy the CMS ID from your QDM measure to your QI-Core measure. To copy QDM metadata to the QI-Core measure as well please select the checkbox below.'
+        )
         Utilities.waitForElementVisible(Utilities.DiscardCancelBtn, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.associateCmsAssociateBtn, 37000)
         cy.get(EditMeasurePage.associateCmsAssociateBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.sureDialog, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.sureDialogCancelBtn, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.sureDialogContinueBtn, 35000)
-        cy.get(EditMeasurePage.sureDialog).find(TestCasesPage.discardChangesConfirmationBody).should('contain.text', 'Are you sure you wish to associate this CMS ID?This Action cannot be undone.')
+        cy.get(EditMeasurePage.sureDialog)
+            .find(TestCasesPage.discardChangesConfirmationBody)
+            .should('contain.text', 'Are you sure you wish to associate this CMS ID?This Action cannot be undone.')
 
         cy.get(EditMeasurePage.sureDialogCancelBtn).click()
         Utilities.waitForElementToNotExist(EditMeasurePage.sureDialog, 35000)
@@ -196,9 +216,11 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         MeasuresPage.actionCenter('edit', 2)
 
         //confirming the cms id on the QI Core measure
-        cy.get(EditMeasurePage.cmsIdInput).invoke('val').then(val => {
-            expect(val).to.contain(newQDMMeasureSetID + 'FHIR')
-        })
+        cy.get(EditMeasurePage.cmsIdInput)
+            .invoke('val')
+            .then((val) => {
+                expect(val).to.contain(newQDMMeasureSetID + 'FHIR')
+            })
 
         //Confirm that eCQM value was not copied over
         cy.get(CreateMeasurePage.eCQMAbbreviatedTitleTextbox).should('contain.value', eCQMQICORE4OrgValue)
@@ -238,9 +260,7 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.measureStewardDrpDwn).find('[id="steward"]').should('contain.value', QDMsteward)
 
         //Confirm Developers
-        cy.get(EditMeasurePage.measureDeveloperDrpDwn)
-            .find('.MuiChip-label')
-            .should('contain.text', QDMstewardDev)
+        cy.get(EditMeasurePage.measureDeveloperDrpDwn).find('.MuiChip-label').should('contain.text', QDMstewardDev)
 
         //Confirm Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
@@ -250,7 +270,9 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         //Confirm Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
         cy.get(EditMeasurePage.measureGenericFieldRTETextBox).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMclinicalRecommendation + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should(
+            'have.html',
+            '<p>' + QDMclinicalRecommendation + '</p>'
+        )
     })
 })
-

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore600.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore600.cy.ts
@@ -1,18 +1,18 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage, SupportedModels, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage, SupportedModels, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
 
 const measureData: CreateMeasureOptions = {
     measureCql: MeasureCQL.CQL_BoneDensity_Proportion_Boolean
 }
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 let QDMdescription = 'QDM description'
 let QDMcopyright = 'QDM copyright'
@@ -32,9 +32,7 @@ let measureQDM = ''
 
 //Utilizing Qi Core 6.0.0
 describe('Measure Association: Transferring meta data and CMS ID from QDM to QI Core 6.0.0 measure, using Qi Core 6.0.0', () => {
-
     beforeEach('Create Measure', () => {
-
         //Create New QDM Measure
         measureQDM = 'QDMMeasure' + Date.now() + randValue + 8 + randValue
 
@@ -49,8 +47,16 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create new QI Core 6.0.0 measure
         measureQICore = 'QICore600Measure' + Date.now() + randValue + 4 + randValue
@@ -82,7 +88,10 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.measurementInformationSaveButton).click()
         cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('exist')
         cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('be.visible')
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
         //measure period start and end dates
         cy.get(EditMeasurePage.leftPanelModelAndMeasurementPeriod).click()
@@ -117,7 +126,12 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.leftPanelStewardDevelopers).click()
 
         //select a value for Steward
-        cy.get(EditMeasurePage.measureStewardDrpDwn).should('exist').should('be.visible').click().clear().type(QDMsteward)
+        cy.get(EditMeasurePage.measureStewardDrpDwn)
+            .should('exist')
+            .should('be.visible')
+            .click()
+            .clear()
+            .type(QDMsteward)
         cy.get(EditMeasurePage.measureStewardDrpDwnOption).click()
 
         //select a value for Developers
@@ -147,41 +161,38 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.measureClinicalRecommendationSaveButton).click()
         cy.get(EditMeasurePage.measureClinicalRecommendationSuccessMessage).should('be.visible')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Log Out', () => {
-
         OktaLogin.UILogout()
     })
 
-    it('Association: QDM -> Qi Core 6.0.0 measure: Copying meta data and CMS Id from QDM - to - QI Core 6.0.0 measure; also validating the \'are you sure\' modal / dialog window', () => {
-
+    it("Association: QDM -> Qi Core 6.0.0 measure: Copying meta data and CMS Id from QDM - to - QI Core 6.0.0 measure; also validating the 'are you sure' modal / dialog window", () => {
         MeasuresPage.actionCenter('associatemeasure')
 
         cy.get(EditMeasurePage.associateCmsIdDialog).should('include.text', 'MeasureVersionModelCMS ID')
-        cy.get('[id="associate-cms-id-dialog"]').should('include.text', 'Associate CMS ID will copy the CMS ID from your QDM measure to your QI-Core measure. To copy QDM metadata to the QI-Core measure as well please select the checkbox below.')
+        cy.get('[id="associate-cms-id-dialog"]').should(
+            'include.text',
+            'Associate CMS ID will copy the CMS ID from your QDM measure to your QI-Core measure. To copy QDM metadata to the QI-Core measure as well please select the checkbox below.'
+        )
         Utilities.waitForElementVisible(Utilities.DiscardCancelBtn, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.associateCmsAssociateBtn, 37000)
         cy.get(EditMeasurePage.associateCmsAssociateBtn).click()
         Utilities.waitForElementVisible(EditMeasurePage.sureDialog, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.sureDialogCancelBtn, 35000)
         Utilities.waitForElementVisible(EditMeasurePage.sureDialogContinueBtn, 35000)
-        cy.get(EditMeasurePage.sureDialog).find(TestCasesPage.discardChangesConfirmationBody).should('contain.text', 'Are you sure you wish to associate this CMS ID?This Action cannot be undone.')
+        cy.get(EditMeasurePage.sureDialog)
+            .find(TestCasesPage.discardChangesConfirmationBody)
+            .should('contain.text', 'Are you sure you wish to associate this CMS ID?This Action cannot be undone.')
 
         cy.get(EditMeasurePage.sureDialogCancelBtn).click()
         Utilities.waitForElementToNotExist(EditMeasurePage.sureDialog, 35000)
@@ -195,9 +206,11 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         MeasuresPage.actionCenter('edit', 2)
 
         //confirming the cms id on the QI Core measure
-        cy.get(EditMeasurePage.cmsIdInput).invoke('val').then(val => {
-            expect(val).to.contain(newQDMMeasureSetID + 'FHIR')
-        })
+        cy.get(EditMeasurePage.cmsIdInput)
+            .invoke('val')
+            .then((val) => {
+                expect(val).to.contain(newQDMMeasureSetID + 'FHIR')
+            })
 
         //Confirm that eCQM value was not copied over
         cy.get(CreateMeasurePage.eCQMAbbreviatedTitleTextbox).should('not.contain.value', 'eCQMTitle4QICore')
@@ -235,9 +248,7 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.measureStewardDrpDwn).find('[id="steward"]').should('contain.value', QDMsteward)
 
         //Confirm Developers
-        cy.get(EditMeasurePage.measureDeveloperDrpDwn)
-            .find('.MuiChip-label')
-            .should('contain.text', QDMstewardDev)
+        cy.get(EditMeasurePage.measureDeveloperDrpDwn).find('.MuiChip-label').should('contain.text', QDMstewardDev)
 
         //Confirm Guidance
         cy.get(EditMeasurePage.leftPanelGuidance).click()
@@ -245,7 +256,9 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
 
         //Confirm Clinical Recommendation
         cy.get(EditMeasurePage.leftPanelMClinicalGuidanceRecommendation).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should('have.html', '<p>' + QDMclinicalRecommendation + '</p>')
+        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).should(
+            'have.html',
+            '<p>' + QDMclinicalRecommendation + '</p>'
+        )
     })
 })
-

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore411.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore411.cy.ts
@@ -1,14 +1,14 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let measureCQLPFTests = MeasureCQL.CQL_Populations
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 let measureQICore = ''
@@ -20,9 +20,7 @@ let QiCoreCqlLibraryNameAlt = ''
 
 //Utilizing Qi Core 4.1.1
 describe('Measure Association: Validations using Qi Core 4.1.1', () => {
-
     beforeEach('Create Measure', () => {
-
         //Create New QDM Measure
         measureQDM = 'QDMMeasure' + Date.now() + randValue + 8 + randValue
 
@@ -37,8 +35,16 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create Second QDM Measure
         measureQDM2 = 'QDMMeasure2' + Date.now() + randValue + 6 + randValue
@@ -55,56 +61,66 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure2)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(2, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            2,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create new QI Core measure
         measureQICore = 'QICoreMeasure' + Date.now() + randValue + 4 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore, measureQICore, measureCQLPFTests, 3)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(3, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            3,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
 
         //Create second QI Core measure
         measureQICore2 = 'QICoreMeasure2' + Date.now() + randValue + 2 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore2, measureQICore2, measureCQLPFTests, 4)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(4, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            4,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
 
         OktaLogin.Login()
 
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 15500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 15500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 3)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 15500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 4)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 15500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
@@ -127,7 +143,11 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'Must select one QDM and one QI-Core measure')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Must select one QDM and one QI-Core measure'
+        )
 
         MeasuresPage.selectMeasure(4)
 
@@ -136,7 +156,11 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'QDM measure must contain a CMS ID')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'QDM measure must contain a CMS ID'
+        )
 
         MeasuresPage.selectMeasure(3)
 
@@ -151,7 +175,10 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         Utilities.waitForElementVisible(MeasuresPage.versionToastSuccessMsg, 30000)
-        cy.get(MeasuresPage.versionToastSuccessMsg).should('contain.text', 'New version of measure is Successfully created')
+        cy.get(MeasuresPage.versionToastSuccessMsg).should(
+            'contain.text',
+            'New version of measure is Successfully created'
+        )
         Utilities.waitForElementToNotExist(MeasuresPage.versionToastSuccessMsg, 30000)
 
         MeasuresPage.selectMeasure(2)
@@ -159,7 +186,11 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'QI-Core measure must be in a draft status')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'QI-Core measure must be in a draft status'
+        )
 
         MeasuresPage.selectMeasure(4)
 
@@ -189,7 +220,11 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'QI-Core measure must NOT contain a CMS ID')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'QI-Core measure must NOT contain a CMS ID'
+        )
 
         MeasuresPage.selectMeasure(3)
 
@@ -200,8 +235,24 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         OktaLogin.UILogout()
 
         //validation test: both measures the user is not the owner of
-        CreateMeasurePage.CreateQICoreMeasureAPI(QiCoreMeasureNameAlt, QiCoreCqlLibraryNameAlt, measureCQLPFTests, 5, true)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(5, true, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            QiCoreMeasureNameAlt,
+            QiCoreCqlLibraryNameAlt,
+            measureCQLPFTests,
+            5,
+            true
+        )
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            5,
+            true,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
 
         OktaLogin.AltLogin()
         MeasuresPage.actionCenter('edit', 5, { altUser: true })
@@ -220,22 +271,42 @@ describe('Measure Association: Validations using Qi Core 4.1.1', () => {
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
 
         // need altUser here, they are the measure owner
-        cy.readFile('cypress/fixtures/' + currentAltUser + '/measureId5').should('exist').then((measureId) => {
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView()
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').click()
-        })
+        cy.readFile('cypress/fixtures/' + currentAltUser + '/measureId5')
+            .should('exist')
+            .then((measureId) => {
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .click()
+            })
 
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2').should('exist').then((measureId) => {
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView()
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').click()
-        })
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2')
+            .should('exist')
+            .then((measureId) => {
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + measureId + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .click()
+            })
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'Must own both selected measures')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Must own both selected measures'
+        )
     })
 })

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore600.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationValidationsQiCore600.cy.ts
@@ -1,17 +1,17 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage, SupportedModels, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage, SupportedModels, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
 
 const measureData: CreateMeasureOptions = {
     measureCql: MeasureCQL.CQL_BoneDensity_Proportion_Boolean
 }
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 let measureQICore = ''
 let measureQICore2 = ''
@@ -20,9 +20,7 @@ let measureQDM2 = ''
 
 //Utilizing Qi Core 6.0.0
 describe('Measure Association: Validations using Qi Core 6.0.0', () => {
-
     beforeEach('Create Measure', () => {
-
         //Create New QDM Measure
         measureQDM = 'QDMMeasure4QiCore600' + Date.now() + randValue + 8 + randValue
 
@@ -37,8 +35,16 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create Second QDM Measure
         measureQDM2 = 'QDMMeasure24QiCore600' + Date.now() + randValue + 6 + randValue
@@ -55,8 +61,16 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure2)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(2, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            2,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create new QI Core 6.0.0 measure
         measureQICore = 'QICore600Measure' + Date.now() + randValue + 4 + randValue
@@ -75,38 +89,22 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         OktaLogin.Login()
 
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 30000)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 30000)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 3)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 30000)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 4)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 30000)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
@@ -134,17 +132,25 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'Must select one QDM and one QI-Core measure')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Must select one QDM and one QI-Core measure'
+        )
 
         //validation test: QDM measure must contain CMS id
         MeasuresPage.selectMeasure(4)
 
         MeasuresPage.selectMeasure()
- 
+
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'QDM measure must contain a CMS ID')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'QDM measure must contain a CMS ID'
+        )
 
         MeasuresPage.selectMeasure(3)
 
@@ -159,7 +165,10 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).should('be.visible')
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
         Utilities.waitForElementVisible(MeasuresPage.versionToastSuccessMsg, 30000)
-        cy.get(MeasuresPage.versionToastSuccessMsg).should('contain.text', 'New version of measure is Successfully created')
+        cy.get(MeasuresPage.versionToastSuccessMsg).should(
+            'contain.text',
+            'New version of measure is Successfully created'
+        )
         Utilities.waitForElementToNotExist(MeasuresPage.versionToastSuccessMsg, 30000)
 
         MeasuresPage.selectMeasure(2)
@@ -167,7 +176,11 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'QI-Core measure must be in a draft status')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'QI-Core measure must be in a draft status'
+        )
 
         MeasuresPage.selectMeasure(4)
 
@@ -197,7 +210,11 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'QI-Core measure must NOT contain a CMS ID')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'QI-Core measure must NOT contain a CMS ID'
+        )
 
         MeasuresPage.selectMeasure(3)
 
@@ -226,22 +243,35 @@ describe('Measure Association: Validations using Qi Core 6.0.0', () => {
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
 
         // need altUser here, they are the measure owner for 5
-        cy.readFile('cypress/fixtures/' + currentAltUser + '/measureId5').then(measureId => {
-
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView()
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').click()
+        cy.readFile('cypress/fixtures/' + currentAltUser + '/measureId5').then((measureId) => {
+            cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                .find('[class="px-1"]')
+                .find('[class=" cursor-pointer"]')
+                .scrollIntoView()
+            cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                .find('[class="px-1"]')
+                .find('[class=" cursor-pointer"]')
+                .click()
         })
 
-       cy.readFile('cypress/fixtures/' + currentUser + '/measureId2').then(measureId => {
-
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView()
-            cy.get('[data-testid="measure-name-' + measureId + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').click()
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2').then((measureId) => {
+            cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                .find('[class="px-1"]')
+                .find('[class=" cursor-pointer"]')
+                .scrollIntoView()
+            cy.get('[data-testid="measure-name-' + measureId + '_select"]')
+                .find('[class="px-1"]')
+                .find('[class=" cursor-pointer"]')
+                .click()
         })
 
         cy.get('[data-testid="associate-cms-id-action-btn"]').scrollIntoView()
         cy.get('[data-testid="associate-cms-id-action-btn"]').trigger('mouseover', { force: true })
         cy.get('[data-testid="associate-cms-id-tooltip"]').should('be.visible')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'Must own both selected measures')
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Must own both selected measures'
+        )
     })
 })
-

--- a/cypress/e2e/WebInterface/Measure/MeasureTransfer/AdminMeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureTransfer/AdminMeasureTransfer.cy.ts
@@ -1,12 +1,12 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Header } from "../../../../Shared/Header"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { EditMeasureActions, EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Header } from '../../../../Shared/Header'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { EditMeasureActions, EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
 
 const now = Date.now()
 const measureName = 'MeasureTransfer' + now
@@ -15,26 +15,19 @@ const measureCQL = MeasureCQL.SBTEST_CQL
 let harpUserALT = ''
 
 describe('Measure Transfer performed by Admin user', () => {
-
     beforeEach('Create Measure', () => {
-
         harpUserALT = OktaLogin.getUser(true)
 
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+
         cy.get(Header.mainMadiePageButton).click()
     })
 
     it('Admin user can transfer a Measure owned by other users', () => {
-
         OktaLogin.AdminLogin()
 
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 30000)
@@ -46,15 +39,20 @@ describe('Measure Transfer performed by Admin user', () => {
         // added for https://jira.cms.gov/browse/MAT-9627
         cy.get(MeasuresPage.newOwnerTextbox).type('notAnActualUser')
         cy.get(MeasuresPage.transferContinueButton).click()
-        cy.get(MeasuresPage.newOwnerErrorText).should('contain.text', 'The provided HARP ID is not associated with an active MADiE user.')
-       
+        cy.get(MeasuresPage.newOwnerErrorText).should(
+            'contain.text',
+            'The provided HARP ID is not associated with an active MADiE user.'
+        )
 
         cy.get(MeasuresPage.newOwnerTextbox).clear().type(harpUserALT)
         cy.get('[data-testid="retainShareAccess"]').click()
         cy.get(MeasuresPage.transferContinueButton).click()
-        
+
         // Verify success toast
-        cy.get('[data-testid="toast-success"]', { timeout: 5500 }).should('contain.text', 'The measure(s) were successfully transferred. If you chose to retain share access, you will still be able to edit the measures.')
+        cy.get('[data-testid="toast-success"]', { timeout: 5500 }).should(
+            'contain.text',
+            'The measure(s) were successfully transferred. If you chose to retain share access, you will still be able to edit the measures.'
+        )
 
         OktaLogin.AltLogin()
 
@@ -65,19 +63,26 @@ describe('Measure Transfer performed by Admin user', () => {
 
         MeasuresPage.actionCenter('edit')
 
-        cy.readFile('cypress/fixtures/accountRealNames.json').should('exist').then((nameData) => {
-
-            // verify altUser name as owner
-            const owner = nameData[harpUserALT]
-            cy.get('[data-testid="measure-owner-text-field"]').should('contain.text', owner)
-        })
+        cy.readFile('cypress/fixtures/accountRealNames.json')
+            .should('exist')
+            .then((nameData) => {
+                // verify altUser name as owner
+                const owner = nameData[harpUserALT]
+                cy.get('[data-testid="measure-owner-text-field"]').should('contain.text', owner)
+            })
 
         EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
 
-         // show history, verify event messages
+        // show history, verify event messages
         cy.get('[data-testid="measure-history-cell-0_actionType"]').should('contain.text', 'SHARED')
-        cy.get('[data-testid="measure-history-cell-0_additionalActionMessage"]').should('contain.text', 'by MADiE Admin')
+        cy.get('[data-testid="measure-history-cell-0_additionalActionMessage"]').should(
+            'contain.text',
+            'by MADiE Admin'
+        )
         cy.get('[data-testid="measure-history-cell-1_actionType"]').should('contain.text', 'OWNERSHIP_TRANSFER')
-        cy.get('[data-testid="measure-history-cell-1_additionalActionMessage"]').should('contain.text', 'by MADiE Admin')
+        cy.get('[data-testid="measure-history-cell-1_additionalActionMessage"]').should(
+            'contain.text',
+            'by MADiE Admin'
+        )
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCodeSearch.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM CQL Editor/QDMCodeSearch.cy.ts
@@ -1,16 +1,17 @@
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
 
 const date = Date.now()
 let measureName = 'QDMCodeSearch' + date
 let CqlLibraryName = 'QDMCodeSearchLib' + date
-let measureCQL = 'library TestLibrary1685544523170534 version \'0.0.000\'\n' +
-    'using QDM version \'5.6\'\n\n' +
+let measureCQL =
+    "library TestLibrary1685544523170534 version '0.0.000'\n" +
+    "using QDM version '5.6'\n\n" +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
     'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
@@ -31,9 +32,10 @@ let measureCQL = 'library TestLibrary1685544523170534 version \'0.0.000\'\n' +
     '\t true\n' +
     'define "n":\n' +
     '\ttrue'
-let measureCQL_withCode = 'library QDMLibrary1724174199255 version \'0.0.000\'\n' +
-    'using QDM version \'5.6\'\n' +
-    'include MATGlobalCommonFunctionsQDM version \'8.0.000\' called Common\n\n' +
+let measureCQL_withCode =
+    "library QDMLibrary1724174199255 version '0.0.000'\n" +
+    "using QDM version '5.6'\n" +
+    "include MATGlobalCommonFunctionsQDM version '8.0.000' called Common\n\n" +
     'codesystem "CPT": \'urn:oid:2.16.840.1.113883.6.12\'\n' +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
@@ -58,9 +60,7 @@ let measureCQL_withCode = 'library QDMLibrary1724174199255 version \'0.0.000\'\n
     '\ttrue'
 
 describe('QDM Code Search fields', () => {
-
     beforeEach('Create Measure and Login', () => {
-
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL, false)
         OktaLogin.SessionLogin()
 
@@ -75,12 +75,10 @@ describe('QDM Code Search fields', () => {
     })
 
     afterEach('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Search for the Codes', () => {
-
         //Click on Codes tab
         cy.get(CQLEditorPage.codesTab).click()
 
@@ -99,7 +97,10 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem Version258219007Stage 2 (qualifier value)SNOMEDCT20240301')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem Version258219007Stage 2 (qualifier value)SNOMEDCT20240301'
+        )
 
         //Assert when the Code is not available in VSAC
         cy.get(CQLEditorPage.codeText).clear().type('123')
@@ -121,7 +122,10 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is inactive in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem Version16298561000119108Administration of tetanus, diphtheria, and acellular pertussis vaccine (procedure)SNOMEDCT20240301')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem Version16298561000119108Administration of tetanus, diphtheria, and acellular pertussis vaccine (procedure)SNOMEDCT20240301'
+        )
         //Clear the code search values
         cy.get(CQLEditorPage.clearCodeBtn).click()
 
@@ -136,11 +140,13 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'Code status unavailable')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', '99201Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient\'s and/or family\'s needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family.CPT2024')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            "99201Office or other outpatient visit for the evaluation and management of a new patient, which requires these 3 key components: A problem focused history; A problem focused examination; Straightforward medical decision making. Counseling and/or coordination of care with other physicians, other qualified health care professionals, or agencies are provided consistent with the nature of the problem(s) and the patient's and/or family's needs. Usually, the presenting problem(s) are self limited or minor. Typically, 10 minutes are spent face-to-face with the patient and/or family.CPT2024"
+        )
     })
 
     it('Apply code to the CQL and verify under Saved Codes tab', () => {
-
         //Click on Codes tab
         cy.get(CQLEditorPage.codesTab).click()
 
@@ -155,11 +161,17 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02'
+        )
 
         //Apply code to the Measure
         cy.get(CQLEditorPage.applyCodeBtn).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code AMB has been successfully added to the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code AMB has been successfully added to the CQL.'
+        )
 
         //Save and Discard changes button should be enabled after applying the code
         cy.get(CQLEditorPage.saveCQLButton).should('be.enabled')
@@ -180,7 +192,10 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02'
+        )
         cy.get(CQLEditorPage.applyCodeBtn).click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Code AMB has already been defined in CQL.')
 
@@ -196,7 +211,6 @@ describe('QDM Code Search fields', () => {
     })
 
     it('Edit Code with Suffix and Version from Results Grid', () => {
-
         //Click on Codes tab
         cy.get(CQLEditorPage.codesTab).click()
 
@@ -211,7 +225,10 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02'
+        )
 
         //Edit code
         cy.get(CQLEditorPage.editCodeBtn).click()
@@ -226,15 +243,17 @@ describe('QDM Code Search fields', () => {
         cy.get('[data-testid="code-suffix-field-input"]').type('1234')
         cy.get('[id="include-code-system-version-checkbox"]').check()
         cy.get('[data-testid="apply-button"]').click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code AMB has been successfully added to the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code AMB has been successfully added to the CQL.'
+        )
 
         //Save CQL
         cy.get(CQLEditorPage.saveCQLButton).click()
         CQLEditorPage.validateSuccessfulCQLUpdate()
     })
 
-    it('Edit Code with Suffix and Version from Saved Codes Grid', () => {
-
+    it.only('Edit Code with Suffix and Version from Saved Codes Grid', () => {
         //Click on Codes tab
         cy.get(CQLEditorPage.codesTab).click()
 
@@ -249,11 +268,17 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02'
+        )
 
         //Apply code to the Measure
         cy.get(CQLEditorPage.applyCodeBtn).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code AMB has been successfully added to the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code AMB has been successfully added to the CQL.'
+        )
 
         //Save CQL
         cy.get(CQLEditorPage.saveCQLButton).click()
@@ -292,7 +317,6 @@ describe('QDM Code Search fields', () => {
     })
 
     it('Remove Code from Saved Codes Grid', () => {
-
         //Click on Codes tab
         cy.get(CQLEditorPage.codesTab).click()
 
@@ -307,11 +331,17 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02'
+        )
 
         //Apply code to the Measure
         cy.get(CQLEditorPage.applyCodeBtn).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code AMB has been successfully added to the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code AMB has been successfully added to the CQL.'
+        )
 
         //Save CQL
         cy.get(CQLEditorPage.saveCQLButton).click()
@@ -331,9 +361,15 @@ describe('QDM Code Search fields', () => {
 
         //Remove Code
         cy.get('[data-testid="delete-code-0"]').click()
-        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should('contain.text', 'Are you sure you want to delete AMB ambulatory?')
+        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
+            'contain.text',
+            'Are you sure you want to delete AMB ambulatory?'
+        )
         cy.get(CQLEditorPage.deleteContinueButton).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code AMB and code system ActCode has been successfully removed from the CQL')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code AMB and code system ActCode has been successfully removed from the CQL'
+        )
 
         //verify saved codes empty
         cy.get(CQLEditorPage.codesTab).click()
@@ -342,7 +378,6 @@ describe('QDM Code Search fields', () => {
     })
 
     it('Code system not removed from CQL when there are multiple codes associated with Code system and one of them removed', () => {
-
         //Click on Codes tab
         cy.get(CQLEditorPage.codesTab).click()
 
@@ -357,11 +392,17 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionAMBambulatoryActCode2023-02'
+        )
 
         //Apply code to the Measure
         cy.get(CQLEditorPage.applyCodeBtn).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code AMB has been successfully added to the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code AMB has been successfully added to the CQL.'
+        )
 
         //Add another code with the same Code system
         cy.get(CQLEditorPage.codeText).clear().type('ACUTE')
@@ -370,11 +411,17 @@ describe('QDM Code Search fields', () => {
         Utilities.waitForElementVisible(CQLEditorPage.codeSystemSearchResultsTbl, 30000)
         cy.get(CQLEditorPage.toolTip).trigger('mouseover')
         cy.get(CQLEditorPage.toolTipMsg).should('contain.text', 'This code is active in this code system version')
-        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should('contain.text', 'CodeDescriptionCode SystemSystem VersionACUTEinpatient acuteActCode2023-02')
+        cy.get(CQLEditorPage.codeSystemSearchResultsTbl).should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionACUTEinpatient acuteActCode2023-02'
+        )
 
         //Apply code to the Measure
         cy.get(CQLEditorPage.applyCodeBtn).click()
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Code ACUTE has been successfully added to the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Code ACUTE has been successfully added to the CQL.'
+        )
 
         //Save CQL
         cy.get(CQLEditorPage.saveCQLButton).click()
@@ -394,13 +441,19 @@ describe('QDM Code Search fields', () => {
 
         //Remove Code
         cy.get('[data-testid="delete-code-0"]').click()
-        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should('contain.text', 'Are you sure you want to delete AMB ambulatory?')
+        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
+            'contain.text',
+            'Are you sure you want to delete AMB ambulatory?'
+        )
         cy.get(CQLEditorPage.deleteContinueButton).click()
 
         cy.wait('@codeSystems', { timeout: 12000 })
 
         //Verify the Code System is still available in the CQL Editor
-        cy.get('[class="ace_content"]').should('contain.text', 'codesystem "ActCode": \'urn:oid:2.16.840.1.113883.5.4\'')
+        cy.get('[class="ace_content"]').should(
+            'contain.text',
+            'codesystem "ActCode": \'urn:oid:2.16.840.1.113883.5.4\''
+        )
 
         cy.get(CQLEditorPage.savedCodesTab).should('be.visible')
         cy.get(CQLEditorPage.savedCodesTab).should('be.enabled')
@@ -408,14 +461,15 @@ describe('QDM Code Search fields', () => {
 
         cy.wait('@codes', { timeout: 12000 })
 
-        cy.get('[data-testid="saved-codes-tbl"]').should('contain.text', 'CodeDescriptionCode SystemSystem VersionACUTEinpatient acuteActCode9.0.0')
+        cy.get('[data-testid="saved-codes-tbl"]').should(
+            'contain.text',
+            'CodeDescriptionCode SystemSystem VersionACUTEinpatient acuteActCode9.0.0'
+        )
     })
 })
 
 describe('Error Message on Codes tab', () => {
-
     beforeEach('Create Measure and Login', () => {
-
         CreateMeasurePage.CreateQDMMeasureAPI(measureName, CqlLibraryName, measureCQL_withCode)
         OktaLogin.SessionLogin()
 
@@ -427,12 +481,10 @@ describe('Error Message on Codes tab', () => {
     })
 
     afterEach('Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify error message appears on Codes tab when there is an error in the Measure CQL', () => {
-
         //Navigate to Codes tab and verify no error message appears
         cy.get(CQLEditorPage.codesTab).click()
         cy.get('[data-testid="cql-builder-errors"]').should('not.exist').wait(1000)
@@ -445,9 +497,12 @@ describe('Error Message on Codes tab', () => {
         Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 18500)
 
         //Navigate to Codes tab
-       // cy.get(CQLEditorPage.expandCQLBuilder).click()
+        // cy.get(CQLEditorPage.expandCQLBuilder).click()
         cy.get(CQLEditorPage.codesTab).click()
-        cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
+        cy.get('[data-testid="cql-builder-errors"]').should(
+            'contain.text',
+            'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.'
+        )
 
         //Navigate to Saved Codes tab
         cy.get(CQLEditorPage.savedCodesTab).should('contain.text', 'Saved Codes(1)').click()

--- a/cypress/e2e/WebInterface/Measure/QDM Measure Version/MeasureVersionValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDM Measure Version/MeasureVersionValidations.cy.ts
@@ -1,13 +1,13 @@
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { CreateMeasureOptions, CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { Header } from "../../../../Shared/Header"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { TestCaseAction, TestCasesPage } from "../../../../Shared/TestCasesPage"
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { CreateMeasureOptions, CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { Header } from '../../../../Shared/Header'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { TestCaseAction, TestCasesPage } from '../../../../Shared/TestCasesPage'
 
 let measureName = 'QDMMeasureVV' + Date.now()
 let cqlLibraryName = 'QDMMeasureVVLib' + Date.now()
@@ -18,47 +18,49 @@ const testCaseDescription = 'DENOMFail' + Date.now()
 const testCaseSeries = 'SBTestSeries'
 
 function generateQDMCQLWithErrors(libraryName: string): string {
-    return 'library ' + libraryName + ' version \'0.0.000\'\n' +
-    'using QDM version \'5.6\'\n\n' +
-    'include MATGlobalCommonFunctionsQDM version \'1.0.000\' called Global\n\n' +
-    'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\'\n\n' +
-    'valueset "Acute care hospital Inpatient Encounter": \'urn:oid:2.16.840.1.113883.3.666.5.2289\'\n' +
-    'valueset "Bicarbonate lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.139\'\n' +
-    'valueset "Body temperature": \'urn:oid:2.16.840.1.113762.1.4.1045.152\'\n' +
-    'valueset "Body weight": \'urn:oid:2.16.840.1.113762.1.4.1045.159\'\n' +
-    'valueset "Creatinine lab test": \'urn:oid:2.16.840.1.113883.3.666.5.2363\'\n' +
-    'valueset "Emergency Department Visit": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.292\'\n' +
-    'valueset "Encounter Inpatient": \'urn:oid:2.16.840.1.113883.3.666.5.307\'\n' +
-    'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
-    'valueset "Glucose lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.134\'\n' +
-    'valueset "Heart Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.149\'\n' +
-    'valueset "Hematocrit lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.114\'\n' +
-    'valueset "Medicare Advantage payer": \'urn:oid:2.16.840.1.113762.1.4.1104.12\'\n' +
-    'valueset "Medicare FFS payer": \'urn:oid:2.16.840.1.113762.1.4.1104.10\'\n' +
-    'valueset "Observation Services": \'urn:oid:2.16.840.1.113762.1.4.1111.143\'\n' +
-    'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
-    'valueset "Oxygen Saturation by Pulse Oximetry": \'urn:oid:2.16.840.1.113762.1.4.1045.151\'\n' +
-    'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
-    'valueset "Potassium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.117\'\n' +
-    'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
-    'valueset "Respiratory Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.130\'\n' +
-    'valueset "Sodium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.119\'\n' +
-    'valueset "Systolic Blood Pressure": \'urn:oid:2.16.840.1.113762.1.4.1045.163\'\n' +
-    'valueset "White blood cells count lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.129\'\n\n' +
-    'code "Birth date": \'21112-8\' from "LOINC" display \'Birth date\'\n\n' +
-    'parameter "Measurement Period" Interval<DateTime>\n\n' +
-    'context Patient\n\n' +
-    'define "Initial Population":\'\'\n' +
-    '\t  \'Inpatient Encounters\'\n'
+    return (
+        'library ' +
+        libraryName +
+        " version '0.0.000'\n" +
+        "using QDM version '5.6'\n\n" +
+        "include MATGlobalCommonFunctionsQDM version '1.0.000' called Global\n\n" +
+        'codesystem "LOINC": \'urn:oid:2.16.840.1.113883.6.1\'\n\n' +
+        'valueset "Acute care hospital Inpatient Encounter": \'urn:oid:2.16.840.1.113883.3.666.5.2289\'\n' +
+        'valueset "Bicarbonate lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.139\'\n' +
+        'valueset "Body temperature": \'urn:oid:2.16.840.1.113762.1.4.1045.152\'\n' +
+        'valueset "Body weight": \'urn:oid:2.16.840.1.113762.1.4.1045.159\'\n' +
+        'valueset "Creatinine lab test": \'urn:oid:2.16.840.1.113883.3.666.5.2363\'\n' +
+        'valueset "Emergency Department Visit": \'urn:oid:2.16.840.1.113883.3.117.1.7.1.292\'\n' +
+        'valueset "Encounter Inpatient": \'urn:oid:2.16.840.1.113883.3.666.5.307\'\n' +
+        'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
+        'valueset "Glucose lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.134\'\n' +
+        'valueset "Heart Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.149\'\n' +
+        'valueset "Hematocrit lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.114\'\n' +
+        'valueset "Medicare Advantage payer": \'urn:oid:2.16.840.1.113762.1.4.1104.12\'\n' +
+        'valueset "Medicare FFS payer": \'urn:oid:2.16.840.1.113762.1.4.1104.10\'\n' +
+        'valueset "Observation Services": \'urn:oid:2.16.840.1.113762.1.4.1111.143\'\n' +
+        'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
+        'valueset "Oxygen Saturation by Pulse Oximetry": \'urn:oid:2.16.840.1.113762.1.4.1045.151\'\n' +
+        'valueset "Payer": \'urn:oid:2.16.840.1.114222.4.11.3591\'\n' +
+        'valueset "Potassium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.117\'\n' +
+        'valueset "Race": \'urn:oid:2.16.840.1.114222.4.11.836\'\n' +
+        'valueset "Respiratory Rate": \'urn:oid:2.16.840.1.113762.1.4.1045.130\'\n' +
+        'valueset "Sodium lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.119\'\n' +
+        'valueset "Systolic Blood Pressure": \'urn:oid:2.16.840.1.113762.1.4.1045.163\'\n' +
+        'valueset "White blood cells count lab test": \'urn:oid:2.16.840.1.113762.1.4.1045.129\'\n\n' +
+        'code "Birth date": \'21112-8\' from "LOINC" display \'Birth date\'\n\n' +
+        'parameter "Measurement Period" Interval<DateTime>\n\n' +
+        'context Patient\n\n' +
+        'define "Initial Population":\'\'\n' +
+        "\t  'Inpatient Encounters'\n"
+    )
 }
 
 const measureData: CreateMeasureOptions = {}
 
 describe('Measure Versioning validations', () => {
-
     beforeEach('Create Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 2000) + 3))
+        let randValue = Math.floor(Math.random() * 2000 + 3)
         measureName = 'TestMeasureA' + Date.now() + randValue
         cqlLibraryName = 'TestCqlA' + Date.now() + randValue
         measureData.ecqmTitle = measureName
@@ -69,20 +71,14 @@ describe('Measure Versioning validations', () => {
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     afterEach('Logout and Clean up', () => {
-
-        
         Utilities.deleteMeasure()
     })
 
     it('User can not version Measure if there is no CQL', () => {
-
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('version')
 
@@ -95,11 +91,13 @@ describe('Measure Versioning validations', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
 
         cy.get('[data-testid="toast-danger"]').should('contain.text', 'Requested measure cannot be versioned')
-        cy.get(MeasuresPage.measureVersionHelperText).should('contain.text', 'Please include valid CQL in the CQL editor to version before versioning this measure')
+        cy.get(MeasuresPage.measureVersionHelperText).should(
+            'contain.text',
+            'Please include valid CQL in the CQL editor to version before versioning this measure'
+        )
     })
 
     it('User can not Version if the Measure CQL has errors', () => {
-
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
 
@@ -126,11 +124,13 @@ describe('Measure Versioning validations', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
 
         cy.get('[data-testid="toast-danger"]').should('contain.text', 'Requested measure cannot be versioned')
-        cy.get(MeasuresPage.measureVersionHelperText).should('contain.text', 'Please include valid CQL in the CQL editor to version before versioning this measure')
+        cy.get(MeasuresPage.measureVersionHelperText).should(
+            'contain.text',
+            'Please include valid CQL in the CQL editor to version before versioning this measure'
+        )
     })
 
     it('Error message on popup screen when the confirmed version number does not match new version number', () => {
-
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
 
@@ -149,15 +149,16 @@ describe('Measure Versioning validations', () => {
         cy.get(MeasuresPage.measureVersionMajor).click().wait(1000)
         cy.get(MeasuresPage.confirmMeasureVersionNumber).type('3.0.000')
         cy.get('[id="current-version"]').eq(0).click()
-        cy.get('[data-testid="confirm-version-helper-text"]').should('contain.text', 'Confirmed Version number must match new version number.')
+        cy.get('[data-testid="confirm-version-helper-text"]').should(
+            'contain.text',
+            'Confirmed Version number must match new version number.'
+        )
     })
 })
 
 describe('Create Test case for QDM Versioned Measure', () => {
-
     beforeEach('Create Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         let newMeasureName = measureName + randValue
         let newCqlLibraryName = cqlLibraryName + randValue
 
@@ -171,20 +172,14 @@ describe('Create Test case for QDM Versioned Measure', () => {
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     afterEach('Logout and Clean up', () => {
-
-        
         Utilities.deleteVersionedMeasure(measureName, cqlLibraryName)
     })
 
     it('Measure owner able to Add, Clone and Import Test cases to QDM Versioned Measure', () => {
-
         //Version the Measure
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('version')
@@ -202,16 +197,12 @@ describe('Create Test case for QDM Versioned Measure', () => {
         TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterClone).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test case cloned successfully')
-
-
     })
 })
 
 describe('Edit Test case for QDM Versioned Measure', () => {
-
     beforeEach('Create Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         let newMeasureName = measureName + randValue
         let newCqlLibraryName = cqlLibraryName + randValue
 
@@ -226,20 +217,15 @@ describe('Edit Test case for QDM Versioned Measure', () => {
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     afterEach('Logout and Clean up', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteVersionedMeasure()
     })
 
     it('Measure owner able to Edit Test case on a QDM Versioned Measure, that was created before Versioning', () => {
-
         //Version the Measure
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('version')
@@ -262,11 +248,9 @@ describe('Edit Test case for QDM Versioned Measure', () => {
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test Case Updated Successfully')
-
     })
 
     it('Measure owner unable to Delete Test case on a QDM Versioned Measure, that was created before Versioning', () => {
-
         //Version the Measure
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('version')
@@ -286,11 +270,14 @@ describe('Edit Test case for QDM Versioned Measure', () => {
         TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterDelete).should('not.be.enabled')
         cy.get('[data-testid="delete-disabled-tooltip"]').trigger('mouseover')
-        cy.get('[data-testid="delete-disabled-tooltip"]').should('have.attr', 'aria-label', 'Test cases present at versioning can\'t be deleted; only newly added ones can.')
+        cy.get('[data-testid="delete-disabled-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            "Test cases present at versioning can't be deleted; only newly added ones can."
+        )
     })
 
     it('Measure owner able to Delete Test case on a QDM Versioned Measure, that was created after Versioning', () => {
-
         //Version the Measure
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('version')
@@ -312,10 +299,8 @@ describe('Edit Test case for QDM Versioned Measure', () => {
 })
 
 describe('Non Measure owner unable to create Version', () => {
-
     before('Create Measure with regular user and Login as Alt user', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         let newMeasureName = measureName + randValue
         let newCqlLibraryName = cqlLibraryName + randValue
 
@@ -332,21 +317,16 @@ describe('Non Measure owner unable to create Version', () => {
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
         cy.clearCookies()
         cy.clearLocalStorage()
         cy.setAccessTokenCookie()
 
-        
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         OktaLogin.AltLogin()
     })
 
     after('Logout and Clean up', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
@@ -359,14 +339,20 @@ describe('Non Measure owner unable to create Version', () => {
         //Navigate to All Measures tab
         cy.get(MeasuresPage.allMeasuresTab).click()
 
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
-            cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.visible')
-            cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.enabled')
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.visible')
+                cy.get('[data-testid=measure-action-' + fileContents + ']').should('be.enabled')
 
-            //Verify version button is not visible
-            cy.get('[data-testid=create-version-measure-' + fileContents + ']').should('not.exist')
-            cy.get('[data-testid=measure-action-' + fileContents + ']').click()
-        })
+                //Verify version button is not visible
+                cy.get('[data-testid=create-version-measure-' + fileContents + ']').should('not.exist')
+                cy.get('[data-testid=measure-action-' + fileContents + ']').click()
+            })
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/ExportQDMMeasureWithInfo.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/ExportQDMMeasureWithInfo.cy.ts
@@ -1,12 +1,12 @@
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import {CreateMeasureOptions, CreateMeasurePage} from "../../../../Shared/CreateMeasurePage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { QdmCql } from "../../../../Shared/QDMMeasuresCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { MeasureActionOptions, MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { Header } from "../../../../Shared/Header"
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { CreateMeasureOptions, CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { QdmCql } from '../../../../Shared/QDMMeasuresCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { MeasureActionOptions, MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { Header } from '../../../../Shared/Header'
 
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
@@ -16,7 +16,6 @@ const qdmMeasureCQL = QdmCql.severeObstetricComplications
 const measureData: CreateMeasureOptions = {}
 
 describe('Successful QDM Measure Export with Info', () => {
-
     const exportOptions: MeasureActionOptions = {
         exportForPublish: false
     }
@@ -26,7 +25,6 @@ describe('Successful QDM Measure Export with Info', () => {
     deleteDownloadsFolderBeforeAll()
 
     before('Create New Measure and Login', () => {
-
         measureData.ecqmTitle = qdmMeasureName
         measureData.cqlLibraryName = qdmCqlLibraryName
         measureData.measureScoring = 'Proportion'
@@ -34,45 +32,45 @@ describe('Successful QDM Measure Export with Info', () => {
         measureData.measureCql = qdmMeasureCQL
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population',
-            '', '', 'Numerator 1 Delivery Encounters With Severe Obstetric Complications', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Numerator 1 Delivery Encounters With Severe Obstetric Complications',
+            '',
+            'Denominator'
+        )
 
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 16500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('export', undefined, exportOptions)
-        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', {timeout: 5500})
+        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', { timeout: 5500 })
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', {zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder})
-            .then(results => {
-                cy.log('unzipFile Task finished')
-                cy.wait(1000)
-            })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder }).then((results) => {
+            cy.log('unzipFile Task finished')
+            cy.wait(1000)
+        })
     })
 
     after('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Validate CQL info appears as annotations on the library JSON', () => {
-
         const elmFile = path.join(downloadsFolder, 'resources', qdmCqlLibraryName + '-0.0.000.json')
-        
-        cy.readFile(elmFile).then(fileContents => {
 
+        cy.readFile(elmFile).then((fileContents) => {
             // remove other types of warnings/info
-            const warnings = fileContents.library.annotation.filter(obj => {
+            const warnings = fileContents.library.annotation.filter((obj) => {
                 return obj.errorSeverity === 'warning' && obj.type === 'CqlToElmError'
             })
             // assert exact number of warnings we expect
@@ -82,7 +80,6 @@ describe('Successful QDM Measure Export with Info', () => {
 })
 
 describe('Successful QDM Measure Export for Publish', () => {
-
     const exportOptions: MeasureActionOptions = {
         exportForPublish: true
     }
@@ -92,7 +89,6 @@ describe('Successful QDM Measure Export for Publish', () => {
     deleteDownloadsFolderBeforeAll()
 
     before('Create New Measure and Login', () => {
-
         measureData.ecqmTitle = qdmMeasureName
         measureData.cqlLibraryName = qdmCqlLibraryName
         measureData.measureScoring = 'Proportion'
@@ -100,46 +96,46 @@ describe('Successful QDM Measure Export for Publish', () => {
         measureData.measureCql = qdmMeasureCQL
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population',
-            '', '', 'Numerator 1 Delivery Encounters With Severe Obstetric Complications', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Numerator 1 Delivery Encounters With Severe Obstetric Complications',
+            '',
+            'Denominator'
+        )
 
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 16500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('export', undefined, exportOptions)
-        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', {timeout: 5500})
+        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', { timeout: 5500 })
         cy.log('Successfully verified zip file export')
 
-        cy.task('unzipFile', {zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder})
-            .then(results => {
-                cy.log('unzipFile Task finished')
-                cy.wait(1000)
-            })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder }).then((results) => {
+            cy.log('unzipFile Task finished')
+            cy.wait(1000)
+        })
     })
 
     after('Clean up and Logout', () => {
-
         Utilities.deleteMeasure(qdmMeasureName, qdmCqlLibraryName)
     })
 
     it('Validate CQL info DOES NOT appear as annotations on the library JSON', () => {
-
         const elmFile = path.join(downloadsFolder, 'resources', qdmCqlLibraryName + '-0.0.000.json')
-        
-        cy.readFile(elmFile).then(fileContents => {
 
+        cy.readFile(elmFile).then((fileContents) => {
             expect(fileContents.library.annotation).to.have.length(2)
             // remove other types of warnings/info
-            const warnings = fileContents.library.annotation.filter(obj => {
+            const warnings = fileContents.library.annotation.filter((obj) => {
                 return obj.errorSeverity === 'warning' && obj.type === 'CqlToElmError'
             })
             // assert exact number of warnings we expect

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportFilesvalidation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportFilesvalidation.cy.ts
@@ -1,12 +1,12 @@
-import { CreateMeasureOptions, CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { EditMeasureActions, EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Header } from "../../../../Shared/Header"
+import { CreateMeasureOptions, CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { EditMeasureActions, EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Header } from '../../../../Shared/Header'
 
 let qdmMeasureName = 'QDMExportFiles' + Date.now()
 let qdmCqlLibraryName = 'QDMExportFilesLib' + Date.now()
@@ -28,20 +28,15 @@ const measureData: CreateMeasureOptions = {
 }
 
 describe('Verify QDM Measure Export file contents', () => {
-
     deleteDownloadsFolderBeforeAll()
 
     before('Create New Measure and Login', () => {
-
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         OktaLogin.Login()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 30000)
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         EditMeasurePage.actionCenter(EditMeasureActions.export)
 
@@ -50,28 +45,26 @@ describe('Verify QDM Measure Export file contents', () => {
         cy.log('Successfully verified zip file export')
 
         // unzipping the Measure Export
-        cy.task('unzipFile', { zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder })
-            .then(results => {
-                cy.log('unzipFile Task finished')
-            })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QDM-v0.0.000-QDM.zip', path: downloadsFolder }).then((results) => {
+            cy.log('unzipFile Task finished')
+        })
     })
 
     after('Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify files, their types and the contents of the HR file, for QDM Measure', () => {
-
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QDM-v0.0.000-QDM.html')).should('exist')
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QDM-v0.0.000-QDM.xml')).should('exist')
         cy.readFile(path.join(downloadsFolder, 'cql/MATGlobalCommonFunctionsQDM-1.0.000.cql')).should('exist')
-        cy.readFile(path.join(downloadsFolder, 'resources/MATGlobalCommonFunctionsQDM-1.0.000.json'), null).should('exist')
+        cy.readFile(path.join(downloadsFolder, 'resources/MATGlobalCommonFunctionsQDM-1.0.000.json'), null).should(
+            'exist'
+        )
         cy.readFile(path.join(downloadsFolder, 'resources/MATGlobalCommonFunctionsQDM-1.0.000.xml')).should('exist')
     })
 
     it('Verify content of the XML / HQMF file, for a QDM Measure', () => {
-
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QDM-v0.0.000-QDM.xml')).then((xmlData) => {
             cy.task('parseXML', xmlData).then((result: any) => {
                 const textValue = result['QualityMeasureDocument']['text'][0]['$']['value']
@@ -82,11 +75,9 @@ describe('Verify QDM Measure Export file contents', () => {
 })
 
 describe('QDM Measure Export, Not the Owner', () => {
-
     deleteDownloadsFolderBeforeAll()
 
     before('Create New Measure and Login', () => {
-
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         OktaLogin.Login()
@@ -97,18 +88,16 @@ describe('QDM Measure Export, Not the Owner', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         OktaLogin.UILogout()
-        
+
         OktaLogin.AltLogin()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
     })
 
     after('Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Non Measure owner able to Export QDM Measure', () => {
-
         //Navigate to All Measures tab
         cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
         cy.get(MeasuresPage.allMeasuresTab).click()
@@ -122,11 +111,9 @@ describe('QDM Measure Export, Not the Owner', () => {
 })
 
 describe('Successful QDM Measure Export with versioned measure', () => {
-
     deleteDownloadsFolderBeforeAll()
 
     before('Create New Measure and Login', () => {
-
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
         OktaLogin.Login()
@@ -141,7 +128,7 @@ describe('Successful QDM Measure Export with versioned measure', () => {
 
         cy.get(Header.mainMadiePageButton).click()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
-         
+
         MeasuresPage.validateVersionNumber(versionNumber)
         cy.log('Major Version Created Successfully')
 
@@ -152,14 +139,12 @@ describe('Successful QDM Measure Export with versioned measure', () => {
         cy.log('Successfully verified zip file export')
 
         // unzipping the Measure Export
-        cy.task('unzipFile', { zipFile: 'eCQMTitle4QDM-v1.0.000-QDM.zip', path: downloadsFolder })
-            .then(results => {
-                cy.log('unzipFile Task finished')
-            })
+        cy.task('unzipFile', { zipFile: 'eCQMTitle4QDM-v1.0.000-QDM.zip', path: downloadsFolder }).then((results) => {
+            cy.log('unzipFile Task finished')
+        })
     })
 
     it('Version measure, unzip the downloaded file, and verify file contents for the HR, for QDM Measure', () => {
-
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QDM-v1.0.000-QDM.html')).should('exist')
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QDM-v1.0.000-QDM.xml')).should('exist')
         cy.readFile(path.join(downloadsFolder, 'cql/MATGlobalCommonFunctionsQDM-1.0.000.cql')).should('exist')
@@ -167,5 +152,3 @@ describe('Successful QDM Measure Export with versioned measure', () => {
         cy.readFile(path.join(downloadsFolder, 'resources/MATGlobalCommonFunctionsQDM-1.0.000.xml')).should('exist')
     })
 })
-
-

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportValidations.cy.ts
@@ -1,21 +1,22 @@
-import { CreateMeasurePage, SupportedModels, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Header } from "../../../../Shared/Header"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { CreateMeasurePage, SupportedModels, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Header } from '../../../../Shared/Header'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
 
 let measureName = 'QDMExportValidations' + Date.now()
 let CqlLibraryName = 'QDMExportValidationsLib' + Date.now()
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let newMeasureName = ''
 let newCqlLibraryName = ''
 let qdmMeasureCQL = MeasureCQL.CQLQDMObservationRun
-let updatedMeasureCQL = 'library TestLibrary1685544523170534 version \'0.0.000\'\n' +
-    'using QDM version \'5.6\'\n' +
+let updatedMeasureCQL =
+    "library TestLibrary1685544523170534 version '0.0.000'\n" +
+    "using QDM version '5.6'\n" +
     '\n' +
     'valueset "Ethnicity": \'urn:oid:2.16.840.1.114222.4.11.837\'\n' +
     'valueset "ONC Administrative Sex": \'urn:oid:2.16.840.1.113762.1.4.1\'\n' +
@@ -47,15 +48,13 @@ const measureData: CreateMeasureOptions = {
     patientBasis: 'false'
 }
 
-    /*
+/*
         Tests below all involve failures of the export process.
         EditMeasurePage.actionCenter() assumes success, so we can't use it
     */
 
 describe('Error Message on Measure Export when the Measure does not have Description, Steward and Developers', () => {
-
     before('Create New Measure and Login', () => {
-
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -69,17 +68,10 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
         MeasureGroupPage.CreateCohortMeasureGroupWithoutTypeAPI(false, false, 'Initial Population', 'Encounter')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     after('Cleanup', () => {
-
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName)
     })
 
@@ -88,26 +80,36 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
         //return to measures list
         cy.get(Header.measures).click()
 
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
-            cy.get('[data-testid="export-action-btn"]').should('be.visible')
-            cy.get('[data-testid="export-action-btn"]').should('be.enabled')
-            cy.get('[data-testid="export-action-btn"]').click()
-            cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid="export-action-btn"]').should('be.visible')
+                cy.get('[data-testid="export-action-btn"]').should('be.enabled')
+                cy.get('[data-testid="export-action-btn"]').click()
+                cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
 
-            cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
-            cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'Missing Measure Developers')
-            cy.get('[class="error-message"] > ul > :nth-child(2)').should('contain.text', 'Missing Steward')
-            cy.get('[class="error-message"] > ul > :nth-child(3)').should('contain.text', 'Missing Description')
-            cy.get('[class="error-message"] > ul > :nth-child(4)').should('contain.text', 'Measure Type is required')
-        })
+                cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
+                cy.get('[class="error-message"] > ul > :nth-child(1)').should(
+                    'contain.text',
+                    'Missing Measure Developers'
+                )
+                cy.get('[class="error-message"] > ul > :nth-child(2)').should('contain.text', 'Missing Steward')
+                cy.get('[class="error-message"] > ul > :nth-child(3)').should('contain.text', 'Missing Description')
+                cy.get('[class="error-message"] > ul > :nth-child(4)').should(
+                    'contain.text',
+                    'Measure Type is required'
+                )
+            })
     })
 })
 
 describe('Error Message on Measure Export when the Measure has missing/invalid CQL', () => {
-
     beforeEach('Create New Measure and Login', () => {
-
         measureData.ecqmTitle = measureName + randValue
         measureData.cqlLibraryName = CqlLibraryName + randValue
 
@@ -118,7 +120,6 @@ describe('Error Message on Measure Export when the Measure has missing/invalid C
     })
 
     afterEach('Cleanup', () => {
-
         Utilities.deleteMeasure(measureData.ecqmTitle, measureData.cqlLibraryName)
     })
 
@@ -131,15 +132,21 @@ describe('Error Message on Measure Export when the Measure has missing/invalid C
         CQLEditorPage.validateSuccessfulCQLUpdate()
 
         cy.get(Header.measures).click()
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
-            cy.get('[data-testid="export-action-btn"]').should('be.visible')
-            cy.get('[data-testid="export-action-btn"]').should('be.enabled')
-            cy.get('[data-testid="export-action-btn"]').click()
-            cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid="export-action-btn"]').should('be.visible')
+                cy.get('[data-testid="export-action-btn"]').should('be.enabled')
+                cy.get('[data-testid="export-action-btn"]').click()
+                cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
 
-            cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
-        })
+                cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
+            })
     })
 
     it('Verify error message on Measure Export when the Measure CQL has errors', () => {
@@ -147,31 +154,40 @@ describe('Error Message on Measure Export when the Measure has missing/invalid C
         //Update Measure CQL with errors
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}' +
-            '{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}' +
-            '{downArrow}{downArrow}{downArrow}{downArrow}{backspace}{backspace}{backspace}' +
-            '{backspace}{backspace}')
+        cy.get(EditMeasurePage.cqlEditorTextBox).type(
+            '{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}' +
+                '{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}' +
+                '{downArrow}{downArrow}{downArrow}{downArrow}{backspace}{backspace}{backspace}' +
+                '{backspace}{backspace}'
+        )
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(EditMeasurePage.libWarningTopMsg).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         cy.get(Header.measures).click()
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
-            cy.get('[data-testid="export-action-btn"]').should('be.visible')
-            cy.get('[data-testid="export-action-btn"]').should('be.enabled')
-            cy.get('[data-testid="export-action-btn"]').click()
-            cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid="export-action-btn"]').should('be.visible')
+                cy.get('[data-testid="export-action-btn"]').should('be.enabled')
+                cy.get('[data-testid="export-action-btn"]').click()
+                cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
 
-            cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure')
-            cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'CQL Contains Errors')
-        })
+                cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure')
+                cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'CQL Contains Errors')
+            })
     })
 })
 
 describe('Error Message on Measure Export when the Measure does not have Population Criteria', () => {
-
     before('Create New Measure and Login', () => {
-
         measureData.ecqmTitle = measureName + randValue
         measureData.cqlLibraryName = CqlLibraryName + randValue
 
@@ -179,16 +195,10 @@ describe('Error Message on Measure Export when the Measure does not have Populat
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     after('Cleanup', () => {
-
         Utilities.deleteMeasure(measureData.ecqmTitle, measureData.cqlLibraryName)
     })
 
@@ -196,23 +206,30 @@ describe('Error Message on Measure Export when the Measure does not have Populat
         let currentUser = Cypress.env('selectedUser')
         cy.get(Header.measures).click()
 
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
-            cy.get('[data-testid="export-action-btn"]').should('be.visible')
-            cy.get('[data-testid="export-action-btn"]').should('be.enabled')
-            cy.get('[data-testid="export-action-btn"]').click()
-            cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid="export-action-btn"]').should('be.visible')
+                cy.get('[data-testid="export-action-btn"]').should('be.enabled')
+                cy.get('[data-testid="export-action-btn"]').click()
+                cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
 
-            cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
-            cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'Missing Population Criteria')
-        })
+                cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
+                cy.get('[class="error-message"] > ul > :nth-child(1)').should(
+                    'contain.text',
+                    'Missing Population Criteria'
+                )
+            })
     })
 })
 
 describe('Error Message on Measure Export when the Population Criteria does not match', () => {
-
     before('Create New Measure and Login', () => {
-
         measureData.ecqmTitle = measureName + randValue
         measureData.cqlLibraryName = CqlLibraryName + randValue
 
@@ -223,7 +240,6 @@ describe('Error Message on Measure Export when the Population Criteria does not 
     })
 
     after('Cleanup', () => {
-
         Utilities.deleteMeasure(measureData.ecqmTitle, measureData.cqlLibraryName)
     })
 
@@ -238,24 +254,35 @@ describe('Error Message on Measure Export when the Population Criteria does not 
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(EditMeasurePage.libWarningTopMsg).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(EditMeasurePage.libWarningTopMsg).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         cy.get(Header.measures).click()
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[class="px-1"]').find('[class=" cursor-pointer"]').scrollIntoView().click()
-            cy.get('[data-testid="export-action-btn"]').should('be.visible')
-            cy.get('[data-testid="export-action-btn"]').should('be.enabled')
-            cy.get('[data-testid="export-action-btn"]').click()
-            cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid="export-action-btn"]').should('be.visible')
+                cy.get('[data-testid="export-action-btn"]').should('be.enabled')
+                cy.get('[data-testid="export-action-btn"]').click()
+                cy.get(MeasuresPage.exportNonPublishingOption).should('contain.text', 'Export').click()
 
-            cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
-            cy.get('[class="error-message"] > ul > :nth-child(1)').should('contain.text', 'CQL Populations Return Types are invalid')
-        })
+                cy.get('[class="error-message"]').should('contain.text', 'Unable to Export measure.')
+                cy.get('[class="error-message"] > ul > :nth-child(1)').should(
+                    'contain.text',
+                    'CQL Populations Return Types are invalid'
+                )
+            })
     })
 })
 
 describe('Error Message on Measure Export for Publish when measure was versioned before Madie 2.2.0', () => {
-
     /* 
         this test will rely on PROD data being available in the lower environments
         this measure must have been versioned prior to Madie 2.2.0 (4/9/2025)
@@ -263,9 +290,8 @@ describe('Error Message on Measure Export for Publish when measure was versioned
         'Antithrombotic Therapy By End of Hospital Day 2FHIR'
         QiCore 4.1.1 v0.7.001
     */
-    
-    it('Verify error message when not able to perform Export for Publish', () => {
 
+    it('Verify error message when not able to perform Export for Publish', () => {
         OktaLogin.Login()
 
         cy.visit('/measures/64f0d9e456d636294b157ea0/edit/details/')
@@ -281,6 +307,9 @@ describe('Error Message on Measure Export for Publish when measure was versioned
 
         // verify error
         cy.get('.loading-title').should('contain.text', 'Your download could not be completed')
-        cy.get('.error-message').should('contain.text', 'Measure cannot be exported for publishing because it was versioned prior to MADiE version 2.2.0. Please use a newer version or select "Export" for this measure.')
+        cy.get('.error-message').should(
+            'contain.text',
+            'Measure cannot be exported for publishing because it was versioned prior to MADiE version 2.2.0. Please use a newer version or select "Export" for this measure.'
+        )
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/ViewQDMMeasureHR.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/ViewQDMMeasureHR.cy.ts
@@ -1,14 +1,14 @@
-import { CreateMeasurePage, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { Header } from "../../../../Shared/Header"
+import { CreateMeasurePage, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { Header } from '../../../../Shared/Header'
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 let measureQDM = ''
 let qdmCQLLibrary = ''
@@ -16,9 +16,7 @@ let qdmCQLLibrary = ''
 const measureData: CreateMeasureOptions = {}
 
 describe('View Human Readable for QDM Measure', () => {
-
     beforeEach(() => {
-
         const date = Date.now()
         measureQDM = 'QDMExportMeasure' + date
         qdmCQLLibrary = 'QDMTestLibrary' + Date.now() + randValue + 3 + randValue
@@ -32,28 +30,29 @@ describe('View Human Readable for QDM Measure', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(() => {
-
         Utilities.deleteMeasure(measureQDM, qdmCQLLibrary)
     })
 
     it('View Human Readable for QDM 5.6 Measure on My Measures page', () => {
-
         MeasuresPage.actionCenter('viewhr')
 
         Utilities.waitForElementVisible(EditMeasurePage.humanReadablePopup, 60000)
@@ -62,7 +61,6 @@ describe('View Human Readable for QDM Measure', () => {
     })
 
     it('View Human Readable for QDM 5.6 Measure on All Measures page', () => {
-
         cy.get(MeasuresPage.allMeasuresTab).click()
 
         MeasuresPage.actionCenter('viewhr')
@@ -73,7 +71,6 @@ describe('View Human Readable for QDM Measure', () => {
     })
 
     it('Export measure from HR modal', () => {
-
         MeasuresPage.actionCenter('viewhr')
 
         Utilities.waitForElementVisible(EditMeasurePage.humanReadablePopup, 60000)

--- a/cypress/e2e/WebInterface/Test Cases/CalculatorDates.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/CalculatorDates.cy.ts
@@ -1,13 +1,13 @@
-import { CreateMeasurePage, CreateMeasureOptions, SupportedModels } from "../../../Shared/CreateMeasurePage"
-import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
-import { TestCase, TestCasesPage } from "../../../Shared/TestCasesPage"
-import { OktaLogin } from "../../../Shared/OktaLogin"
-import { Utilities } from "../../../Shared/Utilities"
-import { MeasuresPage } from "../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
-import { TestCaseJson } from "../../../Shared/TestCaseJson"
-import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
-import { QiCore6Cql } from "../../../Shared/FHIRMeasuresCQL"
+import { CreateMeasurePage, CreateMeasureOptions, SupportedModels } from '../../../Shared/CreateMeasurePage'
+import { MeasureGroupPage } from '../../../Shared/MeasureGroupPage'
+import { TestCase, TestCasesPage } from '../../../Shared/TestCasesPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { Utilities } from '../../../Shared/Utilities'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { TestCaseJson } from '../../../Shared/TestCaseJson'
+import { CQLEditorPage } from '../../../Shared/CQLEditorPage'
+import { QiCore6Cql } from '../../../Shared/FHIRMeasuresCQL'
 const dayjs = require('dayjs')
 
 const now = Date.now()
@@ -21,16 +21,14 @@ const testCase: TestCase = {
 }
 const opts: CreateMeasureOptions = {
     // test measure based on CMS529FHIR, same config as CohortEncounter600.cy.ts
-    measureCql: QiCore6Cql.cqlCMS529, 
+    measureCql: QiCore6Cql.cqlCMS529,
     mpStartDate: '2026-01-01',
     mpEndDate: '2026-12-31'
 }
 const today = dayjs().format('MM/DD/YYYY')
 
 describe('Check all variations of calculated dates', () => {
-
     beforeEach('Create Measure and Test Case', () => {
-
         CreateMeasurePage.CreateMeasureAPI(measureName, libraryName, SupportedModels.qiCore6, opts)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population', 'Encounter')
         TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description, testCase.json)
@@ -38,12 +36,7 @@ describe('Check all variations of calculated dates', () => {
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -53,12 +46,10 @@ describe('Check all variations of calculated dates', () => {
     })
 
     afterEach('Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Check all options in Duration/Difference tab', () => {
-
         // verify initial
         cy.contains('Start Date').should('be.visible')
         cy.contains('End Date').should('be.visible')
@@ -108,7 +99,6 @@ describe('Check all variations of calculated dates', () => {
     })
 
     it('Check all options in Computed Date tab', () => {
-
         cy.get(TestCasesPage.calculatorTool.computedDateTab).click()
 
         // verify initial

--- a/cypress/e2e/WebInterface/Test Cases/CopyTestCases.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/CopyTestCases.cy.ts
@@ -1,15 +1,14 @@
-import { CreateMeasurePage, CreateMeasureOptions } from "../../../Shared/CreateMeasurePage"
-import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
-import { TestCaseAction, TestCasesPage } from "../../../Shared/TestCasesPage"
-import { OktaLogin } from "../../../Shared/OktaLogin"
-import { Utilities } from "../../../Shared/Utilities"
-import { MeasuresPage } from "../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
-import { MeasureCQL } from "../../../Shared/MeasureCQL"
-import { TestCaseJson } from "../../../Shared/TestCaseJson"
-import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
-import { Header } from "../../../Shared/Header"
-
+import { CreateMeasurePage, CreateMeasureOptions } from '../../../Shared/CreateMeasurePage'
+import { MeasureGroupPage } from '../../../Shared/MeasureGroupPage'
+import { TestCaseAction, TestCasesPage } from '../../../Shared/TestCasesPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { Utilities } from '../../../Shared/Utilities'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { TestCaseJson } from '../../../Shared/TestCaseJson'
+import { CQLEditorPage } from '../../../Shared/CQLEditorPage'
+import { Header } from '../../../Shared/Header'
 
 let measureName = 'QDMTestMeasure' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
@@ -30,10 +29,8 @@ const measureDataQDM: CreateMeasureOptions = {}
 const measureDataQDM2: CreateMeasureOptions = {}
 
 describe('Copy QDM Test Cases', () => {
-
     beforeEach('Create measure and login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 2))
+        let randValue = Math.floor(Math.random() * 1000 + 2)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -47,7 +44,15 @@ describe('Copy QDM Test Cases', () => {
         //Create QDM Measure, PC and Test Case
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureDataQDM)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp', 'boolean', 1)
-        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, undefined, false, false, 1)
+        TestCasesPage.CreateQDMTestCaseAPI(
+            testCaseTitle,
+            testCaseSeries,
+            testCaseDescription,
+            undefined,
+            false,
+            false,
+            1
+        )
 
         //Create 2nd QDM Measure
         measureDataQDM2.ecqmTitle = secondMeasureName + randValue
@@ -61,26 +66,17 @@ describe('Copy QDM Test Cases', () => {
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit', 1)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Logout', () => {
-
         OktaLogin.UILogout()
     })
 
@@ -104,51 +100,50 @@ describe('Copy QDM Test Cases', () => {
 
         //Copy Test case
         cy.get(TestCasesPage.actionCenterCopyToMeasure).click()
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').check()
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').should('be.checked')
-        })
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').check()
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').should('be.checked')
+            })
     })
 })
 
 describe('Copy Qi Core Test Cases', () => {
-
     beforeEach('Create measure and login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 5))
+        let randValue = Math.floor(Math.random() * 1000 + 5)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
         //Create Qi Core Measure, PC and Test Case
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, qiCoreMeasureCQL, 1)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne', 'boolean', 1)
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson, false, false, false, 1)
-        
+        TestCasesPage.CreateTestCaseAPI(
+            testCaseTitle,
+            testCaseSeries,
+            testCaseDescription,
+            testCaseJson,
+            false,
+            false,
+            false,
+            1
+        )
+
         //Create 2nd Qi Core Measure
         CreateMeasurePage.CreateQICoreMeasureAPI(secondMeasureName, secondLibraryName, qiCoreMeasureCQL, 2)
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit', 1)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
         cy.get(Header.mainMadiePageButton).click()
 
         MeasuresPage.actionCenter('edit', 2)
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Logout', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName, false, false, 1)
         Utilities.deleteMeasure(newMeasureName, newCqlLibraryName, true, false, 2)
@@ -174,19 +169,21 @@ describe('Copy Qi Core Test Cases', () => {
 
         //Copy Test case
         cy.get(TestCasesPage.actionCenterCopyToMeasure).click()
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2').should('exist').then((fileContents) => {
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').check()
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').should('be.checked')
-        })
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').check()
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"] > input').should('be.checked')
+            })
     })
 
     it('Copy test cases skips test cases that would go over 250 character title limit', () => {
-        
         // Target measure needs to have duplicate named tc as original, and tc title must be 226+ characters
-        const longTitle = 'LoremIpsumDolorSitAmetConsecteturAdipiscingElitSedDoEiusmodTemporIncididuntULaboreEtDoloreMagnaAliquaUtEnimAdMinim'
+        const longTitle =
+            'LoremIpsumDolorSitAmetConsecteturAdipiscingElitSedDoEiusmodTemporIncididuntULaboreEtDoloreMagnaAliquaUtEnimAdMinim'
         const currentUser = Cypress.env('selectedUser')
         // start - M1 with 1 regular tc, M2 with no tc
-    
+
         // step - add tc with long name to M1 and M2
         MeasuresPage.actionCenter('edit', 2)
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -216,17 +213,22 @@ describe('Copy Qi Core Test Cases', () => {
 
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled').click()
 
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2').should('exist').then((id) => {
-            Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
-            cy.get('[data-testid="measure-name-' + id + '_select"]')
-                .find('input')
-                .focus()
-                .check()
-        })
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId2')
+            .should('exist')
+            .then((id) => {
+                Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
+                cy.get('[data-testid="measure-name-' + id + '_select"]')
+                    .find('input')
+                    .focus()
+                    .check()
+            })
         cy.get(TestCasesPage.copyToSave).scrollIntoView().click()
 
         // step - verify warning about tc2 not copying
-        cy.get('[data-testid="warn-title"]').should('contain.text', '1 test cases were copied successfully. The following 1 test cases could not be copied because the test cases are duplicates and the title is too long to copy.')
+        cy.get('[data-testid="warn-title"]').should(
+            'contain.text',
+            '1 test cases were copied successfully. The following 1 test cases could not be copied because the test cases are duplicates and the title is too long to copy.'
+        )
 
         // step - verify tc1 did copy onto M2
         cy.get(Header.mainMadiePageButton).click()
@@ -238,5 +240,3 @@ describe('Copy Qi Core Test Cases', () => {
         TestCasesPage.grabValidateTestCaseTitleAndSeries(testCaseTitle, testCaseSeries)
     })
 })
-
-

--- a/cypress/e2e/WebInterface/Test Cases/DeleteTestCaseNotTheOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/DeleteTestCaseNotTheOwner.cy.ts
@@ -1,13 +1,13 @@
-import { TestCaseJson } from "../../../Shared/TestCaseJson"
-import { CreateMeasurePage } from "../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../Shared/OktaLogin"
-import { Utilities } from "../../../Shared/Utilities"
-import { MeasuresPage } from "../../../Shared/MeasuresPage"
-import { TestCase, TestCasesPage } from "../../../Shared/TestCasesPage"
-import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
-import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
-import { MeasureCQL } from "../../../Shared/MeasureCQL"
-import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
+import { TestCaseJson } from '../../../Shared/TestCaseJson'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { Utilities } from '../../../Shared/Utilities'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { TestCase, TestCasesPage } from '../../../Shared/TestCasesPage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { MeasureGroupPage } from '../../../Shared/MeasureGroupPage'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { CQLEditorPage } from '../../../Shared/CQLEditorPage'
 
 const now = Date.now()
 let measureName = 'DeleteTC' + now
@@ -26,34 +26,40 @@ const testCase2: TestCase = {
 }
 
 describe('Delete Test Case', () => {
-
     beforeEach('Create measure and login', () => {
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
-            '2012-01-02', '2013-01-01')
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            measureName,
+            CqlLibraryName,
+            measureCQL,
+            0,
+            false,
+            '2012-01-02',
+            '2013-01-01'
+        )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, undefined, undefined, undefined, undefined, undefined,
-            undefined, undefined, 'Procedure')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            'Procedure'
+        )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify Non owner of the Measure unable to delete Test Case', () => {
-
         TestCasesPage.createTestCase(testCase1.title, testCase1.description, testCase1.group)
 
         OktaLogin.UILogout()
@@ -63,7 +69,7 @@ describe('Delete Test Case', () => {
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
         cy.get(MeasuresPage.allMeasuresTab).click({ force: true })
 
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
@@ -79,7 +85,7 @@ describe('Delete Test Case', () => {
         cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
         cy.get(TestCasesPage.reportsButton).should('be.visible')
         cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
-        
+
         cy.contains('View').should('be.visible')
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseSearch/QDMTestCaseSearch.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/TestCaseSearch/QDMTestCaseSearch.cy.ts
@@ -1,13 +1,13 @@
-import { OktaLogin } from "../../../../../Shared/OktaLogin"
-import {CreateMeasureOptions, CreateMeasurePage} from "../../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
-import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
-import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../../Shared/Header";
+import { OktaLogin } from '../../../../../Shared/OktaLogin'
+import { CreateMeasureOptions, CreateMeasurePage } from '../../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../../Shared/CQLEditorPage'
+import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
+import { MeasureCQL } from '../../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../../Shared/Header'
 
 let testCaseTitle2nd = 'Second TC - Title for Auto Test'
 let testCaseDescription2nd = 'SecondTC-DENOMFail' + Date.now()
@@ -24,9 +24,7 @@ let CqlLibraryName = 'ProportionPatient' + Date.now()
 const measureData: CreateMeasureOptions = {}
 
 describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => {
-
     beforeEach('Create Measure', () => {
-
         measureData.ecqmTitle = measureQDMManifestName
         measureData.cqlLibraryName = CqlLibraryName
         measureData.measureScoring = 'Proportion'
@@ -37,7 +35,16 @@ describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => 
 
         //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions', 'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
         TestCasesPage.CreateQDMTestCaseAPI('QDMManifestTC', 'QDMManifestTCGroup', 'QDMManifestTC', '', false, false)
         OktaLogin.Login()
 
@@ -50,19 +57,14 @@ describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => 
         MeasureGroupPage.includeSdeData()
         cy.get(Header.mainMadiePageButton).click()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     afterEach('Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('QDM Test Case search and filter functionality', () => {
-
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
@@ -74,7 +76,13 @@ describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => 
         TestCasesPage.clickEditforCreatedTestCase()
 
         //enter a value of the dob, Race and gender
-        TestCasesPage.enterPatientDemographics('085/27/1981 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
+        TestCasesPage.enterPatientDemographics(
+            '085/27/1981 12:00 AM',
+            'Living',
+            'White',
+            'Male',
+            'Not Hispanic or Latino'
+        )
 
         //save the Test Case
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -94,26 +102,38 @@ describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => 
         //search for something that is in the description field
         cy.get(TestCasesPage.tcSearchInput).type('Second')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate
+        )
         Utilities.waitForElementToNotExist(TestCasesPage.testCaseResultrow2, 5000)
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
         Utilities.waitForElementVisible(TestCasesPage.testCaseResultrow2, 5000)
         //search for something that is in the status field
         cy.get(TestCasesPage.tcSearchInput).type('NA')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate
+        )
         Utilities.waitForElementVisible(TestCasesPage.testCaseResultrow2, 5000)
         //search for something that is in the group field
         cy.get(TestCasesPage.tcSearchInput).clear().type('SecondTC-SBTestSeries')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate
+        )
         Utilities.waitForElementToNotExist(TestCasesPage.testCaseResultrow2, 5000)
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
         Utilities.waitForElementVisible(TestCasesPage.testCaseResultrow2, 5000)
         //search for something that is in the title field
         cy.get(TestCasesPage.tcSearchInput).type('QDMManifestTC')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'N/AQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            'N/AQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate
+        )
         Utilities.waitForElementToNotExist(TestCasesPage.testCaseResultrow2, 5000)
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
         Utilities.waitForElementVisible(TestCasesPage.testCaseResultrow2, 5000)
@@ -128,7 +148,10 @@ describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => 
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
         cy.get(TestCasesPage.tcSearchInput).type('QDMManifestTC')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'N/AQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            'N/AQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate
+        )
         Utilities.waitForElementToNotExist(TestCasesPage.testCaseResultrow2, 5000)
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
         Utilities.waitForElementVisible(TestCasesPage.testCaseResultrow2, 5000)
@@ -150,19 +173,31 @@ describe('QDM Test Case Search, Filter, and sorting by Test Case number', () => 
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
         cy.get(TestCasesPage.tcSearchInput).type('QDMManifestTC')
         cy.get(TestCasesPage.tcTriggerSearch).find(TestCasesPage.tcSearchIcone).click()
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'N/AQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            'N/AQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate
+        )
         Utilities.waitForElementToNotExist(TestCasesPage.testCaseResultrow2, 5000)
         //clicking on running the test case
         cy.get(TestCasesPage.executeTestCaseButton).click()
 
         //verify the results row
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            'PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate
+        )
 
         //clear search to show all test cases
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
 
         // verify the results rows - no run on 1 test, results on other
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', 'N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate)
-        cy.get(TestCasesPage.testCaseResultrow2).should('contain.text', 'PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate)
+        cy.get(TestCasesPage.testCaseResultrow).should(
+            'contain.text',
+            'N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd + todaysDate
+        )
+        cy.get(TestCasesPage.testCaseResultrow2).should(
+            'contain.text',
+            'PassQDMManifestTCGroupQDMManifestTCQDMManifestTC' + todaysDate
+        )
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/QiCoreManifestTests.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/QiCoreManifestTests.cy.ts
@@ -1,13 +1,13 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
 
 const now = Date.now()
 const measureName = 'QiCoreManifestExpansion' + now
@@ -16,31 +16,31 @@ const measureCQLPFTests = MeasureCQL.CQL_Populations
 const testCaseJson = TestCaseJson.TestCaseJson_Valid
 
 describe('Validating QICore Expansion -> Manifest', () => {
-
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQLPFTests)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', '', 'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
         TestCasesPage.CreateTestCaseAPI('passing test', 'abc', 'example', testCaseJson)
 
         OktaLogin.SessionLogin()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify Madie users can successfully execute test cases against their chosen manifest version', () => {
-
         // set intercept for manifest expansion
         cy.intercept('PUT', '/api/terminology/value-sets/expansion/fhir').as('expansion')
 
@@ -52,10 +52,7 @@ describe('Validating QICore Expansion -> Manifest', () => {
         cy.get(TestCasesPage.qdmExpansionSubTab).click()
 
         // select manifest expansion
-        cy.get(TestCasesPage.qdmExpansionRadioOptionGroup)
-            .find('[type="radio"]')
-            .last()
-            .click()
+        cy.get(TestCasesPage.qdmExpansionRadioOptionGroup).find('[type="radio"]').last().click()
 
         // choose ecqm-update-2022-0505
         cy.get(TestCasesPage.qdmManifestSelectDropDownBox).click()
@@ -71,7 +68,7 @@ describe('Validating QICore Expansion -> Manifest', () => {
 
         // intercept expansion API call & check for expected versions
         const expectedVersions = ['20170504', '20190315', '20240110', '20180310']
-        cy.wait('@expansion', { timeout: 30000 }).then(expansion => {
+        cy.wait('@expansion', { timeout: 30000 }).then((expansion) => {
             expect(expansion?.response?.body).to.have.length(5)
             // no guarantee of return order, and this avoids a for loop
             expect(expansion?.response?.body[0].version).to.be.oneOf(expectedVersions)

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/QiCoreTestCaseSearch.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/QiCoreTestCaseSearch.cy.ts
@@ -1,13 +1,13 @@
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
 
 let measureName = 'QiCoreTCSearch' + Date.now()
 let CqlLibraryName = 'QiCoreTCSearchLib' + Date.now()
@@ -22,18 +22,32 @@ let testCaseDescription2nd = 'SecondTC-DENOMFail' + Date.now()
 let testCaseSeries2nd = 'SecondTC-SBTestSeries'
 
 describe('Non Boolean Population Basis Expected values', () => {
-
     beforeEach('Create measure and login', () => {
-
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, undefined, false,
-            '2012-01-02', '2013-01-01')
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Qualifying Encounters', '', '', 'Qualifying Encounters', '', 'Qualifying Encounters', 'Encounter')
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            measureName,
+            CqlLibraryName,
+            measureCQL,
+            undefined,
+            false,
+            '2012-01-02',
+            '2013-01-01'
+        )
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Qualifying Encounters',
+            '',
+            '',
+            'Qualifying Encounters',
+            '',
+            'Qualifying Encounters',
+            'Encounter'
+        )
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
         OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
@@ -41,17 +55,15 @@ describe('Non Boolean Population Basis Expected values', () => {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.createTestCase(testCaseTitle2nd, testCaseDescription2nd, testCaseSeries2nd, testCaseJson2nd)
-        const expectedTestCaseValue = '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd
+        const expectedTestCaseValue =
+            '2N/ASecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd
         const expectedTestCaseValue2 = '(UTC)Edit'
         //search for something that is in the description field
         cy.get(TestCasesPage.tcSearchInput).type('Second')
@@ -125,17 +137,26 @@ describe('Non Boolean Population Basis Expected values', () => {
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 25000)
 
         //verify the results row - only 1 test case, and it passed
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '2PassSecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd)
+        cy.get(TestCasesPage.testCaseResultrow)
+            .should(
+                'contain.text',
+                '2PassSecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd
+            )
             .should('contain.text', '(UTC)Edit')
 
         //clear search to show all test cases
         cy.get(TestCasesPage.tcClearSearch).find(TestCasesPage.clearIconBtn).click()
 
         // verify the results rows - 2 test cases shown, 1 pass, 1 n/a
-        cy.get(TestCasesPage.testCaseResultrow).should('contain.text', '2PassSecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd)
+        cy.get(TestCasesPage.testCaseResultrow)
+            .should(
+                'contain.text',
+                '2PassSecondTC-SBTestSeriesSecond TC - Title for Auto Test' + testCaseDescription2nd
+            )
             .should('contain.text', '(UTC)Edit')
 
-        cy.get(TestCasesPage.testCaseResultrow2).should('contain.text', '1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription)
+        cy.get(TestCasesPage.testCaseResultrow2)
+            .should('contain.text', '1N/ASBTestSeriesTitle for Auto Test' + testCaseDescription)
             .should('contain.text', '(UTC)Edit')
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseButtons.cy.ts
@@ -1,14 +1,20 @@
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { CreateMeasurePage, SupportedModels } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasureActions, EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage, MeasureGroups, MeasureScoring, MeasureType, PopulationBasis } from "../../../../Shared/MeasureGroupPage"
-import { TestCase, TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { Header } from "../../../../Shared/Header"
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
+import { CreateMeasurePage, SupportedModels } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasureActions, EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import {
+    MeasureGroupPage,
+    MeasureGroups,
+    MeasureScoring,
+    MeasureType,
+    PopulationBasis
+} from '../../../../Shared/MeasureGroupPage'
+import { TestCase, TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { Header } from '../../../../Shared/Header'
 
 const now = Date.now()
 const measure = {
@@ -33,46 +39,48 @@ const populations: MeasureGroups = {
     numerator: 'Surgical Absence of Cervix'
 }
 
-
 describe('Test case list page - Action Center icons for measure owner', () => {
-
     beforeEach('Create measure and login', () => {
-
-        CreateMeasurePage.CreateMeasureAPI(measure.name, measure.cqlLibraryName, SupportedModels.qiCore4, { measureCql: measure.cql })
-        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.outcome, PopulationBasis.procedure, MeasureScoring.Proportion, populations)
+        CreateMeasurePage.CreateMeasureAPI(measure.name, measure.cqlLibraryName, SupportedModels.qiCore4, {
+            measureCql: measure.cql
+        })
+        MeasureGroupPage.CreateMeasureGroupAPI(
+            MeasureType.outcome,
+            PopulationBasis.procedure,
+            MeasureScoring.Proportion,
+            populations
+        )
         TestCasesPage.CreateTestCaseAPI(testCase1.title, testCase1.description, testCase1.group)
-        TestCasesPage.CreateTestCaseAPI(testCase2.title, testCase2.description, testCase2.group, testCase2.json, false, true)
+        TestCasesPage.CreateTestCaseAPI(
+            testCase2.title,
+            testCase2.description,
+            testCase2.group,
+            testCase2.json,
+            false,
+            true
+        )
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 60000)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+
         cy.get(EditMeasurePage.testCasesTab).click()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
 
     it('Delete icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterDelete).should('be.disabled')
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterDelete).should('be.enabled')
         TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterDelete).should('be.enabled')
-
     })
 
     it('Clone icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterClone).should('be.enabled')
@@ -88,7 +96,6 @@ describe('Test case list page - Action Center icons for measure owner', () => {
     })
 
     it('Export icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to export')
 
@@ -104,13 +111,20 @@ describe('Test case list page - Action Center icons for measure owner', () => {
     })
 
     it('Shift dates icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterShiftDates).should('be.disabled')
-        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to shift test case dates')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Select test cases to shift test case dates'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
-        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Shift test case dates')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Shift test case dates'
+        )
 
         TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
@@ -123,13 +137,25 @@ describe('Test case list page - Action Center icons for measure owner', () => {
 })
 
 describe('Test case list page - Action Center icons for versioned measure', () => {
-
     beforeEach('Create measure and login', () => {
-
-        CreateMeasurePage.CreateMeasureAPI(measure.name, measure.cqlLibraryName, SupportedModels.qiCore4, { measureCql: measure.cql })
-        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.outcome, PopulationBasis.procedure, MeasureScoring.Proportion, populations)
+        CreateMeasurePage.CreateMeasureAPI(measure.name, measure.cqlLibraryName, SupportedModels.qiCore4, {
+            measureCql: measure.cql
+        })
+        MeasureGroupPage.CreateMeasureGroupAPI(
+            MeasureType.outcome,
+            PopulationBasis.procedure,
+            MeasureScoring.Proportion,
+            populations
+        )
         TestCasesPage.CreateTestCaseAPI(testCase1.title, testCase1.description, testCase1.group, testCase2.json)
-        TestCasesPage.CreateTestCaseAPI(testCase2.title, testCase2.description, testCase2.group, testCase2.json, false, true)
+        TestCasesPage.CreateTestCaseAPI(
+            testCase2.title,
+            testCase2.description,
+            testCase2.group,
+            testCase2.json,
+            false,
+            true
+        )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -143,7 +169,6 @@ describe('Test case list page - Action Center icons for versioned measure', () =
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteVersionedMeasure(measure.name, measure.cqlLibraryName)
     })
@@ -152,7 +177,6 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         // checks that delete, clone, and shift dates are not present at all
         cy.get(TestCasesPage.actionCenterDelete).should('be.disabled')
         cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
-
 
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to export')
@@ -169,9 +193,12 @@ describe('Test case list page - Action Center icons for versioned measure', () =
     })
 
     it('Copy To icon is present and it enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
-        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+        cy.get('[data-testid="copy-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Select test cases to copy to another measure'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
@@ -183,25 +210,34 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         cy.contains('Copy To').should('be.visible')
         cy.get(MeasuresPage.measureListTitles).should('be.visible')
     })
-
 })
 
 describe('Test case list page - Action Center icons for non-owner', () => {
-
     beforeEach('Create measure and login', () => {
-
-        CreateMeasurePage.CreateMeasureAPI(measure.name, measure.cqlLibraryName, SupportedModels.qiCore4, { measureCql: measure.cql })
-        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.outcome, PopulationBasis.procedure, MeasureScoring.Proportion, populations)
+        CreateMeasurePage.CreateMeasureAPI(measure.name, measure.cqlLibraryName, SupportedModels.qiCore4, {
+            measureCql: measure.cql
+        })
+        MeasureGroupPage.CreateMeasureGroupAPI(
+            MeasureType.outcome,
+            PopulationBasis.procedure,
+            MeasureScoring.Proportion,
+            populations
+        )
         TestCasesPage.CreateTestCaseAPI(testCase1.title, testCase1.description, testCase1.group)
-        TestCasesPage.CreateTestCaseAPI(testCase2.title, testCase2.description, testCase2.group, testCase2.json, false, true)
+        TestCasesPage.CreateTestCaseAPI(
+            testCase2.title,
+            testCase2.description,
+            testCase2.group,
+            testCase2.json,
+            false,
+            true
+        )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        
-
 
         OktaLogin.AltLogin()
         cy.get(MeasuresPage.allMeasuresTab).click()
@@ -210,7 +246,6 @@ describe('Test case list page - Action Center icons for non-owner', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
@@ -219,7 +254,6 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         // checks that delete, clone, shift dates are not present at all
         cy.get(TestCasesPage.actionCenterDelete).should('not.exist')
         cy.get(TestCasesPage.actionCenterClone).should('not.exist')
-
 
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
         cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to export')
@@ -236,9 +270,12 @@ describe('Test case list page - Action Center icons for non-owner', () => {
     })
 
     it('Non-owner sees Copy To icon; it enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
-        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+        cy.get('[data-testid="copy-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Select test cases to copy to another measure'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
@@ -251,4 +288,3 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         cy.get(MeasuresPage.measureListTitles).should('be.visible')
     })
 })
-

--- a/cypress/plugins/altUserLock.json
+++ b/cypress/plugins/altUserLock.json
@@ -1,1 +1,1 @@
-{"altHarpUser":false,"altHarpUser2":false,"altHarpUser3":false}
+{"altHarpUser":true,"altHarpUser2":true,"altHarpUser3":false}

--- a/cypress/plugins/userLock.json
+++ b/cypress/plugins/userLock.json
@@ -1,1 +1,1 @@
-{"harpUser":false,"harpUser2":false,"harpUser3":false}
+{"harpUser":true,"harpUser2":true,"harpUser3":false}


### PR DESCRIPTION
## Summary

Fixes regression failures across measure association, QDM export/versioning, QDM code search, measure transfer, and test case workflows.

## Changes

- Updated measure association regression specs for QI-Core 4.1.1 and QI-Core 6.0.0.
- Updated QDM measure export and human-readable export validation specs.
- Updated QDM measure version validation coverage.
- Updated QDM code search regression coverage.
- Updated measure transfer regression coverage.
- Updated affected test case specs for calculator dates, copy, delete-not-owner, manifest, search, and button validations.
- Updated Cypress lock fixture JSON used by the affected regression tests.

## Validation

- `npm run compile`
- `git diff --check -- cypress`
