### PR TITLE
Fix follow-up regression tests

### DIFF
--- a/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
@@ -77,7 +77,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
             Utilities.dropdownSelect(
                 MeasureGroupPage.improvementNotationSelect,
-                'Increased score indicates improvement',
+                'Increased score indicates improvement'
             )
 
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
@@ -85,7 +85,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
                 'contain.text',
-                'Population details for this group saved successfully.',
+                'Population details for this group saved successfully.'
             )
 
             //Navigate to Test Cases page and add Test Case details
@@ -121,7 +121,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                     '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
                     '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
                     '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
-                    '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}',
+                    '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}'
             )
             //save changes to CQL
             cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -130,19 +130,19 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             Utilities.waitForElementVisible(EditMeasurePage.errorMessage, 350000)
             cy.get(EditMeasurePage.errorMessage).should(
                 'contain.text',
-                'CQL return types do not match population criteria! Test Cases will not execute until this issue is resolved.',
+                'CQL return types do not match population criteria! Test Cases will not execute until this issue is resolved.'
             )
             //navigate to the PC tab and verify mismatch message appears
             cy.get(EditMeasurePage.measureGroupsTab).click()
             cy.get(MeasureGroupPage.CQLPCMismatchError).should(
                 'contain.text',
-                'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.',
+                'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.'
             )
             //navigate to the TC tab and verify mismatch message appears and the execute test case button is disabled
             cy.get(EditMeasurePage.testCasesTab).click()
             cy.get('[data-testid="test-case-alerts"]').should(
                 'contain.text',
-                '2 errors were foundOne or more Population Criteria has a mismatch with CQL return types. Please check the population criteria tab to update.Test Cases cannot be executed and Valuesets from the measure CQL cannot be expanded until this is resolved.',
+                '2 errors were foundOne or more Population Criteria has a mismatch with CQL return types. Please check the population criteria tab to update.Test Cases cannot be executed and Valuesets from the measure CQL cannot be expanded until this is resolved.'
             )
             cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
             TestCasesPage.clickEditforCreatedTestCase()
@@ -161,9 +161,9 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                         cy.request({
                             url: '/api/measures/' + id,
                             headers: {
-                                authorization: 'Bearer ' + accessToken?.value,
+                                authorization: 'Bearer ' + accessToken?.value
                             },
-                            method: 'GET',
+                            method: 'GET'
                         }).then((response) => {
                             expect(response.status).to.eql(200)
                             expect(response.body.errors[0]).to.equal('MISMATCH_CQL_POPULATION_RETURN_TYPES')
@@ -185,7 +185,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             //remove the dayObs line(s) from CQL
             cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
             cy.get(EditMeasurePage.cqlEditorTextBox).type(
-                measureCQL + '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{del}',
+                measureCQL + '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{del}'
             )
 
             //save changes to CQL
@@ -205,16 +205,16 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                         cy.request({
                             url: '/api/measures/' + id,
                             headers: {
-                                authorization: 'Bearer ' + accessToken?.value,
+                                authorization: 'Bearer ' + accessToken?.value
                             },
-                            method: 'GET',
+                            method: 'GET'
                         }).then((response) => {
                             expect(response.status).to.eql(200)
                             expect(response.body.errors).is.empty
                         })
                     })
             })
-        },
+        }
     )
 
     it(
@@ -225,10 +225,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             //Click on Edit Measure
             MeasuresPage.actionCenter('edit')
 
-            cy.get(EditMeasurePage.cqlEditorTab).click()
-            cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-            cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+            CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
             //Click on the measure group tab
             cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -259,7 +256,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(MeasureGroupPage.rateAggregation).type('Typed some value for Rate Aggregation text area field')
             Utilities.dropdownSelect(
                 MeasureGroupPage.improvementNotationSelect,
-                'Increased score indicates improvement',
+                'Increased score indicates improvement'
             )
 
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
@@ -267,7 +264,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
                 'contain.text',
-                'Population details for this group saved successfully.',
+                'Population details for this group saved successfully.'
             )
 
             //Navigate to Test Cases page and add Test Case details
@@ -303,7 +300,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                     '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
                     '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
                     '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}' +
-                    '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}',
+                    '{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}'
             )
             //save changes to CQL
             cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -312,19 +309,19 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             Utilities.waitForElementVisible(EditMeasurePage.errorMessage, 35000)
             cy.get(EditMeasurePage.errorMessage).should(
                 'contain.text',
-                'CQL return types do not match population criteria! Test Cases will not execute until this issue is resolved.',
+                'CQL return types do not match population criteria! Test Cases will not execute until this issue is resolved.'
             )
             //navigate to the PC tab and verify mismatch message appears
             cy.get(EditMeasurePage.measureGroupsTab).click()
             cy.get(MeasureGroupPage.CQLPCMismatchError).should(
                 'contain.text',
-                'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.',
+                'One or more Population Criteria has a mismatch with CQL return types. Test Cases cannot be executed until this is resolved.'
             )
             //navigate to the TC tab and verify mismatch message appears and the execute test case button is disabled
             cy.get(EditMeasurePage.testCasesTab).click()
             cy.get('[data-testid="test-case-alerts"]').should(
                 'contain.text',
-                '2 errors were foundOne or more Population Criteria has a mismatch with CQL return types. Please check the population criteria tab to update.Test Cases cannot be executed and Valuesets from the measure CQL cannot be expanded until this is resolved.',
+                '2 errors were foundOne or more Population Criteria has a mismatch with CQL return types. Please check the population criteria tab to update.Test Cases cannot be executed and Valuesets from the measure CQL cannot be expanded until this is resolved.'
             )
             cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
             TestCasesPage.clickEditforCreatedTestCase()
@@ -345,9 +342,9 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                         cy.request({
                             url: '/api/measures/' + id,
                             headers: {
-                                authorization: 'Bearer ' + accessToken?.value,
+                                authorization: 'Bearer ' + accessToken?.value
                             },
-                            method: 'GET',
+                            method: 'GET'
                         }).then((response) => {
                             expect(response.status).to.eql(200)
                             expect(response.body.errors[0]).to.equal('MISMATCH_CQL_POPULATION_RETURN_TYPES')
@@ -373,7 +370,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
                 'contain.text',
-                'Population details for this group updated successfully.',
+                'Population details for this group updated successfully.'
             )
 
             //verify that the errors flag contains no errors / has been cleared
@@ -388,15 +385,15 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                         cy.request({
                             url: '/api/measures/' + id,
                             headers: {
-                                authorization: 'Bearer ' + accessToken?.value,
+                                authorization: 'Bearer ' + accessToken?.value
                             },
-                            method: 'GET',
+                            method: 'GET'
                         }).then((response) => {
                             expect(response.status).to.eql(200)
                             expect(response.body.errors).is.empty
                         })
                     })
             })
-        },
+        }
     )
 })

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/MeasureButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/MeasureButtons.cy.ts
@@ -1,19 +1,19 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage, CreateMeasureOptions } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage, EditMeasureActions } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
-import { QdmCql } from "../../../../Shared/QDMMeasuresCQL"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage, CreateMeasureOptions } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage, EditMeasureActions } from '../../../../Shared/EditMeasurePage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
+import { QdmCql } from '../../../../Shared/QDMMeasuresCQL'
 
 const path = require('path')
 const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeEach } = require('cypress-delete-downloads-folder')
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let measureCQLPFTests = MeasureCQL.CQL_Populations
 let qdmManifestTestCQL = MeasureCQL.qdmCQLManifestTest
 let qdmMeasureCQL = QdmCql.simpleQDM_CQL
@@ -26,9 +26,7 @@ let harpUserALT = ''
 const measureData: CreateMeasureOptions = {}
 
 describe('Delete measure on the measure edit page', () => {
-
     beforeEach('Create Measure', () => {
-
         //Create New QDM Measure
         measureQDM = 'QDMMeasure' + Date.now() + randValue + 8 + randValue
         qiCoreCQLLibrary = 'QDMTestLibrary' + Date.now() + randValue + 8 + randValue
@@ -42,15 +40,32 @@ describe('Delete measure on the measure edit page', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create new QI Core measure
         measureQICore = 'QICoreMeasure' + Date.now() + randValue + 4 + randValue
         qiCoreCQLLibrary = 'QiCoreTestLibrary' + Date.now() + randValue + 4 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore, qiCoreCQLLibrary, measureCQLPFTests, 1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(1, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            1,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
 
         OktaLogin.Login()
 
@@ -72,7 +87,6 @@ describe('Delete measure on the measure edit page', () => {
     })
 
     it('Delete measure on the edit page for a measure', () => {
-
         //Qi Core
         MeasuresPage.actionCenter('edit', 1)
         Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 30000)
@@ -82,9 +96,14 @@ describe('Delete measure on the measure edit page', () => {
         Utilities.waitForElementVisible(EditMeasurePage.deleteMeasureConfirmationButton, 30000)
         cy.get(EditMeasurePage.deleteMeasureConfirmationButton).click()
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 30000)
-        cy.get(EditMeasurePage.successMessage).should('contain.text', "Measure successfully deleted")
+        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure successfully deleted')
         Utilities.waitForElementToNotExist(EditMeasurePage.successMessage, 30000)
-        cy.url().should('be.oneOf', ['https://dev.madie.internal.cms.gov/measures?tab=0&page=1&limit=10', 'https://test.madie.internal.cms.gov/measures?tab=0&page=1&limit=10', 'https://impl.madie.internal.cms.gov/measures?tab=0&page=1&limit=10', 'https://madie.cms.gov/measures?tab=0&page=1&limit=10'])
+        cy.url().should('be.oneOf', [
+            'https://dev.madie.internal.cms.gov/measures?tab=0&page=1&limit=10',
+            'https://test.madie.internal.cms.gov/measures?tab=0&page=1&limit=10',
+            'https://impl.madie.internal.cms.gov/measures?tab=0&page=1&limit=10',
+            'https://madie.cms.gov/measures?tab=0&page=1&limit=10'
+        ])
 
         //QDM
         MeasuresPage.actionCenter('edit')
@@ -95,20 +114,23 @@ describe('Delete measure on the measure edit page', () => {
         Utilities.waitForElementVisible(EditMeasurePage.deleteMeasureConfirmationButton, 30000)
         cy.get(EditMeasurePage.deleteMeasureConfirmationButton).click()
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 30000)
-        cy.get(EditMeasurePage.successMessage).should('contain.text', "Measure successfully deleted")
+        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure successfully deleted')
         Utilities.waitForElementToNotExist(EditMeasurePage.successMessage, 30000)
-        cy.url().should('be.oneOf', ['https://dev.madie.internal.cms.gov/measures?tab=0&page=1&limit=10', 'https://test.madie.internal.cms.gov/measures?tab=0&page=1&limit=10', 'https://impl.madie.internal.cms.gov/measures?tab=0&page=1&limit=10', 'https://madie.cms.gov/measures?tab=0&page=1&limit=10'])
+        cy.url().should('be.oneOf', [
+            'https://dev.madie.internal.cms.gov/measures?tab=0&page=1&limit=10',
+            'https://test.madie.internal.cms.gov/measures?tab=0&page=1&limit=10',
+            'https://impl.madie.internal.cms.gov/measures?tab=0&page=1&limit=10',
+            'https://madie.cms.gov/measures?tab=0&page=1&limit=10'
+        ])
     })
 })
 
 describe('Version and Draft QDM Measure on the Edit Measure page', () => {
-
     measureQDM = 'QDMMeasure' + Date.now() + randValue + 9 + randValue
     let updatedMeasureName = 'Updated' + measureQDM
     qdmCQLLibrary = 'QDMTestLibrary' + Date.now() + randValue + 9 + randValue
 
     beforeEach('Create Measure', () => {
-
         measureData.ecqmTitle = measureQDM
         measureData.cqlLibraryName = qdmCQLLibrary
         measureData.measureScoring = 'Proportion'
@@ -118,27 +140,30 @@ describe('Version and Draft QDM Measure on the Edit Measure page', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         OktaLogin.Login()
 
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Log Out and Clean up', () => {
-
         Utilities.deleteVersionedMeasure(measureQDM, qdmCQLLibrary)
     })
 
     it('Version and Draft QDM Measure on the edit page for a measure', () => {
-
         //Version Measure
         MeasuresPage.actionCenter('edit')
         Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 5000)
@@ -151,13 +176,18 @@ describe('Version and Draft QDM Measure on the Edit Measure page', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
 
         Utilities.waitForElementVisible(EditMeasurePage.editPageVersionDraftMsg, 60000)
-        cy.get(EditMeasurePage.editPageVersionDraftMsg).should('contain.text', 'New version of measure is Successfully created')
+        cy.get(EditMeasurePage.editPageVersionDraftMsg).should(
+            'contain.text',
+            'New version of measure is Successfully created'
+        )
         cy.log('Version Created Successfully')
 
         //Draft Measure
         Utilities.waitForElementVisible(EditMeasurePage.editMeasureDraftActionBtn, 5000)
         cy.get(EditMeasurePage.editMeasureDraftActionBtn).click()
-        cy.get('[data-testid="measure-name-field"] > .MuiInputBase-root > [data-testid="measure-name-input"]').clear().type(updatedMeasureName)
+        cy.get('[data-testid="measure-name-field"] > .MuiInputBase-root > [data-testid="measure-name-input"]')
+            .clear()
+            .type(updatedMeasureName)
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.get(EditMeasurePage.editPageVersionDraftMsg).should('contain.text', 'New draft created successfully.')
 
@@ -166,34 +196,36 @@ describe('Version and Draft QDM Measure on the Edit Measure page', () => {
 })
 
 describe('Version and Draft Qi Core Measure on the Edit Measure page', () => {
-
     measureQICore = 'QiCore' + Date.now() + randValue + 5 + randValue
     qiCoreCQLLibrary = 'QiCoreTestLibrary' + Date.now() + randValue + 5 + randValue
     let updatedMeasureName = 'Updated' + measureQDM
 
     beforeEach('Create Measure', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore, qiCoreCQLLibrary, measureCQLPFTests)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
         OktaLogin.Login()
 
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Log Out and Clean up', () => {
-
         Utilities.deleteVersionedMeasure(measureQICore, qiCoreCQLLibrary)
     })
 
     it('Version and Draft Qi Core measure on the edit page for a measure', () => {
-
         //Version Measure
         MeasuresPage.actionCenter('edit')
         Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 5000)
@@ -206,13 +238,18 @@ describe('Version and Draft Qi Core Measure on the Edit Measure page', () => {
         cy.get(MeasuresPage.measureVersionContinueBtn).click()
 
         Utilities.waitForElementVisible(EditMeasurePage.editPageVersionDraftMsg, 60000)
-        cy.get(EditMeasurePage.editPageVersionDraftMsg).should('contain.text', 'New version of measure is Successfully created')
+        cy.get(EditMeasurePage.editPageVersionDraftMsg).should(
+            'contain.text',
+            'New version of measure is Successfully created'
+        )
         cy.log('Version Created Successfully')
 
         //Draft Measure
         Utilities.waitForElementVisible(EditMeasurePage.editMeasureDraftActionBtn, 5000)
         cy.get(EditMeasurePage.editMeasureDraftActionBtn).click()
-        cy.get('[data-testid="measure-name-field"] > .MuiInputBase-root > [data-testid="measure-name-input"]').clear().type(updatedMeasureName)
+        cy.get('[data-testid="measure-name-field"] > .MuiInputBase-root > [data-testid="measure-name-input"]')
+            .clear()
+            .type(updatedMeasureName)
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.get(EditMeasurePage.editPageVersionDraftMsg).should('contain.text', 'New draft created successfully.')
 
@@ -221,11 +258,9 @@ describe('Version and Draft Qi Core Measure on the Edit Measure page', () => {
 })
 
 describe('Export measure on the Edit Measure page', () => {
-
     deleteDownloadsFolderBeforeEach()
 
     before(() => {
-
         const date = Date.now()
         measureQDM = 'QDMExportMeasure' + date
         qdmCQLLibrary = 'QDMTestLibrary' + Date.now() + randValue + 3 + randValue
@@ -241,18 +276,34 @@ describe('Export measure on the Edit Measure page', () => {
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         measureQICore = 'QICoreExportMeasure' + date
         qiCoreCQLLibrary = 'QiCoreTestLibrary' + Date.now() + randValue + 3 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore, qiCoreCQLLibrary, measureCQLPFTests, 1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(1, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            1,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
     })
 
     after(() => {
-
         Utilities.deleteMeasure(measureQDM, qdmCQLLibrary)
         Utilities.deleteMeasure(measureQICore, qiCoreCQLLibrary, false, false, 1)
     })
@@ -263,7 +314,7 @@ describe('Export measure on the Edit Measure page', () => {
 
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
@@ -286,7 +337,7 @@ describe('Export measure on the Edit Measure page', () => {
 
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit", 1)
+        MeasuresPage.actionCenter('edit', 1)
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
@@ -305,9 +356,7 @@ describe('Export measure on the Edit Measure page', () => {
 })
 
 describe('Share measure from the Edit Measure page', () => {
-
     before(() => {
-
         OktaLogin.setupUserSession(false)
         harpUserALT = OktaLogin.getUser(true)
 
@@ -331,7 +380,6 @@ describe('Share measure from the Edit Measure page', () => {
     })
 
     after(() => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measureQDM, qdmCQLLibrary)
         Utilities.deleteMeasure(measureQICore, qiCoreCQLLibrary, false, false, 1)
@@ -363,20 +411,33 @@ describe('Share measure from the Edit Measure page', () => {
         cy.get(MeasuresPage.measureListTitles).should('contain', measureQDM)
 
         //Delete button disabled for shared owner
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-            Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 30000)
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[type="checkbox"]').scrollIntoView()
-            cy.get('[data-testid="measure-name-' + fileContents + '_select"]').find('[type="checkbox"]').check()
-        })
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[type="checkbox"]')
+                    .scrollIntoView()
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[type="checkbox"]')
+                    .check()
+            })
         cy.get('[data-testid="delete-action-btn"]').should('be.disabled')
 
         //Edit Measure details
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.measureNameTextBox).clear().type('Updated' + measureQDM)
-        cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type('Updated' + qdmCQLLibrary)
+        cy.get(EditMeasurePage.measureNameTextBox)
+            .clear()
+            .type('Updated' + measureQDM)
+        cy.get(EditMeasurePage.cqlLibraryNameTextBox)
+            .clear()
+            .type('Updated' + qdmCQLLibrary)
         cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
         //Edit Measure CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -405,15 +466,17 @@ describe('Share measure from the Edit Measure page', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully.'
+        )
     })
 
     it('Verify Measure owner can share Qi Core Measure from Edit Measure page Action centre share button and shred user is able to edit Measure', () => {
-
         //Login as Regular user and share Measure with ALT user
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit", 1)
+        MeasuresPage.actionCenter('edit', 1)
 
         Utilities.waitForElementVisible(EditMeasurePage.cqlLibraryNameTextBox, 15500)
 
@@ -437,10 +500,17 @@ describe('Share measure from the Edit Measure page', () => {
         //Edit Measure details
         MeasuresPage.actionCenter('edit', 1)
 
-        cy.get(EditMeasurePage.measureNameTextBox).clear().type('Updated' + measureQICore)
-        cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type('Updated' + qiCoreCQLLibrary)
+        cy.get(EditMeasurePage.measureNameTextBox)
+            .clear()
+            .type('Updated' + measureQICore)
+        cy.get(EditMeasurePage.cqlLibraryNameTextBox)
+            .clear()
+            .type('Updated' + qiCoreCQLLibrary)
         cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
         //Edit Measure CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -480,9 +550,7 @@ describe('Share measure from the Edit Measure page', () => {
 })
 
 describe('Dirty Check Validations', () => {
-
     before('Create Measure', () => {
-
         //Create New QDM Measure
         measureQDM = 'QDMMeasure' + Date.now() + randValue + 7 + randValue
         qdmCQLLibrary = 'QDMTestLibrary' + Date.now() + randValue + 7 + randValue
@@ -496,25 +564,40 @@ describe('Dirty Check Validations', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         //Create new QI Core measure
         measureQICore = 'QICoreMeasure' + Date.now() + randValue + 6 + randValue
         qiCoreCQLLibrary = 'QiCoreTestLibrary' + Date.now() + randValue + 6 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore, qiCoreCQLLibrary, measureCQLPFTests, 1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(1, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            1,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
     })
 
     after('Log Out', () => {
-
         Utilities.deleteMeasure(measureQDM, qdmCQLLibrary)
         Utilities.deleteMeasure(measureQICore, qiCoreCQLLibrary, false, false, 1)
     })
 
     it('Dirty check pops up when QDM Measure has unsaved changes and user try to Version', () => {
-
         OktaLogin.Login()
 
         //Edit Measure
@@ -532,7 +615,6 @@ describe('Dirty Check Validations', () => {
     })
 
     it('Dirty check pops up when Qi Core Measure has unsaved changes and user try to Version', () => {
-
         OktaLogin.Login()
 
         //Edit Measure
@@ -551,9 +633,7 @@ describe('Dirty Check Validations', () => {
 })
 
 describe('View measure Human Readable on the Edit Measure page', () => {
-
     before(() => {
-
         const date = Date.now()
         measureQDM = 'QDMExportMeasure' + date
         qdmCQLLibrary = 'QDMTestLibrary' + Date.now() + randValue + 3 + randValue
@@ -567,27 +647,42 @@ describe('View measure Human Readable on the Edit Measure page', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         measureQICore = 'QICoreExportMeasure' + date
         qiCoreCQLLibrary = 'QiCoreTestLibrary' + Date.now() + randValue + 3 + randValue
         CreateMeasurePage.CreateQICoreMeasureAPI(measureQICore, qiCoreCQLLibrary, measureCQLPFTests, 1)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(1, false, 'Initial Population', '', '',
-            'Initial Population', '', 'Initial Population', 'boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            1,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
     })
 
     after(() => {
-
         Utilities.deleteMeasure(measureQDM, qdmCQLLibrary)
         Utilities.deleteMeasure(measureQICore, qiCoreCQLLibrary, false, false, 1)
     })
 
     it('View Human Readable for QDM 5.6 measure', () => {
-
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         Utilities.waitForElementVisible(EditMeasurePage.cqlLibraryNameTextBox, 15500)
 
@@ -598,10 +693,9 @@ describe('View measure Human Readable on the Edit Measure page', () => {
     })
 
     it('View Human Readable for QiCore 4.1.1 measure', () => {
-
         OktaLogin.Login()
 
-        MeasuresPage.actionCenter("edit", 1)
+        MeasuresPage.actionCenter('edit', 1)
 
         Utilities.waitForElementVisible(EditMeasurePage.cqlLibraryNameTextBox, 15500)
 

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
@@ -1,13 +1,13 @@
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { LandingPage } from "../../../../Shared/LandingPage"
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { LandingPage } from '../../../../Shared/LandingPage'
 
 let measureName = 'MeasureObservations' + Date.now()
 let CqlLibraryName = 'MeasureObservationsLib' + Date.now()
@@ -15,31 +15,24 @@ let newMeasureName = ''
 let newCqlLibraryName = ''
 
 describe('Measure Observations', () => {
-
     beforeEach('Create New Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(' Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Add Measure Observations for Ratio Measure', () => {
-
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
 
         //navigate away from measure group page
@@ -73,7 +66,10 @@ describe('Measure Observations', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //navigate away from measure group page
         cy.get(Header.mainMadiePageButton).click()
@@ -95,16 +91,17 @@ describe('Measure Observations', () => {
     })
 
     it('Add Measure Observations for Continuous Variable Measure', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save CQL on measure
         Utilities.waitForElementEnabled(EditMeasurePage.cqlEditorSaveButton, 28500)
@@ -173,7 +170,6 @@ describe('Measure Observations', () => {
     })
 
     it('Remove Measure Observations from Ratio Measure', () => {
-
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
         //navigate away from measure group page
         cy.get(Header.mainMadiePageButton).click()
@@ -214,7 +210,10 @@ describe('Measure Observations', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //navigate away from measure group page
         cy.get(Header.mainMadiePageButton).click()
@@ -245,16 +244,17 @@ describe('Measure Observations', () => {
     })
 
     it('Verify drop down values for Measure observation aggregate function', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
         //save CQL on measure
         Utilities.waitForElementEnabled(EditMeasurePage.cqlEditorSaveButton, 11700)
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -282,31 +282,24 @@ describe('Measure Observations', () => {
 })
 
 describe('Measure Observations and Stratification -- non-owner tests', () => {
-
     beforeEach('Create New Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(' Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Non-owner of measure cannot change measure observation', () => {
-
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
         //navigate away from measure group page
         cy.get(Header.mainMadiePageButton).click()
@@ -339,7 +332,10 @@ describe('Measure Observations and Stratification -- non-owner tests', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //navigate away from measure group page
         cy.get(Header.mainMadiePageButton).click()
@@ -399,16 +395,17 @@ describe('Measure Observations and Stratification -- non-owner tests', () => {
     })
 
     it('Measure Observations and stratification cannot be changed by non-owner', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save CQL on measure
         Utilities.waitForElementVisible(EditMeasurePage.cqlEditorSaveButton, 11700)
@@ -526,40 +523,35 @@ describe('Measure Observations and Stratification -- non-owner tests', () => {
 })
 
 describe('Measure Observation - Expected Values', () => {
-
     beforeEach('Create New Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(' Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify Expected values for Boolean Type Continuous Variable Measure Observations', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
         //save CQL on measure
         Utilities.waitForElementEnabled(EditMeasurePage.cqlEditorSaveButton, 26500)
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
@@ -608,7 +600,10 @@ describe('Measure Observation - Expected Values', () => {
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully.'
+        )
 
         //Navigate to Test Cases page and verify Measure Observations
         TestCasesPage.createTestCase('TestCase001', 'testCaseSeries', 'testCaseDescription')
@@ -641,7 +636,6 @@ describe('Measure Observation - Expected Values', () => {
     })
 
     it('Verify Expected values for Boolean Type Ratio Measure Observations', () => {
-
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
         //navigate away from measure group page
         cy.get(Header.mainMadiePageButton).click()
@@ -683,7 +677,10 @@ describe('Measure Observation - Expected Values', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //Navigate to Test Cases page and verify Measure Observations
         TestCasesPage.createTestCase('TestCase002', 'testCaseSeries', 'testCaseDescription')
@@ -745,40 +742,35 @@ describe('Measure Observation - Expected Values', () => {
 })
 
 describe('Validate Measure Observation Parameters', () => {
-
     beforeEach('Create New Measure and Login', () => {
-
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
         CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach(' Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify error message when the population basis does not match with the function selected for Measure Observation', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
         //save CQL on measure
         Utilities.waitForElementVisible(EditMeasurePage.cqlEditorSaveButton, 11700)
         Utilities.waitForElementEnabled(EditMeasurePage.cqlEditorSaveButton, 11700)
@@ -801,7 +793,10 @@ describe('Validate Measure Observation Parameters', () => {
 
         //Verify error message when the function selected for Measure Observation has parameters for Boolean population basis type
         Utilities.dropdownSelect(MeasureGroupPage.cvMeasureObservation, 'isFinishedEncounter') //select isFinishedEncounter
-        cy.get('[data-testid="measure-observation-cv-obs-helper-text"]').should('contain.text', 'Selected function can not have parameters')
+        cy.get('[data-testid="measure-observation-cv-obs-helper-text"]').should(
+            'contain.text',
+            'Selected function can not have parameters'
+        )
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.disabled')
 
@@ -815,7 +810,10 @@ describe('Validate Measure Observation Parameters', () => {
         //Verify error message when the parameter used in function selected for Measure Observation does not match with population basis type
 
         Utilities.dropdownSelect(MeasureGroupPage.cvMeasureObservation, 'fun') //select fun
-        cy.get('[data-testid="measure-observation-cv-obs-helper-text"]').should('contain.text', 'Selected function must have exactly one parameter of type Encounter')
+        cy.get('[data-testid="measure-observation-cv-obs-helper-text"]').should(
+            'contain.text',
+            'Selected function must have exactly one parameter of type Encounter'
+        )
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.disabled')
     })

--- a/cypress/e2e/WebInterface/Measure/MeasureHistory/MeasureHistory.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureHistory/MeasureHistory.cy.ts
@@ -33,478 +33,455 @@ measureData.patientBasis = 'true'
 measureData.measureCql = measureCQL
 
 describe('Measure History - Create, Update, CMS ID, Sharing and Unsharing Actions', () => {
-  beforeEach('Create Measure and Set Access Token', () => {
-    measureData.ecqmTitle = measureName + Date.now()
-    measureData.cqlLibraryName = cqlLibraryName + Date.now()
+    beforeEach('Create Measure and Set Access Token', () => {
+        measureData.ecqmTitle = measureName + Date.now()
+        measureData.cqlLibraryName = cqlLibraryName + Date.now()
 
-    harpUser = OktaLogin.getUser(false)
-    harpUserALT = OktaLogin.getUser(true)
-    cy.readFile('cypress/fixtures/accountRealNames.json').then((nameData) => {
-      harpUserALTDisplay = `${nameData[harpUserALT]} (${harpUserALT})`
-    })
-
-    CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-    OktaLogin.Login()
-  })
-
-  afterEach('Log out and Clean up', () => {
-    OktaLogin.UILogout()
-    Utilities.deleteMeasure()
-  })
-
-  it('Verify that Measure Create and Update actions are recorded in Measure History', () => {
-    //Update Measure
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    //wait for alert / successful save message to appear
-    Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
-    //Go to Measure History and verify that Create and Update actions are recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get('[data-testid="measure-history-cell-1_actionType"]').should('contain.text', 'CREATED')
-    cy.get('[data-testid="measure-history-cell-1_performedBy"]').should('contain.text', harpUser)
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'UPDATED')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-  })
-
-  it('Verify that Create and Delete CMS ID actions are recorded in Measure History', () => {
-    let currentUser = Cypress.env('selectedUser')
-    //Generate CMS ID
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.generateCmsIdButton).should('exist')
-    cy.get(EditMeasurePage.generateCmsIdButton).should('be.enabled')
-    cy.get(EditMeasurePage.cmsIdInput).should('not.exist')
-    cy.get(EditMeasurePage.generateCmsIdButton).click()
-    Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
-    Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
-    cy.get(EditMeasurePage.cmsIDDialogContinue).click()
-    cy.get(EditMeasurePage.cmsIdInput).should('exist')
-    cy.get(EditMeasurePage.cmsIdInput)
-      .invoke('val')
-      .then((val) => {
-        const cmsId = val?.toString().valueOf()
-        cy.writeFile('cypress/fixtures/' + currentUser + '/cmsId', cmsId!)
-        cy.log('CMS ID Generated successfully: ' + cmsId)
-      })
-
-    //Go to Measure History and verify that CMS ID generation is recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'CREATE_CMSID')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Created CMS ID')
-
-    OktaLogin.UILogout()
-
-    //Delete CMS ID
-    OktaLogin.setupAdminSession()
-    cy.getCookie('accessToken').then((accessToken) => {
-      cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-        .should('exist')
-        .then((measureId) => {
-          cy.readFile('cypress/fixtures/' + currentUser + '/cmsId')
-            .should('exist')
-            .then((cmsId) => {
-              cy.readFile('cypress/fixtures/' + currentUser + '/measureSetId')
-                .should('exist')
-                .then((measureSetId) => {
-                  cy.request({
-                    url: '/api/admin/measures/' + measureId + '/delete-cms-id?cmsId=' + cmsId,
-                    method: 'DELETE',
-                    headers: {
-                      authorization: 'Bearer ' + accessToken?.value,
-                      harpId: harpUser,
-                    },
-                  }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.eql(
-                      'CMS id of ' +
-                        cmsId +
-                        ' was deleted successfully from measure set with measure set id of ' +
-                        measureSetId,
-                    )
-                  })
-                })
-            })
+        harpUser = OktaLogin.getUser(false)
+        harpUserALT = OktaLogin.getUser(true)
+        cy.readFile('cypress/fixtures/accountRealNames.json').then((nameData) => {
+            harpUserALTDisplay = `${nameData[harpUserALT]} (${harpUserALT})`
         })
+
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
+        OktaLogin.Login()
     })
 
-    OktaLogin.setupUserSession(false)
-    OktaLogin.Login()
-    //wait until page / tabs loads
-    Utilities.waitForElementVisible(LandingPage.myMeasuresTab, 20700)
-    cy.get(LandingPage.myMeasuresTab).should('exist')
-    cy.get(LandingPage.myMeasuresTab).should('be.visible')
+    afterEach('Log out and Clean up', () => {
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure()
+    })
 
-    //Go to Measure History and verify that Delete CMS ID is recorded
-    MeasuresPage.actionCenter('viewHistory')
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Deleted CMS ID ')
-  })
+    it('Verify that Measure Create and Update actions are recorded in Measure History', () => {
+        //Update Measure
+        MeasuresPage.actionCenter('edit')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
-  it('Verify that Measure Sharing and Unsharing actions are recorded in Measure History', () => {
-    //Share Measure
-    MeasuresPage.actionCenter('edit')
-    EditMeasurePage.actionCenter(EditMeasureActions.share)
-    cy.get(EditMeasurePage.shareOption).click({ force: true })
-    cy.get(EditMeasurePage.harpIdInputTextBox).type(harpUserALT)
-    cy.get(EditMeasurePage.addBtn).click()
+        //Go to Measure History and verify that Create and Update actions are recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get('[data-testid="measure-history-cell-1_actionType"]').should('contain.text', 'CREATED')
+        cy.get('[data-testid="measure-history-cell-1_performedBy"]').should('contain.text', harpUser)
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'UPDATED')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+    })
 
-    //Verify that the Harp id is added to the table
-    cy.get(EditMeasurePage.sharedUserTable).should('contain.text', harpUserALT)
+    it('Verify that Create and Delete CMS ID actions are recorded in Measure History', () => {
+        let currentUser = Cypress.env('selectedUser')
+        //Generate CMS ID
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.generateCmsIdButton).should('exist')
+        cy.get(EditMeasurePage.generateCmsIdButton).should('be.enabled')
+        cy.get(EditMeasurePage.cmsIdInput).should('not.exist')
+        cy.get(EditMeasurePage.generateCmsIdButton).click()
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
+        cy.get(EditMeasurePage.cmsIDDialogContinue).click()
+        cy.get(EditMeasurePage.cmsIdInput).should('exist')
+        cy.get(EditMeasurePage.cmsIdInput)
+            .invoke('val')
+            .then((val) => {
+                const cmsId = val?.toString().valueOf()
+                cy.writeFile('cypress/fixtures/' + currentUser + '/cmsId', cmsId!)
+                cy.log('CMS ID Generated successfully: ' + cmsId)
+            })
 
-    cy.get(EditMeasurePage.saveUserBtn).click()
-    cy.get(EditMeasurePage.successMessage).should('contain.text', 'The measure(s) were successfully shared')
+        //Go to Measure History and verify that CMS ID generation is recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'CREATE_CMSID')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Created CMS ID')
 
-    cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+        OktaLogin.UILogout()
 
-    //Go to Measure History and verify that Measure Sharing is recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'SHARED')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Shared with - ' + harpUserALTDisplay)
+        //Delete CMS ID
+        OktaLogin.setupAdminSession()
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+                .should('exist')
+                .then((measureId) => {
+                    cy.readFile('cypress/fixtures/' + currentUser + '/cmsId')
+                        .should('exist')
+                        .then((cmsId) => {
+                            cy.readFile('cypress/fixtures/' + currentUser + '/measureSetId')
+                                .should('exist')
+                                .then((measureSetId) => {
+                                    cy.request({
+                                        url: '/api/admin/measures/' + measureId + '/delete-cms-id?cmsId=' + cmsId,
+                                        method: 'DELETE',
+                                        headers: {
+                                            authorization: 'Bearer ' + accessToken?.value,
+                                            harpId: harpUser
+                                        }
+                                    }).then((response) => {
+                                        expect(response.status).to.eql(200)
+                                        expect(response.body).to.eql(
+                                            'CMS id of ' +
+                                                cmsId +
+                                                ' was deleted successfully from measure set with measure set id of ' +
+                                                measureSetId
+                                        )
+                                    })
+                                })
+                        })
+                })
+        })
 
-    //Close History popup
-    cy.get('[data-testid="measure-history-close-button"]').click().wait(1000)
-    cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+        OktaLogin.setupUserSession(false)
+        OktaLogin.Login()
+        //wait until page / tabs loads
+        Utilities.waitForElementVisible(LandingPage.myMeasuresTab, 20700)
+        cy.get(LandingPage.myMeasuresTab).should('exist')
+        cy.get(LandingPage.myMeasuresTab).should('be.visible')
 
-    //Un Share Measure
-    EditMeasurePage.actionCenter(EditMeasureActions.share)
-    cy.get(EditMeasurePage.unshareOption).click({ force: true })
-    cy.get(EditMeasurePage.unshareCheckBox).click()
-    cy.get(EditMeasurePage.saveUserBtn).click()
-    cy.get(EditMeasurePage.acceptBtn).click()
+        //Go to Measure History and verify that Delete CMS ID is recorded
+        MeasuresPage.actionCenter('viewHistory')
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Deleted CMS ID ')
+    })
 
-    cy.get(EditMeasurePage.successMessage).should('contain.text', 'The measure(s) were successfully unshared.')
-    cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+    it('Verify that Measure Sharing and Unsharing actions are recorded in Measure History', () => {
+        //Share Measure
+        MeasuresPage.actionCenter('edit')
+        EditMeasurePage.actionCenter(EditMeasureActions.share)
+        cy.get(EditMeasurePage.shareOption).click({ force: true })
+        cy.get(EditMeasurePage.harpIdInputTextBox).type(harpUserALT)
+        cy.get(EditMeasurePage.addBtn).click()
 
-    //Go to Measure History and verify that Measure Unsharing is recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'UNSHARED')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Unshared with - ' + harpUserALTDisplay)
-  })
+        //Verify that the Harp id is added to the table
+        cy.get(EditMeasurePage.sharedUserTable).should('contain.text', harpUserALT)
+
+        cy.get(EditMeasurePage.saveUserBtn).click()
+        cy.get(EditMeasurePage.successMessage).should('contain.text', 'The measure(s) were successfully shared')
+
+        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+
+        //Go to Measure History and verify that Measure Sharing is recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'SHARED')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Shared with - ' + harpUserALTDisplay)
+
+        //Close History popup
+        cy.get('[data-testid="measure-history-close-button"]').click().wait(1000)
+        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+
+        //Un Share Measure
+        EditMeasurePage.actionCenter(EditMeasureActions.share)
+        cy.get(EditMeasurePage.unshareOption).click({ force: true })
+        cy.get(EditMeasurePage.unshareCheckBox).click()
+        cy.get(EditMeasurePage.saveUserBtn).click()
+        cy.get(EditMeasurePage.acceptBtn).click()
+
+        cy.get(EditMeasurePage.successMessage).should('contain.text', 'The measure(s) were successfully unshared.')
+        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+
+        //Go to Measure History and verify that Measure Unsharing is recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'UNSHARED')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Unshared with - ' + harpUserALTDisplay)
+    })
 })
 
 describe('Measure History - Version and Draft actions', () => {
-  beforeEach('Create Measure and Set Access Token', () => {
-    measureData.ecqmTitle = measureName + 'Version' + Date.now()
-    measureData.cqlLibraryName = cqlLibraryName + 'Version' + Date.now()
+    beforeEach('Create Measure and Set Access Token', () => {
+        measureData.ecqmTitle = measureName + 'Version' + Date.now()
+        measureData.cqlLibraryName = cqlLibraryName + 'Version' + Date.now()
 
-    harpUser = OktaLogin.getUser(false)
-    harpUserALT = OktaLogin.getUser(true)
+        harpUser = OktaLogin.getUser(false)
+        harpUserALT = OktaLogin.getUser(true)
 
-    CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-    MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
-    OktaLogin.Login()
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    //wait for alert / successful save message to appear
-    Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-  })
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial Population')
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+    })
 
-  // afterEach('Log out and Clean up', () => {
+    afterEach('Log out and Clean up', () => {
+        OktaLogin.UILogout()
+        Utilities.deleteVersionedMeasure(measureData.ecqmTitle, measureData.cqlLibraryName)
+    })
 
-  //     OktaLogin.UILogout()
-  //     Utilities.deleteVersionedMeasure(measureData.ecqmTitle, measureData.cqlLibraryName)
-  // })
+    it('Verify that Measure Version and Draft actions are recorded in Measure History', () => {
+        //Create Measure Version
+        EditMeasurePage.actionCenter(EditMeasureActions.version)
 
-  it('Verify that Measure Version and Draft actions are recorded in Measure History', () => {
-    //Create Measure Version
-    EditMeasurePage.actionCenter(EditMeasureActions.version)
+        Utilities.waitForElementToNotExist(TestCasesPage.successMsg, 60000)
+        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
 
-    Utilities.waitForElementToNotExist(TestCasesPage.successMsg, 60000)
-    cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+        //Go to Measure History and verify that Measure Version action is recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get('[data-testid="measure-history-header"]').should(
+            'contain.text',
+            measureData.ecqmTitle + '(Version 1.0.000)'
+        )
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'VERSIONED_MAJOR')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Versioned to 1.0.000')
 
-    //Go to Measure History and verify that Measure Version action is recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get('[data-testid="measure-history-header"]').should('contain.text', measureData.ecqmTitle + '(Version 1.0.000)')
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'VERSIONED_MAJOR')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Versioned to 1.0.000')
+        //Close History popup
+        cy.get('[data-testid="measure-history-close-button"]').click().wait(1000)
+        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
 
-    //Close History popup
-    cy.get('[data-testid="measure-history-close-button"]').click().wait(1000)
-    cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
+        //Draft Measure
+        EditMeasurePage.actionCenter(EditMeasureActions.draft)
+        cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
 
-    //Draft Measure
-    EditMeasurePage.actionCenter(EditMeasureActions.draft)
-    cy.get(EditMeasurePage.editMeasureButtonActionBtn).click()
-
-    //Go to Measure History and verify that Measure Draft action is recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get('[data-testid="measure-history-header"]').should(
-      'contain.text',
-      measureData.ecqmTitle + '(Version 1.0.000)Draft',
-    )
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'DRAFTED')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Draft created from version 1.0.000')
-  })
+        //Go to Measure History and verify that Measure Draft action is recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get('[data-testid="measure-history-header"]').should(
+            'contain.text',
+            measureData.ecqmTitle + '(Version 1.0.000)Draft'
+        )
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'DRAFTED')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'Draft created from version 1.0.000')
+    })
 })
 
 describe('Measure History - Associate Measure and Export Measure actions', () => {
-  let measureQDMManifestName1 = 'AssociateMeasureHistoryQDM' + Date.now()
-  let QDMCqlLibraryName1 = 'AssociateMeasureHistoryQDMLib' + Date.now()
+    let measureQDMManifestName1 = 'AssociateMeasureHistoryQDM' + Date.now()
+    let QDMCqlLibraryName1 = 'AssociateMeasureHistoryQDMLib' + Date.now()
 
-  const qdmMeasure: CreateMeasureOptions = {
-    ecqmTitle: measureQDMManifestName1,
-    cqlLibraryName: QDMCqlLibraryName1,
-    measureScoring: 'Proportion',
-    patientBasis: 'false',
-    measureCql: qdmManifestTestCQL,
-    mpStartDate: '2025-01-01',
-    mpEndDate: '2025-12-31',
-  }
+    const qdmMeasure: CreateMeasureOptions = {
+        ecqmTitle: measureQDMManifestName1,
+        cqlLibraryName: QDMCqlLibraryName1,
+        measureScoring: 'Proportion',
+        patientBasis: 'false',
+        measureCql: qdmManifestTestCQL,
+        mpStartDate: '2025-01-01',
+        mpEndDate: '2025-12-31'
+    }
 
-  let QiCoreMeasureName1 = 'AssociateMeasureHistoryQiCore' + Date.now()
-  let QiCoreCqlLibraryName1 = 'AssociateMeasureHistoryQiCoreLib' + Date.now()
+    let QiCoreMeasureName1 = 'AssociateMeasureHistoryQiCore' + Date.now()
+    let QiCoreCqlLibraryName1 = 'AssociateMeasureHistoryQiCoreLib' + Date.now()
 
-  beforeEach('Create Measure', () => {
-    harpUser = OktaLogin.setupUserSession(false)
-    harpUserALT = OktaLogin.getUser(true)
+    beforeEach('Create Measure', () => {
+        harpUser = OktaLogin.setupUserSession(false)
+        harpUserALT = OktaLogin.getUser(true)
 
-    //Create New QDM Measure
-    //0
-    CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure)
-    MeasureGroupPage.CreateProportionMeasureGroupAPI(
-      0,
-      false,
-      'Initial Population',
-      '',
-      'Denominator Exceptions',
-      'Numerator',
-      '',
-      'Denominator',
-    )
+        //Create New QDM Measure
+        //0
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure)
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
-    //Create new QI Core measure
-    //1
-    CreateMeasurePage.CreateQICoreMeasureAPI(QiCoreMeasureName1, QiCoreCqlLibraryName1, measureCQLPFTests, 1)
-    MeasureGroupPage.CreateProportionMeasureGroupAPI(
-      1,
-      false,
-      'Initial Population',
-      '',
-      '',
-      'Initial Population',
-      '',
-      'Initial Population',
-      'boolean',
-    )
+        //Create new QI Core measure
+        //1
+        CreateMeasurePage.CreateQICoreMeasureAPI(QiCoreMeasureName1, QiCoreCqlLibraryName1, measureCQLPFTests, 1)
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            1,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Initial Population',
+            '',
+            'Initial Population',
+            'boolean'
+        )
 
-    OktaLogin.Login()
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-    cy.get(Header.mainMadiePageButton).click()
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
-    MeasuresPage.actionCenter('edit', 1)
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-    cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    //wait for alert / successful save message to appear
-    Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-    cy.get(Header.mainMadiePageButton).click()
-  })
-
-  afterEach('Log out and Clean up', () => {
-    OktaLogin.UILogout()
-    Utilities.deleteMeasure()
-    Utilities.deleteMeasure(undefined, undefined, false, false, 1)
-  })
-
-  it.only('Verify that Associate Measure actions are recorded in Measure History', () => {
-    let currentUser = Cypress.env('selectedUser')
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.generateCmsIdButton).click()
-    Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
-    Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
-    cy.get(EditMeasurePage.cmsIDDialogCancel).click()
-    cy.get(EditMeasurePage.cmsIdInput).should('not.exist')
-    cy.get(EditMeasurePage.generateCmsIdButton).click()
-    Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
-    Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
-    cy.get(EditMeasurePage.cmsIDDialogContinue).click()
-    cy.get(Header.mainMadiePageButton).click()
-
-    OktaLogin.UILogout()
-    cy.getCookie('accessToken').then((accessToken) => {
-      cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-        .should('exist')
-        .then((qdmId1) => {
-          cy.readFile('cypress/fixtures/' + currentUser + '/measureId1')
-            .should('exist')
-            .then((qicoreId1) => {
-              cy.request({
-                failOnStatusCode: false,
-                url:
-                  '/api/measures/cms-id-association?qiCoreMeasureId=' +
-                  qicoreId1 +
-                  '&qdmMeasureId=' +
-                  qdmId1 +
-                  '&copyMetaData=true',
-                headers: {
-                  authorization: 'Bearer ' + accessToken?.value,
-                },
-                method: 'PUT',
-                body: {},
-              }).then((response) => {
-                expect(response.status).to.eql(200)
-                cy.log('CMS ID was associated.')
-              })
-            })
-        })
+        MeasuresPage.actionCenter('edit', 1)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+        cy.get(Header.mainMadiePageButton).click()
     })
 
-    OktaLogin.Login()
-    MeasuresPage.actionCenter('edit', 1)
-    //Go to Measure History and verify that Associate Measure action is recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'ASSOCIATED')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-  })
+    afterEach('Log out and Clean up', () => {
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure()
+        Utilities.deleteMeasure(undefined, undefined, false, false, 1)
+    })
 
-  it('Verify that Export Measure actions are recorded in Measure History', () => {
-    MeasuresPage.actionCenter('export')
-    cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', { timeout: 5500 })
+    it('Verify that Associate Measure actions are recorded in Measure History', () => {
+        let currentUser = Cypress.env('selectedUser')
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.generateCmsIdButton).click()
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
+        cy.get(EditMeasurePage.cmsIDDialogCancel).click()
+        cy.get(EditMeasurePage.cmsIdInput).should('not.exist')
+        cy.get(EditMeasurePage.generateCmsIdButton).click()
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
+        Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
+        cy.get(EditMeasurePage.cmsIDDialogContinue).click()
+        cy.get(Header.mainMadiePageButton).click()
 
-    MeasuresPage.actionCenter('viewhistory')
+        OktaLogin.UILogout()
+        cy.getCookie('accessToken').then((accessToken) => {
+            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+                .should('exist')
+                .then((qdmId1) => {
+                    cy.readFile('cypress/fixtures/' + currentUser + '/measureId1')
+                        .should('exist')
+                        .then((qicoreId1) => {
+                            cy.request({
+                                failOnStatusCode: false,
+                                url:
+                                    '/api/measures/cms-id-association?qiCoreMeasureId=' +
+                                    qicoreId1 +
+                                    '&qdmMeasureId=' +
+                                    qdmId1 +
+                                    '&copyMetaData=true',
+                                headers: {
+                                    authorization: 'Bearer ' + accessToken?.value
+                                },
+                                method: 'PUT',
+                                body: {}
+                            }).then((response) => {
+                                expect(response.status).to.eql(200)
+                                cy.log('CMS ID was associated.')
+                            })
+                        })
+                })
+        })
 
-    cy.get('[data-testid="measure-history-header"]').should(
-      'contain.text',
-      qdmMeasure.ecqmTitle + '(Version 0.0.000)Draft',
-    )
-    cy.get(MeasuresPage.userActionRow).should('contain.text', 'EXPORTED_MEASURE')
-    cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
-    cy.get(MeasuresPage.additionalActionRow).should('contain.text', '-')
-  })
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit', 1)
+        //Go to Measure History and verify that Associate Measure action is recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'ASSOCIATED')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+    })
+
+    it('Verify that Export Measure actions are recorded in Measure History', () => {
+        MeasuresPage.actionCenter('export')
+        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM.zip', { timeout: 5500 })
+
+        MeasuresPage.actionCenter('viewhistory')
+
+        cy.get('[data-testid="measure-history-header"]').should(
+            'contain.text',
+            qdmMeasure.ecqmTitle + '(Version 0.0.000)Draft'
+        )
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'EXPORTED_MEASURE')
+        cy.get(MeasuresPage.harpIdRow).should('contain.text', harpUser)
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'by MADiE Admin')
+    })
 })
 
 describe('Measure History - Qi Core Export Test case Action', () => {
-  deleteDownloadsFolderBeforeAll()
-  deleteDownloadsFolderBeforeEach()
+    deleteDownloadsFolderBeforeAll()
+    deleteDownloadsFolderBeforeEach()
 
-  beforeEach('Create Measure and Set Access Token', () => {
-    harpUser = OktaLogin.getUser(false)
-    harpUserALT = OktaLogin.getUser(true)
+    beforeEach('Create Measure and Set Access Token', () => {
+        harpUser = OktaLogin.getUser(false)
+        harpUserALT = OktaLogin.getUser(true)
 
-    CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, qiCoreMeasureCQL)
-    TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
-    OktaLogin.Login()
-  })
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, qiCoreMeasureCQL)
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
+        OktaLogin.Login()
+    })
 
-  afterEach('Log out and Clean up', () => {
-    OktaLogin.UILogout()
-    Utilities.deleteMeasure()
-  })
+    afterEach('Log out and Clean up', () => {
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure()
+    })
 
-  it('Verify that Export Qi Core Test case Action is recorded in Measure History', () => {
-    //Export Test Case
-    Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
-    cy.get(Header.cqlLibraryTab).should('be.visible')
-    cy.get(Header.cqlLibraryTab).click()
+    it('Verify that Export Qi Core Test case Action is recorded in Measure History', () => {
+        //Export Test Case
+        Utilities.waitForElementVisible(Header.cqlLibraryTab, 35000)
+        cy.get(Header.cqlLibraryTab).should('be.visible')
+        cy.get(Header.cqlLibraryTab).click()
 
-    Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
-    cy.get(Header.mainMadiePageButton).should('be.visible')
-    cy.get(Header.mainMadiePageButton).click()
+        Utilities.waitForElementVisible(Header.mainMadiePageButton, 35000)
+        cy.get(Header.mainMadiePageButton).should('be.visible')
+        cy.get(Header.mainMadiePageButton).click()
 
-    MeasuresPage.actionCenter('edit')
+        MeasuresPage.actionCenter('edit')
 
-    //Navigate to Test Case page
-    cy.get(EditMeasurePage.testCasesTab).click()
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
 
-    // export
-    TestCasesPage.checkTestCase(1)
-    cy.get(TestCasesPage.actionCenterExport).click()
-    cy.get(TestCasesPage.exportCollectionTypeOption).click()
+        // export
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterExport).click()
+        cy.get(TestCasesPage.exportCollectionTypeOption).click()
 
-    cy.readFile(zipPath).should('exist')
-    cy.log('Successfully verified zip file export')
+        cy.readFile(zipPath).should('exist')
+        cy.log('Successfully verified zip file export')
 
-    //Go to Measure History and verify that Create and Update actions are recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get('[data-testid="measure-history-cell-0_actionType"]').should('contain.text', 'EXPORTED_TESTCASES')
-    cy.get('[data-testid="measure-history-cell-0_performedBy"]').should('contain.text', harpUser)
-  })
+        //Go to Measure History and verify that Create and Update actions are recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get('[data-testid="measure-history-cell-0_actionType"]').should('contain.text', 'EXPORTED_TESTCASES')
+        cy.get('[data-testid="measure-history-cell-0_performedBy"]').should('contain.text', harpUser)
+    })
 })
 
 describe('Measure History - QDM Export Test case Action', () => {
-  deleteDownloadsFolderBeforeAll()
-  deleteDownloadsFolderBeforeEach()
+    deleteDownloadsFolderBeforeAll()
+    deleteDownloadsFolderBeforeEach()
 
-  beforeEach('Create Measure and Set Access Token', () => {
-    harpUser = OktaLogin.getUser(false)
-    harpUserALT = OktaLogin.getUser(true)
+    beforeEach('Create Measure and Set Access Token', () => {
+        harpUser = OktaLogin.getUser(false)
+        harpUserALT = OktaLogin.getUser(true)
 
-    const qdmMeasureName = 'QDMTestCaseExportHistory' + Date.now()
-    const qdmLibName = 'QDMTestCaseExportHistoryLib' + Date.now()
+        const qdmMeasureName = 'QDMTestCaseExportHistory' + Date.now()
+        const qdmLibName = 'QDMTestCaseExportHistoryLib' + Date.now()
 
-    const qdmMeasure: CreateMeasureOptions = {
-      ecqmTitle: qdmMeasureName,
-      cqlLibraryName: qdmLibName,
-      measureScoring: 'Proportion',
-      patientBasis: 'false',
-      measureCql: qdmManifestTestCQL,
-      mpStartDate: '2025-01-01',
-      mpEndDate: '2025-12-31',
-    }
+        const qdmMeasure: CreateMeasureOptions = {
+            ecqmTitle: qdmMeasureName,
+            cqlLibraryName: qdmLibName,
+            measureScoring: 'Proportion',
+            patientBasis: 'false',
+            measureCql: qdmManifestTestCQL,
+            mpStartDate: '2025-01-01',
+            mpEndDate: '2025-12-31'
+        }
 
-    CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure)
-    MeasureGroupPage.CreateProportionMeasureGroupAPI(
-      0,
-      false,
-      'Initial Population',
-      '',
-      'Denominator Exceptions',
-      'Numerator',
-      '',
-      'Denominator',
-    )
-    TestCasesPage.CreateQDMTestCaseAPI('QDMManifestTC1', 'QDMManifestTCGroup1', 'QDMManifestTC1')
+        CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure)
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
+        TestCasesPage.CreateQDMTestCaseAPI('QDMManifestTC1', 'QDMManifestTCGroup1', 'QDMManifestTC1')
 
-    OktaLogin.Login()
-    Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
-  })
+        OktaLogin.Login()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 45000)
+    })
 
-  afterEach('Log out and Clean up', () => {
-    OktaLogin.UILogout()
-    Utilities.deleteMeasure()
-  })
+    afterEach('Log out and Clean up', () => {
+        OktaLogin.UILogout()
+        Utilities.deleteMeasure()
+    })
 
-  it.only('Verify that Export QDM Test case Action is recorded in Measure History', () => {
-    let currentUser = Cypress.env('selectedUser')
+    it('Verify that Export QDM Test case Action is recorded in Measure History', () => {
+        let currentUser = Cypress.env('selectedUser')
 
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).scrollIntoView()
-    cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        MeasuresPage.actionCenter('edit')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
-    //Navigate to Test Case page
-    cy.get(EditMeasurePage.testCasesTab).click()
-    Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 45000)
-    cy.get(TestCasesPage.executeTestCaseButton).click()
-    Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 45000)
+        //Navigate to Test Case page
+        cy.get(EditMeasurePage.testCasesTab).click()
+        Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 45000)
+        cy.get(TestCasesPage.executeTestCaseButton).click()
+        Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 45000)
 
-    // export
-    cy.get(TestCasesPage.actionCenterExport).click()
-    cy.contains('Excel').click()
-    cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM-TestCases.xlsx', { timeout: 5500 })
+        // export
+        cy.get(TestCasesPage.actionCenterExport).click()
+        cy.contains('Excel').click()
+        cy.verifyDownload('eCQMTitle4QDM-v0.0.000-QDM-TestCases.xlsx', { timeout: 5500 })
 
-    //Go to Measure History and verify that Export Test cases actions are recorded
-    EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
-    cy.get('[data-testid="measure-history-cell-0_actionType"]').should('contain.text', 'EXPORTED_TESTCASES')
-    cy.get('[data-testid="measure-history-cell-0_performedBy"]').should('contain.text', harpUser)
-  })
+        //Go to Measure History and verify that Export Test cases actions are recorded
+        EditMeasurePage.actionCenter(EditMeasureActions.viewHistory)
+        cy.get('[data-testid="measure-history-cell-0_actionType"]').should('contain.text', 'EXPORTED_TESTCASES')
+        cy.get('[data-testid="measure-history-cell-0_performedBy"]').should('contain.text', harpUser)
+    })
 })

--- a/cypress/e2e/WebInterface/Measure/MeasureSharingAndUnsharing/MeasureSharing.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureSharingAndUnsharing/MeasureSharing.cy.ts
@@ -24,394 +24,386 @@ let updatedMeasuresPageName = ''
 let harpUserALT = ''
 
 describe('Measure Sharing', () => {
-  let randValue = Math.floor(Math.random() * 1000 + 1)
-  let newMeasureName = measureName + randValue
-  let newCqlLibraryName = cqlLibraryName + randValue
+    let randValue = Math.floor(Math.random() * 1000 + 1)
+    let newMeasureName = measureName + randValue
+    let newCqlLibraryName = cqlLibraryName + randValue
 
-  beforeEach('Create Measure and Set Access Token', () => {
-    harpUserALT = OktaLogin.getUser(true)
+    beforeEach('Create Measure and Set Access Token', () => {
+        harpUserALT = OktaLogin.getUser(true)
 
-    CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-    OktaLogin.Login()
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    //wait for alert / successful save message to appear
-    Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-    OktaLogin.UILogout()
-  })
+        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
+        OktaLogin.UILogout()
+    })
 
-  afterEach('Log out and Clean up', () => {
-    Utilities.deleteMeasure()
-  })
+    afterEach('Log out and Clean up', () => {
+        Utilities.deleteMeasure()
+    })
 
-  it('Verify shared Measure is viewable under Shared Measure tab', () => {
-    //Share Measure with ALT User
-    Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+    it('Verify shared Measure is viewable under Shared Measure tab', () => {
+        //Share Measure with ALT User
+        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
 
-    //Login as ALT User
-    OktaLogin.AltLogin()
-    Utilities.waitForElementVisible(MeasuresPage.sharedMeasures, 50000)
-    cy.get(MeasuresPage.sharedMeasures).click()
-    cy.get(MeasuresPage.measureListTitles).wait(3000).should('contain', newMeasureName)
-  })
+        //Login as ALT User
+        OktaLogin.AltLogin()
+        Utilities.waitForElementVisible(MeasuresPage.sharedMeasures, 50000)
+        cy.get(MeasuresPage.sharedMeasures).click()
+        cy.get(MeasuresPage.measureListTitles).wait(3000).should('contain', newMeasureName)
+    })
 
-  it('Verify Measure can be edited by the shared user', () => {
-    //Share Measure with ALT User
-    Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+    it('Verify Measure can be edited by the shared user', () => {
+        //Share Measure with ALT User
+        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
 
-    //Login as ALT User
-    OktaLogin.AltLogin()
+        //Login as ALT User
+        OktaLogin.AltLogin()
 
-    //Edit Measure details
-    cy.get(LandingPage.sharedMeasures).click()
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.measureNameTextBox).clear().type(updatedMeasureName)
-    cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type(updatedCqlLibraryName)
-    cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-    cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
-      'contain.text',
-      'Measurement Information Updated Successfully',
-    )
+        //Edit Measure details
+        cy.get(LandingPage.sharedMeasures).click()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.measureNameTextBox).clear().type(updatedMeasureName)
+        cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type(updatedCqlLibraryName)
+        cy.get(EditMeasurePage.measurementInformationSaveButton).click()
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
-    //Edit Measure CQL
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
+        //Edit Measure CQL
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
 
-    Utilities.typeFileContents('cypress/fixtures/CQLForTestCaseExecution.txt', EditMeasurePage.cqlEditorTextBox)
+        Utilities.typeFileContents('cypress/fixtures/CQLForTestCaseExecution.txt', EditMeasurePage.cqlEditorTextBox)
 
-    //save CQL on measure
-    cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        //save CQL on measure
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.collapseEditor()
 
-    //Click on the measure group tab
-    cy.get(EditMeasurePage.measureGroupsTab).should('exist')
-    cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
-    cy.get(EditMeasurePage.measureGroupsTab).click()
+        //Click on the measure group tab
+        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+        cy.get(EditMeasurePage.measureGroupsTab).click()
 
-    cy.get(MeasureGroupPage.addMeasureGroupButton).click()
-    MeasureGroupPage.setMeasureGroupType()
+        cy.get(MeasureGroupPage.addMeasureGroupButton).click()
+        MeasureGroupPage.setMeasureGroupType()
 
-    Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
-    Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
-    cy.get(MeasureGroupPage.reportingTab).click()
+        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
+        Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
+        cy.get(MeasureGroupPage.reportingTab).click()
 
-    Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
+        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
 
-    Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
-    Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
+        Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
 
-    //Create New Test case
-    TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
-  })
+        //Create New Test case
+        TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
+    })
 
-  it('Verify Measure owner can share Measure from Action centre share button and shared user is able to edit Measure', () => {
-    let currentUser = Cypress.env('selectedUser')
-    //Login as Regular user and share Measure with ALT user
-    OktaLogin.Login()
+    it('Verify Measure owner can share Measure from Action centre share button and shared user is able to edit Measure', () => {
+        let currentUser = Cypress.env('selectedUser')
+        //Login as Regular user and share Measure with ALT user
+        OktaLogin.Login()
 
-    MeasuresPage.actionCenter('share')
-    cy.get(EditMeasurePage.shareOption).click({ force: true })
-    cy.get(EditMeasurePage.harpIdInputTextBox).type(harpUserALT)
-    cy.get(EditMeasurePage.addBtn).click()
+        MeasuresPage.actionCenter('share')
+        cy.get(EditMeasurePage.shareOption).click({ force: true })
+        cy.get(EditMeasurePage.harpIdInputTextBox).type(harpUserALT)
+        cy.get(EditMeasurePage.addBtn).click()
 
-    //Verify that the Harp id is added to the table
-    cy.get(EditMeasurePage.sharedUserTable).should('contain.text', harpUserALT)
+        //Verify that the Harp id is added to the table
+        cy.get(EditMeasurePage.sharedUserTable).should('contain.text', harpUserALT)
 
-    cy.get(EditMeasurePage.saveUserBtn).click()
-    cy.get(EditMeasurePage.successMessage).should('contain.text', 'The measure(s) were successfully shared')
+        cy.get(EditMeasurePage.saveUserBtn).click()
+        cy.get(EditMeasurePage.successMessage).should('contain.text', 'The measure(s) were successfully shared')
 
-    //Login as ALT User
-    OktaLogin.AltLogin()
-    Utilities.waitForElementVisible(LandingPage.sharedMeasures, 50000)
-    cy.get(LandingPage.sharedMeasures).click()
-    cy.get(MeasuresPage.measureListTitles).wait(3000).should('contain', newMeasureName)
+        //Login as ALT User
+        OktaLogin.AltLogin()
+        Utilities.waitForElementVisible(LandingPage.sharedMeasures, 50000)
+        cy.get(LandingPage.sharedMeasures).click()
+        cy.get(MeasuresPage.measureListTitles).wait(3000).should('contain', newMeasureName)
 
-    //Delete button disabled for shared owner
-    cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-      .should('exist')
-      .then((fileContents) => {
-        Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 30000)
-        cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
-          .find('[class="px-1"]')
-          .find('[class=" cursor-pointer"]')
-          .scrollIntoView()
-          .click()
-      })
-    cy.get('[data-testid="delete-action-tooltip"]').should('not.be.enabled')
+        //Delete button disabled for shared owner
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+            })
+        cy.get('[data-testid="delete-action-tooltip"]').should('not.be.enabled')
 
-    //Edit Measure details
-    cy.get(LandingPage.sharedMeasures).click()
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.measureNameTextBox).clear().type(updatedMeasureName)
-    cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type(updatedCqlLibraryName)
-    cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-    cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
-      'contain.text',
-      'Measurement Information Updated Successfully',
-    )
+        //Edit Measure details
+        cy.get(LandingPage.sharedMeasures).click()
+        MeasuresPage.actionCenter('edit')
+        cy.get(EditMeasurePage.measureNameTextBox).clear().type(updatedMeasureName)
+        cy.get(EditMeasurePage.cqlLibraryNameTextBox).clear().type(updatedCqlLibraryName)
+        cy.get(EditMeasurePage.measurementInformationSaveButton).click()
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
-    //Edit Measure CQL
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
+        //Edit Measure CQL
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
 
-    Utilities.typeFileContents('cypress/fixtures/CQLForTestCaseExecution.txt', EditMeasurePage.cqlEditorTextBox)
+        Utilities.typeFileContents('cypress/fixtures/CQLForTestCaseExecution.txt', EditMeasurePage.cqlEditorTextBox)
 
-    //save CQL on measure
-    cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        //save CQL on measure
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.collapseEditor()
 
-    //Click on the measure group tab
-    cy.get(EditMeasurePage.measureGroupsTab).should('exist')
-    cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
-    cy.get(EditMeasurePage.measureGroupsTab).click()
+        //Click on the measure group tab
+        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+        cy.get(EditMeasurePage.measureGroupsTab).click()
 
-    cy.get(MeasureGroupPage.addMeasureGroupButton).click()
-    MeasureGroupPage.setMeasureGroupType()
+        cy.get(MeasureGroupPage.addMeasureGroupButton).click()
+        MeasureGroupPage.setMeasureGroupType()
 
-    Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
-    Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
-    cy.get(MeasureGroupPage.reportingTab).click()
+        Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
+        Utilities.populationSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
+        cy.get(MeasureGroupPage.reportingTab).click()
 
-    Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
+        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
 
-    Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
-    Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
+        Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
 
-    //Create New Test case
-    TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
-  })
+        //Create New Test case
+        TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
+    })
 
-  it('Action centre share button disabled for Non Measure Owner', () => {
-    let currentUser = Cypress.env('selectedUser')
+    it('Action centre share button disabled for Non Measure Owner', () => {
+        let currentUser = Cypress.env('selectedUser')
 
-    //Login
-    OktaLogin.AltLogin()
+        //Login
+        OktaLogin.AltLogin()
 
-    //Navigate to All Measures tab
-    cy.get(MeasuresPage.allMeasuresTab).click()
-    cy.get(MeasuresPage.searchInputBox).clear().type(newMeasureName).type('{enter}')
-    cy.get('[data-testid="row-item"] > :nth-child(2)').should('contain', newMeasureName)
-    cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-      .should('exist')
-      .then((fileContents) => {
-        Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 30000)
-        cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
-          .find('[type="checkbox"]')
-          .scrollIntoView()
-        cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
-          .find('[type="checkbox"]')
-          .check()
-      })
-    cy.get('[data-testid="share-action-btn"]').should('be.visible')
-    cy.get('[data-testid="share-action-btn"]').should('be.disabled')
-  })
+        //Navigate to All Measures tab
+        cy.get(MeasuresPage.allMeasuresTab).click()
+        cy.get(MeasuresPage.searchInputBox).clear().type(newMeasureName).type('{enter}')
+        cy.get('[data-testid="row-item"] > :nth-child(2)').should('contain', newMeasureName)
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+            .should('exist')
+            .then((fileContents) => {
+                Utilities.waitForElementVisible('[data-testid="measure-name-' + fileContents + '_select"]', 30000)
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[type="checkbox"]')
+                    .scrollIntoView()
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[type="checkbox"]')
+                    .check()
+            })
+        cy.get('[data-testid="share-action-btn"]').should('be.visible')
+        cy.get('[data-testid="share-action-btn"]').should('be.disabled')
+    })
 })
 
 describe('Measure Sharing - Multiple instances', () => {
-  let randValue = Math.floor(Math.random() * 1000 + 1)
-  let newMeasureName = measureName + randValue
-  let newCqlLibraryName = cqlLibraryName + randValue
+    let randValue = Math.floor(Math.random() * 1000 + 1)
+    let newMeasureName = measureName + randValue
+    let newCqlLibraryName = cqlLibraryName + randValue
 
-  beforeEach('Create Measure and Set Access Token', () => {
-    harpUserALT = OktaLogin.getUser(true)
+    beforeEach('Create Measure and Set Access Token', () => {
+        harpUserALT = OktaLogin.getUser(true)
 
-    CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-    MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp')
-    OktaLogin.Login()
-    MeasuresPage.actionCenter('edit')
-    cy.get(EditMeasurePage.cqlEditorTab).click()
-    cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-    cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-    //wait for alert / successful save message to appear
-    Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
-    cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
+        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'ipp')
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
-    //Click on the measure group tab
-    cy.get(EditMeasurePage.measureGroupsTab).should('exist')
-    cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
-    cy.get(EditMeasurePage.measureGroupsTab).click()
+        //Click on the measure group tab
+        cy.get(EditMeasurePage.measureGroupsTab).should('exist')
+        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+        cy.get(EditMeasurePage.measureGroupsTab).click()
 
-    cy.get(MeasureGroupPage.reportingTab).click()
+        cy.get(MeasureGroupPage.reportingTab).click()
 
-    Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
+        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
 
-    Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+        Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
 
-    Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationDescQiCore, 5000)
+        Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationDescQiCore, 5000)
 
-    cy.get(MeasureGroupPage.improvementNotationDescQiCore).type('some imporvement notation description')
+        cy.get(MeasureGroupPage.improvementNotationDescQiCore).type('some imporvement notation description')
 
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
-    cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
-    Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
+        cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
+        Utilities.waitForElementVisible(MeasureGroupPage.successfulSaveMeasureGroupMsg, 3000)
 
-    cy.get(Header.measures).click()
-  })
-
-  afterEach('Log out and Clean up', () => {
-    Utilities.deleteMeasure()
-  })
-
-  it('Verify all instances in the Measure set (Version and Draft) are shared to the user', () => {
-    let currentUser = Cypress.env('selectedUser')
-    let versionNumber = '1.0.000'
-    updatedMeasuresPageName = 'UpdatedTestMeasures1' + Date.now()
-    let filePath = 'cypress/fixtures/' + currentUser + '/measureId'
-
-    //Version the Measure
-    MeasuresPage.actionCenter('version')
-    cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
-    cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
-    cy.get(MeasuresPage.measureVersionContinueBtn).click()
-    cy.get('.toast').should('contain.text', 'New version of measure is Successfully created')
-    MeasuresPage.validateVersionNumber(versionNumber)
-    cy.log('Version Created Successfully')
-
-    //Draft the Versioned Measure
-    cy.readFile(filePath)
-      .should('exist')
-      .then((fileContents) => {
-        cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
-          .find('[class="px-1"]')
-          .find('[class=" cursor-pointer"]')
-          .scrollIntoView()
-          .click()
-        cy.get('[data-testid="draft-action-btn"]').should('be.visible')
-        cy.get('[data-testid="draft-action-btn"]').should('be.enabled')
-        cy.get('[data-testid="draft-action-btn"]').click()
-      })
-    cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(updatedMeasuresPageName)
-    //intercept draft id once measure is drafted
-    cy.readFile(filePath)
-      .should('exist')
-      .then((fileContents) => {
-        cy.intercept('POST', '/api/measures/' + fileContents + '/draft').as('draft')
-      })
-    cy.get(MeasuresPage.createDraftContinueBtn).click()
-    cy.wait('@draft', { timeout: 60000 }).then((request) => {
-      cy.writeFile(filePath, request?.response?.body.id)
+        cy.get(Header.measures).click()
     })
-    cy.get('.toast').should('contain.text', 'New draft created successfully.')
-    cy.log('Draft Created Successfully')
 
-    //Share Measure with ALT User
-    Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+    afterEach('Log out and Clean up', () => {
+        Utilities.deleteMeasure()
+    })
 
-    //Login as ALT User
-    OktaLogin.AltLogin()
-    cy.get(LandingPage.sharedMeasures).wait(500).click()
-    cy.get('[class="measure-table"]').should('contain', updatedMeasuresPageName)
-  })
+    it('Verify all instances in the Measure set (Version and Draft) are shared to the user', () => {
+        let currentUser = Cypress.env('selectedUser')
+        let versionNumber = '1.0.000'
+        updatedMeasuresPageName = 'UpdatedTestMeasures1' + Date.now()
+        let filePath = 'cypress/fixtures/' + currentUser + '/measureId'
+
+        //Version the Measure
+        MeasuresPage.actionCenter('version')
+        cy.get(MeasuresPage.versionMeasuresSelectionButton).eq(0).type('{enter}')
+        cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
+        cy.get(MeasuresPage.measureVersionContinueBtn).click()
+        cy.get('.toast').should('contain.text', 'New version of measure is Successfully created')
+        MeasuresPage.validateVersionNumber(versionNumber)
+        cy.log('Version Created Successfully')
+
+        //Draft the Versioned Measure
+        cy.readFile(filePath)
+            .should('exist')
+            .then((fileContents) => {
+                cy.get('[data-testid="measure-name-' + fileContents + '_select"]')
+                    .find('[class="px-1"]')
+                    .find('[class=" cursor-pointer"]')
+                    .scrollIntoView()
+                    .click()
+                cy.get('[data-testid="draft-action-btn"]').should('be.visible')
+                cy.get('[data-testid="draft-action-btn"]').should('be.enabled')
+                cy.get('[data-testid="draft-action-btn"]').click()
+            })
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type(updatedMeasuresPageName)
+        //intercept draft id once measure is drafted
+        cy.readFile(filePath)
+            .should('exist')
+            .then((fileContents) => {
+                cy.intercept('POST', '/api/measures/' + fileContents + '/draft').as('draft')
+            })
+        cy.get(MeasuresPage.createDraftContinueBtn).click()
+        cy.wait('@draft', { timeout: 60000 }).then((request) => {
+            cy.writeFile(filePath, request?.response?.body.id)
+        })
+        cy.get('.toast').should('contain.text', 'New draft created successfully.')
+        cy.log('Draft Created Successfully')
+
+        //Share Measure with ALT User
+        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+
+        //Login as ALT User
+        OktaLogin.AltLogin()
+        cy.get(LandingPage.sharedMeasures).wait(500).click()
+        cy.get('[class="measure-table"]').should('contain', updatedMeasuresPageName)
+    })
 })
 
 describe('Delete Test Case with Shared user', () => {
-  let randValue = Math.floor(Math.random() * 1000 + 1)
-  let newMeasureName = measureName + randValue
-  let newCqlLibraryName = cqlLibraryName + randValue
+    let randValue = Math.floor(Math.random() * 1000 + 1)
+    let newMeasureName = measureName + randValue
+    let newCqlLibraryName = cqlLibraryName + randValue
 
-  beforeEach('Create Measure and Set Access Token', () => {
-    harpUserALT = OktaLogin.getUser(true)
+    beforeEach('Create Measure and Set Access Token', () => {
+        harpUserALT = OktaLogin.getUser(true)
 
-    CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
-    TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
-  })
+        CreateMeasurePage.CreateQICoreMeasureAPI(newMeasureName, newCqlLibraryName, measureCQL)
+        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
+    })
 
-  afterEach('Log out and Clean up', () => {
-    Utilities.deleteMeasure()
-  })
+    afterEach('Log out and Clean up', () => {
+        Utilities.deleteMeasure()
+    })
 
-  it('Verify Test Case can be deleted by the shared user', () => {
-    //Share Measure with ALT User
-    Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+    it('Verify Test Case can be deleted by the shared user', () => {
+        //Share Measure with ALT User
+        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
 
-    //Login as Alt User
-    OktaLogin.AltLogin()
-    cy.get(LandingPage.sharedMeasures).click()
-    MeasuresPage.actionCenter('edit')
-
-    cy.get(EditMeasurePage.testCasesTab).click()
-
-    TestCasesPage.checkTestCase(1)
-    cy.get(TestCasesPage.actionCenterDelete).click()
-
-    cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
-      'contain.text',
-      'You are choosing to delete the following Test Case(s)!' + testCaseDescription + ' - ' + testCaseTitle,
-    )
-    cy.get(CQLEditorPage.deleteContinueButton).click()
-
-    cy.get(TestCasesPage.testCaseListTable).should('not.contain', testCaseTitle)
-  })
-})
-
-describe("Remove user's share access from a measure", () => {
-  beforeEach('Create Measure and Set Access Token', () => {
-    harpUserALT = OktaLogin.getUser(true)
-
-    CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL)
-
-    // initial share to harpUserAlt
-    Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
-  })
-
-  afterEach('Log out and Clean up', () => {
-    Utilities.deleteMeasure()
-  })
-
-  it('After removing access, user can no longer edit on the measure', () => {
-    OktaLogin.AltLogin()
-    cy.get(LandingPage.sharedMeasures).click()
-
-    // captures name of measure in 2nd row
-    cy.get('[data-testid*="_measureName"]')
-      .eq(1)
-      .then((secondMeasure) => {
-        let capturedName = secondMeasure.text()
-
+        //Login as Alt User
+        OktaLogin.AltLogin()
+        cy.get(LandingPage.sharedMeasures).click()
         MeasuresPage.actionCenter('edit')
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
-        // add a test case to prove edit access
-        TestCasesPage.createTestCase('fresh tc', 'created by harpUserAlt', 'PASS', 'null')
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterDelete).click()
 
-        // Log out ALT user and revoke share as the measure owner
-        OktaLogin.UILogout()
-        OktaLogin.setupUserSession(false)
-        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.REVOKE, harpUserALT)
+        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
+            'contain.text',
+            'You are choosing to delete the following Test Case(s)!' + testCaseDescription + ' - ' + testCaseTitle
+        )
+        cy.get(CQLEditorPage.deleteContinueButton).click()
 
-        // Log back in as ALT user and verify edit access was removed
+        cy.get(TestCasesPage.testCaseListTable).should('not.contain', testCaseTitle)
+    })
+})
+
+describe("Remove user's share access from a measure", () => {
+    beforeEach('Create Measure and Set Access Token', () => {
+        harpUserALT = OktaLogin.getUser(true)
+
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCQL)
+
+        // initial share to harpUserAlt
+        Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
+    })
+
+    afterEach('Log out and Clean up', () => {
+        Utilities.deleteMeasure()
+    })
+
+    it('After removing access, user can no longer edit on the measure', () => {
         OktaLogin.AltLogin()
         cy.get(LandingPage.sharedMeasures).click()
-        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 30000)
 
-        // proves that edit access was removed — measure that was 2nd is now 1st
-        MeasuresPage.checkFirstRow({ name: capturedName })
-      })
-  })
+        // captures name of measure in 2nd row
+        cy.get('[data-testid*="_measureName"]')
+            .eq(1)
+            .then((secondMeasure) => {
+                let capturedName = secondMeasure.text()
+
+                MeasuresPage.actionCenter('edit')
+
+                cy.get(EditMeasurePage.testCasesTab).click()
+
+                // add a test case to prove edit access
+                TestCasesPage.createTestCase('fresh tc', 'created by harpUserAlt', 'PASS', 'null')
+
+                // Log out ALT user and revoke share as the measure owner
+                OktaLogin.UILogout()
+                OktaLogin.setupUserSession(false)
+                Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.REVOKE, harpUserALT)
+
+                // Log back in as ALT user and verify edit access was removed
+                OktaLogin.AltLogin()
+                cy.get(LandingPage.sharedMeasures).click()
+                Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 30000)
+
+                // proves that edit access was removed — measure that was 2nd is now 1st
+                MeasuresPage.checkFirstRow({ name: capturedName })
+            })
+    })
 })

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/CQLEditor.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/CQLEditor.cy.ts
@@ -1,14 +1,14 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Header } from "../../../../Shared/Header"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage";
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Header } from '../../../../Shared/Header'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { CQLLibraryPage } from '../../../../Shared/CQLLibraryPage'
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 let measureName = 'TestMeasure' + Date.now() + 1
 let newMeasureName = ''
 let newCqlLibraryName = ''
@@ -19,43 +19,47 @@ let newCQLTestCqlLibraryName = CqlLibraryName + randValue
 let measureFHIR_with_invalid_using = MeasureCQL.ICF_FHIR_with_invalid_using
 let measureQICoreCQL_without_using = MeasureCQL.ICFCleanTestQICore_CQL_without_using
 let measureQICoreCQL_with_incorrect_using = MeasureCQL.ICFCleanTestQICore_CQL_with_incorrect_using
-let measureQICoreCQL_with_different_Lib_name = 
-    'library ' + newCQLTestCqlLibraryName + 'b' + ' version \'0.0.004\'\n' +
-    'using QICore version \'4.1.0\'\n\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n\n' +
-    'codesystem \"SNOMEDCT:2017-09\": \'http://snomed.info/sct/731000124108\' version \'http://snomed.info/sct/731000124108/version/201709\'\n\n' +
+let measureQICoreCQL_with_different_Lib_name =
+    'library ' +
+    newCQLTestCqlLibraryName +
+    'b' +
+    " version '0.0.004'\n" +
+    "using QICore version '4.1.0'\n\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n\n" +
+    "codesystem \"SNOMEDCT:2017-09\": 'http://snomed.info/sct/731000124108' version 'http://snomed.info/sct/731000124108/version/201709'\n\n" +
     'valueset \"Hysterectomy with No Residual Cervix\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.198.12.1014\'\n' +
     'valueset \"Office Visit\": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n\n' +
     'parameter \"Measurement Period\" Interval<DateTime>\n' +
     'context Patient\n\n' +
     'define \"Surgical Absence of Cervix\":\n' +
     '	[Procedure: \"Hysterectomy with No Residual Cervix\"] NoCervixHysterectomy\n' +
-    '		where NoCervixHysterectomy.status = \'completed\''
+    "		where NoCervixHysterectomy.status = 'completed'"
 
-let qdmUsingStatementCql = 'library TestCql1733741911531 version \'0.0.000\'\n\n' +
-    'using QDM version \'5.6\'\n\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n\n' +
+let qdmUsingStatementCql =
+    "library TestCql1733741911531 version '0.0.000'\n\n" +
+    "using QDM version '5.6'\n\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n\n" +
     'parameter "Measurement Period" Interval<DateTime>\n\n' +
     'context Patient'
 
-let fhirUsingStatement = 'library TestLibrary17337661869931379 version \'0.0.000\'\n\n' +
-    'using FHIR version \'4.0.1\'\n\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n\n' +
+let fhirUsingStatement =
+    "library TestLibrary17337661869931379 version '0.0.000'\n\n" +
+    "using FHIR version '4.0.1'\n\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n\n" +
     'parameter "Measurement Period" Interval<DateTime>\n\n' +
     'context Patient'
 
-let fhirandQicoreUsingStatements = 'library TestLibrary17337661869931379 version \'0.0.000\'\n\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'using FHIR version \'4.0.1\'\n\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n\n' +
+let fhirandQicoreUsingStatements =
+    "library TestLibrary17337661869931379 version '0.0.000'\n\n" +
+    "using QICore version '4.1.1'\n" +
+    "using FHIR version '4.0.1'\n\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n\n" +
     'parameter "Measurement Period" Interval<DateTime>\n\n' +
     'context Patient'
-
 
 describe('Validate CQL Editor tab sticky footer', () => {
-
     beforeEach('Create measure and login', () => {
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -64,7 +68,6 @@ describe('Validate CQL Editor tab sticky footer', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
@@ -78,9 +81,11 @@ describe('Validate CQL Editor tab sticky footer', () => {
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
         //write CQL value into CQL Editor
-        cy.readFile('cypress/fixtures/EXM124v7QICore4Entry.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/EXM124v7QICore4Entry.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
         //Save CQL button should be available
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
         //Discard CQL button should be available
@@ -100,9 +105,8 @@ describe('Validate CQL Editor tab sticky footer', () => {
 })
 
 describe('Measure: CQL Editor', () => {
-
     beforeEach('Create measure and login', () => {
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -111,12 +115,10 @@ describe('Measure: CQL Editor', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify errors appear on CQL Editor page and in the CQL Editor object, on save and on tab / page load', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -124,24 +126,37 @@ describe('Measure: CQL Editor', () => {
         CQLEditorPage.clickCQLEditorTab()
 
         //type text in the CQL Editor that will cause error
-        cy.readFile('cypress/fixtures/cqlCQLEditor.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/cqlCQLEditor.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         //Validate error(s) in CQL Editor window - need to validate separately, cannot guarantee they will appear in order
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').click({ force: true, multiple: true })
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 1:3 | Could not resolve identifier SDE in the current library.")
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 5:13 | Member SDE Sex not found for type null.")
+        cy.get('#ace-editor-wrapper > div.ace_gutter > div')
+            .find(CQLLibraryPage.errorInCQLEditorWindow)
+            .should('be.visible')
+        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow)
+            .invoke('show')
+            .click({ force: true, multiple: true })
+        cy.get('#ace-editor-wrapper > div.ace_tooltip')
+            .invoke('show')
+            .should('contain.text', 'ELM: 1:3 | Could not resolve identifier SDE in the current library.')
+        cy.get('#ace-editor-wrapper > div.ace_tooltip')
+            .invoke('show')
+            .should('contain.text', 'ELM: 5:13 | Member SDE Sex not found for type null.')
 
         //Navigate away from CQL Editor tab
         cy.get(EditMeasurePage.measureDetailsTab).click()
@@ -153,64 +168,89 @@ describe('Measure: CQL Editor', () => {
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').click({ force: true, multiple: true })
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 1:3 | Could not resolve identifier SDE in the current library.")
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', "ELM: 5:13 | Member SDE Sex not found for type null.")
+        cy.get('#ace-editor-wrapper > div.ace_gutter > div')
+            .find(CQLLibraryPage.errorInCQLEditorWindow)
+            .should('be.visible')
+        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow)
+            .invoke('show')
+            .click({ force: true, multiple: true })
+        cy.get('#ace-editor-wrapper > div.ace_tooltip')
+            .invoke('show')
+            .should('contain.text', 'ELM: 1:3 | Could not resolve identifier SDE in the current library.')
+        cy.get('#ace-editor-wrapper > div.ace_tooltip')
+            .invoke('show')
+            .should('contain.text', 'ELM: 5:13 | Member SDE Sex not found for type null.')
     })
 
-    it('Verify errors appear on CQL Editor page and in the CQL Editor object, on save and on tab / page load, when ' +
-        'included library is not found', () => {
-
+    it(
+        'Verify errors appear on CQL Editor page and in the CQL Editor object, on save and on tab / page load, when ' +
+            'included library is not found',
+        () => {
             //Click on Edit Measure
             MeasuresPage.actionCenter('edit')
 
             //Click on the CQL Editor tab
             CQLEditorPage.clickCQLEditorTab()
 
-            cy.readFile('cypress/fixtures/EXM124v7QICore4Entry_FHIR_404.txt').should('exist').then((fileContents) => {
-                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-            })
+            cy.readFile('cypress/fixtures/EXM124v7QICore4Entry_FHIR_404.txt')
+                .should('exist')
+                .then((fileContents) => {
+                    cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+                })
 
             //save the value in the CQL Editor
             cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+            CQLEditorPage.collapseEditor()
 
             //Validate message on page
-            cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+            cy.get(CQLLibraryPage.libraryWarning).should(
+                'contain.text',
+                'Library statement was incorrect. MADiE has overwritten it.'
+            )
 
             //Validate error(s) in CQL Editor after saving
             cy.scrollTo('top')
             cy.get(EditMeasurePage.cqlEditorTextBox).click()
             cy.get(EditMeasurePage.cqlEditorTextBox).type('{pageUp}')
-            Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, "ELM: 1:55 | Library resource HospiceQICore4 version '2.0.000' is not found")
-    })
+            Utilities.validateErrors(
+                CQLEditorPage.errorInCQLEditorWindow,
+                CQLEditorPage.errorContainer,
+                "ELM: 1:55 | Library resource HospiceQICore4 version '2.0.000' is not found"
+            )
+        }
+    )
 
     it('Verify Library name and version are replaced with the actual Library Name and Version for the Measure', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLForFluentFunction.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForFluentFunction.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.collapseEditor()
 
         //Validate message on page
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         //Validate the lack of error(s) in CQL Editor
         cy.get(CQLEditorPage.errorInCQLEditorWindow).should('not.exist')
 
         cy.get(EditMeasurePage.cqlEditorTextBox).contains(newCqlLibraryName)
-        cy.get(EditMeasurePage.cqlEditorTextBox).contains('version \'0.0.000\'')
+        cy.get(EditMeasurePage.cqlEditorTextBox).contains("version '0.0.000'")
 
         //Navigate away from the page
         cy.get(EditMeasurePage.measureDetailsTab).click()
@@ -223,22 +263,26 @@ describe('Measure: CQL Editor', () => {
     })
 
     it('CQL updates when CQL Library name is updated in Measure Details', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLForFluentFunction.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForFluentFunction.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         //Validate the lack of error(s) in CQL Editor
         cy.get(CQLEditorPage.errorInCQLEditorWindow).should('not.exist')
@@ -250,7 +294,10 @@ describe('Measure: CQL Editor', () => {
         cy.get(EditMeasurePage.cqlLibraryNameTextBox).type(newCqlLibraryName + 'TEST')
 
         cy.get(EditMeasurePage.measurementInformationSaveButton).click()
-        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should('contain.text', 'Measurement Information Updated Successfully')
+        cy.get(EditMeasurePage.successfulMeasureSaveMsg).should(
+            'contain.text',
+            'Measurement Information Updated Successfully'
+        )
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
@@ -259,44 +306,61 @@ describe('Measure: CQL Editor', () => {
     })
 
     it('When Concept constructor is used in the Qi Core Measure CQL, the constructor was removed and a success message is displayed while saving CQL', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/cqlSaveCQL.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+        cy.readFile('cypress/fixtures/cqlSaveCQL.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
 
-            //save the value in the CQL Editor
-            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+                //save the value in the CQL Editor
+                cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+                CQLEditorPage.collapseEditor()
 
-            //Validate message on page
-            cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+                //Validate message on page
+                cy.get(CQLLibraryPage.libraryWarning).should(
+                    'contain.text',
+                    'Library statement was incorrect. MADiE has overwritten it.'
+                )
 
-            cy.get(EditMeasurePage.cqlEditorTextBox).type('{enter}').type('Concept {Code \'66071002\' from "SNOMED-CT",Code \'B18.1\' from "ICD-10-CM"} display \'Type B viral hepatitis', { parseSpecialCharSequences: false })
+                cy.get(EditMeasurePage.cqlEditorTextBox)
+                    .type('{enter}')
+                    .type(
+                        "Concept {Code '66071002' from \"SNOMED-CT\",Code 'B18.1' from \"ICD-10-CM\"} display 'Type B viral hepatitis",
+                        { parseSpecialCharSequences: false }
+                    )
 
-            //save the value in the CQL Editor
-            cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-            Utilities.waitForElementVisible('#content', 60000)
+                //save the value in the CQL Editor
+                cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+                Utilities.waitForElementVisible('#content', 60000)
 
-            cy.get('#content').should('contain.text', 'Concept Constructs are not supported in MADiE. It has been removed.')
-            cy.get(EditMeasurePage.cqlEditorTextBox).should('not.contain', 'Concept {Code \'66071002\' from "SNOMED-CT",Code \'B18.1\' from "ICD-10-CM"} display \'Type B viral hepatitis')
-        })
+                cy.get('#content').should(
+                    'contain.text',
+                    'Concept Constructs are not supported in MADiE. It has been removed.'
+                )
+                cy.get(EditMeasurePage.cqlEditorTextBox).should(
+                    'not.contain',
+                    "Concept {Code '66071002' from \"SNOMED-CT\",Code 'B18.1' from \"ICD-10-CM\"} display 'Type B viral hepatitis"
+                )
+            })
     })
 
     it('Dirty Check Modal is displayed', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/cqlSaveCQL.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/cqlSaveCQL.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         cy.get(Header.mainMadiePageButton).click()
 
@@ -304,16 +368,17 @@ describe('Measure: CQL Editor', () => {
     })
 
     it('Verify error message if FHIR Helpers is missing in CQL', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/QICoreCQL_MissingFHIRHelpers_Error.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/QICoreCQL_MissingFHIRHelpers_Error.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -322,25 +387,37 @@ describe('Measure: CQL Editor', () => {
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
         //Validate message on page
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get('[data-testid="generic-errors-text-list"]').should('contain.text', 'Row: 1, Col:0: ELM: 0:0 | FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
+        cy.get('[data-testid="generic-errors-text-list"]').should(
+            'contain.text',
+            'Row: 1, Col:0: ELM: 0:0 | FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.'
+        )
+        CQLEditorPage.collapseEditor()
 
         //Validate error(s) in CQL Editor after saving
         cy.scrollTo('top')
         cy.get(EditMeasurePage.cqlEditorTextBox).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{pageUp}')
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, 'ELM: 0:0 | FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.')
+        Utilities.validateErrors(
+            CQLEditorPage.errorInCQLEditorWindow,
+            CQLEditorPage.errorContainer,
+            'ELM: 0:0 | FHIRHelpers is required as an included library for QI-Core. Please add the appropriate version of FHIRHelpers to your CQL.'
+        )
     })
 
     it('FHIRHelpers alias name is defaulted, when CQL has incorrect alias name', () => {
-
         MeasuresPage.actionCenter('edit')
 
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLWithInvalidFHIRHelpersAlias.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLWithInvalidFHIRHelpersAlias.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -348,18 +425,22 @@ describe('Measure: CQL Editor', () => {
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'FHIRHelpers was incorrectly aliased. MADiE has overwritten the alias with \'FHIRHelpers\'.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            "FHIRHelpers was incorrectly aliased. MADiE has overwritten the alias with 'FHIRHelpers'."
+        )
     })
 
     it('Verify error message when CQL is missing keyword "Context"', () => {
-
         MeasuresPage.actionCenter('edit')
 
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLCsFHIRVersionProvided.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLCsFHIRVersionProvided.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -367,27 +448,38 @@ describe('Measure: CQL Editor', () => {
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get('[data-testid="generic-errors-text-list"]').should('contain.text', 'ELM: 0:0 | Measure CQL must contain a Context.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
+        cy.get('[data-testid="generic-errors-text-list"]').should(
+            'contain.text',
+            'ELM: 0:0 | Measure CQL must contain a Context.'
+        )
+        CQLEditorPage.collapseEditor()
 
         // nav away & return to same error
         cy.get(EditMeasurePage.measureDetailsTab).click()
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.get('[data-testid="generic-errors-text-list"]').should('contain.text', 'ELM: 0:0 | Measure CQL must contain a Context.')
+        cy.get('[data-testid="generic-errors-text-list"]').should(
+            'contain.text',
+            'ELM: 0:0 | Measure CQL must contain a Context.'
+        )
         cy.get('[data-testid="CancelIcon"]').should('be.visible')
     })
 
     it('Verify error message when Context is anything except Patient', () => {
-
         MeasuresPage.actionCenter('edit')
 
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLWithPractitionerContext.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLWithPractitionerContext.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -399,14 +491,15 @@ describe('Measure: CQL Editor', () => {
     })
 
     it('Verify error message if CQL contains access modifiers like private or public', () => {
-
         MeasuresPage.actionCenter('edit')
 
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLWithPrivateAccessModifier.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLWithPrivateAccessModifier.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -414,14 +507,16 @@ describe('Measure: CQL Editor', () => {
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
-        cy.get(CQLEditorPage.errorMsg).should('contain.text', 'Access modifiers like Public and Private can not be used in MADiE.')
+        cy.get(CQLEditorPage.errorMsg).should(
+            'contain.text',
+            'Access modifiers like Public and Private can not be used in MADiE.'
+        )
     })
 })
 
 describe('Measure: CQL Editor: valueSet', () => {
-
     beforeEach('Create measure and login', () => {
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -430,43 +525,50 @@ describe('Measure: CQL Editor: valueSet', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Value Sets are valid', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/EXM124v7QICore4Entry.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/EXM124v7QICore4Entry.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
     })
 
     //needs some love, maybe new CQL to test
     it.skip('Value Set Invalid, 404', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLFileWithInvalidValuesetURL.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLFileWithInvalidValuesetURL.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         cy.get(CQLEditorPage.umlsMessage).should('not.exist')
 
@@ -474,26 +576,34 @@ describe('Measure: CQL Editor: valueSet', () => {
         cy.scrollTo('top')
         cy.get(EditMeasurePage.cqlEditorTextBox).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{pageUp}')
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, "VSAC: 0:102 | Request failed with status code 404 for oid = 2.16.840.1.113883.3.464.1003.110.12.1059999 " +
-            "location = 36:0-36:102")
+        Utilities.validateErrors(
+            CQLEditorPage.errorInCQLEditorWindow,
+            CQLEditorPage.errorContainer,
+            'VSAC: 0:102 | Request failed with status code 404 for oid = 2.16.840.1.113883.3.464.1003.110.12.1059999 ' +
+                'location = 36:0-36:102'
+        )
     })
 
     //needs some love, maybe new CQL to test
     it.skip('Value Set Invalid, 404 undefined', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/ValueSetTestingEntryInValid400.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/ValueSetTestingEntryInValid400.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         cy.get(CQLEditorPage.umlsMessage).should('not.exist')
 
@@ -501,14 +611,17 @@ describe('Measure: CQL Editor: valueSet', () => {
         cy.scrollTo('top')
         cy.get(EditMeasurePage.cqlEditorTextBox).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{pageUp}')
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, 'VSAC: 0:22 | Request failed with status code 404 for oid = \'\' location = 18:0-18:22')
+        Utilities.validateErrors(
+            CQLEditorPage.errorInCQLEditorWindow,
+            CQLEditorPage.errorContainer,
+            "VSAC: 0:22 | Request failed with status code 404 for oid = '' location = 18:0-18:22"
+        )
     })
 })
 
 describe('CQL errors with included libraries', () => {
-
     beforeEach('Create measure and login', () => {
-        let randValue = (Math.floor((Math.random() * 1000) + 1))
+        let randValue = Math.floor(Math.random() * 1000 + 1)
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -517,82 +630,99 @@ describe('CQL errors with included libraries', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify errors appear on CQL Editor page when multiple versions of CQL library is included ', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/CQLWithMultipleIncludedLibraries.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLWithMultipleIncludedLibraries.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page -- fails here?
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
+        CQLEditorPage.collapseEditor()
 
         //Validate error(s) in CQL Editor after saving
 
         cy.scrollTo('top')
         cy.get(EditMeasurePage.cqlEditorTextBox).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{pageUp}')
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, 'ELM: 1:56 | Identifier FHIRHelpers is already in use in this library.')
+        Utilities.validateErrors(
+            CQLEditorPage.errorInCQLEditorWindow,
+            CQLEditorPage.errorContainer,
+            'ELM: 1:56 | Identifier FHIRHelpers is already in use in this library.'
+        )
     })
 
     it('Verify error message on CQL Editor page when an include statement is missing the version', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Click on the CQL Editor tab
         CQLEditorPage.clickCQLEditorTab()
 
-        cy.readFile('cypress/fixtures/QiCoreCQLWithoutIncludedLibraryVersion.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/QiCoreCQLWithoutIncludedLibraryVersion.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         //save the value in the CQL Editor
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page -- fails here?
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
 
         //Validate error(s) in CQL Editor after saving
 
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).scrollIntoView()
         cy.get(CQLLibraryPage.cqlLibraryEditorTextBox).click()
         cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('exist')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div').find(CQLLibraryPage.errorInCQLEditorWindow).should('be.visible')
-        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow).invoke('show').click({ force: true, multiple: true })
-        cy.get('#ace-editor-wrapper > div.ace_tooltip').invoke('show').should('contain.text', 'ELM: 1:49 | include MATGlobalCommonFunctions statement is missing version. Please add a version to the include.')
+        cy.get('#ace-editor-wrapper > div.ace_gutter > div')
+            .find(CQLLibraryPage.errorInCQLEditorWindow)
+            .should('be.visible')
+        cy.get('#ace-editor-wrapper > div.ace_gutter > div > ' + CQLLibraryPage.errorInCQLEditorWindow)
+            .invoke('show')
+            .click({ force: true, multiple: true })
+        cy.get('#ace-editor-wrapper > div.ace_tooltip')
+            .invoke('show')
+            .should(
+                'contain.text',
+                'ELM: 1:49 | include MATGlobalCommonFunctions statement is missing version. Please add a version to the include.'
+            )
     })
 })
 
 describe('Measure: CQL Editor: using line : QI Core', () => {
-
     beforeEach('Create measure and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(newCQLTestMeasureName, newCQLTestCqlLibraryName)
         OktaLogin.SessionLogin()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify error message when there is no using statement in the CQL', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -606,12 +736,17 @@ describe('Measure: CQL Editor: using line : QI Core', () => {
 
         Utilities.waitForElementVisible(CQLLibraryPage.libraryWarning, 25000)
 
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).should('contain.text', 'Missing a using statement. Please add in a valid model and version.')
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Library statement was incorrect. MADiE has overwritten it.'
+        )
+        cy.get(CQLLibraryPage.libraryWarning).should(
+            'contain.text',
+            'Missing a using statement. Please add in a valid model and version.'
+        )
     })
 
     it('Verify error message when there is an using statement in the CQL, but it is not accurate', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -623,12 +758,17 @@ describe('Measure: CQL Editor: using line : QI Core', () => {
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(CQLLibraryPage.libraryWarning).children().first().should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).children().last().should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .first()
+            .should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .last()
+            .should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
     })
 
     it('Verify error message when there is an using statement in the CQL, but it is not accurate, and the library name used is not correct', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -640,12 +780,17 @@ describe('Measure: CQL Editor: using line : QI Core', () => {
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(CQLLibraryPage.libraryWarning).children().first().should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).children().last().should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .first()
+            .should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .last()
+            .should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
     })
 
     it('Verify QDM using statement is replaced by QI-CORE using statement', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -659,26 +804,28 @@ describe('Measure: CQL Editor: using line : QI Core', () => {
 
         cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains('QICore')
 
-        cy.get(CQLLibraryPage.libraryWarning).children().first().should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).children().last().should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .first()
+            .should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .last()
+            .should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
     })
 })
 
 describe('Measure: CQL Editor: using line : FHIR', () => {
-
     beforeEach('Create measure and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(newCQLTestMeasureName, newCQLTestCqlLibraryName)
         OktaLogin.SessionLogin()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify error message when there is an using statement in the CQL, but it is invalid', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -689,12 +836,17 @@ describe('Measure: CQL Editor: using line : FHIR', () => {
         cy.get(EditMeasurePage.cqlEditorTextBox).type(measureFHIR_with_invalid_using)
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLLibraryPage.libraryWarning).children().first().should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).children().last().should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .first()
+            .should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .last()
+            .should('contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
     })
 
     it('Verify FHIR using statement can be used for QI-Core measure', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -706,14 +858,19 @@ describe('Measure: CQL Editor: using line : FHIR', () => {
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains('using FHIR version \'4.0.1\'')
+        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains("using FHIR version '4.0.1'")
 
-        cy.get(CQLLibraryPage.libraryWarning).children().first().should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).children().last().should('not.contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .first()
+            .should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .last()
+            .should('not.contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
     })
 
     it('Verify FHIR and QICORE using statements can be used at the same time', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -725,10 +882,16 @@ describe('Measure: CQL Editor: using line : FHIR', () => {
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
-        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains('using QICore version \'4.1.1\'')
-        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains('using FHIR version \'4.0.1\'')
+        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains("using QICore version '4.1.1'")
+        cy.get(EditMeasurePage.cqlEditorTextBox.valueOf().toString()).contains("using FHIR version '4.0.1'")
 
-        cy.get(CQLLibraryPage.libraryWarning).children().first().should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
-        cy.get(CQLLibraryPage.libraryWarning).children().last().should('not.contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .first()
+            .should('contain.text', 'Library statement was incorrect. MADiE has overwritten it.')
+        cy.get(CQLLibraryPage.libraryWarning)
+            .children()
+            .last()
+            .should('not.contain.text', 'Incorrect using statement(s) detected. MADiE has corrected it.')
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/QiCoreCQLDefinitions.cy.ts
@@ -1,18 +1,19 @@
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { Utilities } from "../../../../Shared/Utilities"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { Utilities } from '../../../../Shared/Utilities'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
 
 const now = Date.now()
 const measureName = 'QiCoreDefinitions' + now
 const CqlLibraryName = 'QiCoreDefinitionsLib' + now
-const measureCQL = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n' +
-    'include CQMCommon version \'2.2.000\' called CQMCommon\n\n' +
+const measureCQL =
+    "library QiCoreLibrary1723824228401 version '0.0.000'\n" +
+    "using QICore version '4.1.1'\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n" +
+    "include SupplementalDataElements version '3.5.000' called SupplementalData\n" +
+    "include CQMCommon version '2.2.000' called CQMCommon\n\n" +
     'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
     'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
@@ -34,12 +35,13 @@ const measureCQL = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
     'where ValidEncounter.period during "Measurement Period"\n' +
     'and ValidEncounter.isFinishedEncounter()\n\n' +
     'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '   (Enc E where E.status = \'finished\') is not null '
+    "   (Enc E where E.status = 'finished') is not null "
 
-const measureCQL_withError = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n\n' +
+const measureCQL_withError =
+    "library QiCoreLibrary1723824228401 version '0.0.000'\n" +
+    "using QICore version '4.1.1'\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n" +
+    "include SupplementalDataElements version '3.5.000' called SupplementalData\n\n" +
     'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
     'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
@@ -60,13 +62,14 @@ const measureCQL_withError = 'library QiCoreLibrary1723824228401 version \'0.0.0
     'where ValidEncounter.period during "Measurement Period"\n' +
     'and ValidEncounter.isFinishedEncounter()test\n\n' +
     'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '   (Enc E where E.status = \'finished\') is not null'
+    "   (Enc E where E.status = 'finished') is not null"
 
-const cqlMissingDefinitionName = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n' +
-    'include CQMCommon version \'2.2.000\' called CQMCommon\n\n' +
+const cqlMissingDefinitionName =
+    "library QiCoreLibrary1723824228401 version '0.0.000'\n" +
+    "using QICore version '4.1.1'\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n" +
+    "include SupplementalDataElements version '3.5.000' called SupplementalData\n" +
+    "include CQMCommon version '2.2.000' called CQMCommon\n\n" +
     'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
     'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
@@ -89,13 +92,14 @@ const cqlMissingDefinitionName = 'library QiCoreLibrary1723824228401 version \'0
     'where ValidEncounter.period during "Measurement Period"\n' +
     'and ValidEncounter.isFinishedEncounter()\n\n' +
     'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '   (Enc E where E.status = \'finished\') is not null '
+    "   (Enc E where E.status = 'finished') is not null "
 
-const cqlDefinitionNameKeyword = 'library QiCoreLibrary1723824228401 version \'0.0.000\'\n' +
-    'using QICore version \'4.1.1\'\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include SupplementalDataElements version \'3.5.000\' called SupplementalData\n' +
-    'include CQMCommon version \'2.2.000\' called CQMCommon\n\n' +
+const cqlDefinitionNameKeyword =
+    "library QiCoreLibrary1723824228401 version '0.0.000'\n" +
+    "using QICore version '4.1.1'\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n" +
+    "include SupplementalDataElements version '3.5.000' called SupplementalData\n" +
+    "include CQMCommon version '2.2.000' called CQMCommon\n\n" +
     'valueset "Office Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1001\'\n' +
     'valueset "Annual Wellness Visit": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.526.3.1240\'\n' +
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
@@ -118,24 +122,19 @@ const cqlDefinitionNameKeyword = 'library QiCoreLibrary1723824228401 version \'0
     'where ValidEncounter.period during "Measurement Period"\n' +
     'and ValidEncounter.isFinishedEncounter()\n\n' +
     'define fluent function "isFinishedEncounter"(Enc Encounter):\n' +
-    '   (Enc E where E.status = \'finished\') is not null '
+    "   (Enc E where E.status = 'finished') is not null "
 
 describe('Qi-Core CQL Definitions Builder', () => {
-
     beforeEach('Create Measure and Login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         OktaLogin.SessionLogin()
     })
 
     afterEach('Clean up and Logout', () => {
-
-        
         Utilities.deleteMeasure(measureName, CqlLibraryName, false, false, 0)
     })
 
     it('Search for Qi-Core CQL Definitions Expression Editor Name Options', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -157,7 +156,6 @@ describe('Qi-Core CQL Definitions Builder', () => {
     })
 
     it('Search for Qi-Core CQL Definitions Expression Editor Fluent Function Options', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -179,7 +177,6 @@ describe('Qi-Core CQL Definitions Builder', () => {
     })
 
     it('Insert Qi-Core CQL Definitions through Expression Editor and Apply to CQL editor', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -257,14 +254,15 @@ describe('Qi-Core CQL Definitions Builder', () => {
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'define "Test":')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'CQMCommon."Measurement Period"')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', '"Initial Population"')
-        cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'CQMCommon."Emergency Department Arrival Time"()')
+        cy.get(EditMeasurePage.cqlEditorTextBox)
+            .eq(0)
+            .should('contain.text', 'CQMCommon."Emergency Department Arrival Time"()')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', '"emergencyDepartmentArrivalTime"()')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'after end')
         cy.get(EditMeasurePage.cqlEditorTextBox).eq(0).should('contain.text', 'AgeInDays()')
     })
 
     it('Verify Included Qi-Core CQL Definitions under Saved Definitions tab', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -285,7 +283,6 @@ describe('Qi-Core CQL Definitions Builder', () => {
     })
 
     it('Edit Saved Qi-Core CQL Definitions', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -310,7 +307,6 @@ describe('Qi-Core CQL Definitions Builder', () => {
     })
 
     it('Dirty check pops up when there are changes in CQL and Edit CQL definition button is clicked', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -332,7 +328,6 @@ describe('Qi-Core CQL Definitions Builder', () => {
     })
 
     it('Delete saved Qi-Core CQL Definitions', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -346,7 +341,10 @@ describe('Qi-Core CQL Definitions Builder', () => {
         cy.get(CQLEditorPage.deleteCQLDefinitions).click()
         cy.get(CQLEditorPage.deleteContinueButton).click()
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 60000)
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Definition Initial Population has been successfully removed from the CQL.')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Definition Initial Population has been successfully removed from the CQL.'
+        )
 
         //Navigate to Saved Definitions again and assert if the Definition is removed from Saved Definitions
         CQLEditorPage.expandCQLBuilderPanel()
@@ -361,7 +359,6 @@ describe('Qi-Core CQL Definitions Builder', () => {
     })
 
     it('View and Edit Qi Core CQL Definition Comments from Saved Definitions tab', () => {
-
         //Click on Edit Button
         MeasuresPage.actionCenter('edit')
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -376,7 +373,8 @@ describe('Qi-Core CQL Definitions Builder', () => {
         //Verify Comment
         cy.get('[data-testid="definitions-row-0"] > :nth-child(3)').should('contain.text', 'Test Comments')
 
-        const longComment = 'Adding a comment that is needlessly long for no real reason, other than to' +
+        const longComment =
+            'Adding a comment that is needlessly long for no real reason, other than to' +
             ' annoy any future users of this piece of functionality. It really should not have to be like' +
             ' this but here we are anyway'
         //Edit Comment
@@ -393,13 +391,13 @@ describe('Qi-Core CQL Definitions Builder', () => {
 
         //Navigate to Saved Definitions tab and verify comment
         cy.get(CQLEditorPage.savedDefinitionsTab).click()
-        const shortenedComment = 'Adding a comment that is needlessly long for no real reason, other than to' +
+        const shortenedComment =
+            'Adding a comment that is needlessly long for no real reason, other than to' +
             ' annoy any future users of this piece of functShow more'
         cy.get('[data-testid="definitions-row-0"] > :nth-child(3)').should('contain.text', shortenedComment)
     })
 
     it('Verify error message appears on Definitions tab when there is an error in the Measure CQL', () => {
-
         MeasuresPage.actionCenter('edit')
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
@@ -419,7 +417,10 @@ describe('Qi-Core CQL Definitions Builder', () => {
         //Navigate to Definitions tab
         CQLEditorPage.expandCQLBuilderPanel()
         cy.get(CQLEditorPage.definitionsTab).click()
-        cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
+        cy.get('[data-testid="cql-builder-errors"]').should(
+            'contain.text',
+            'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.'
+        )
 
         //Navigate to Saved Definitions tab
         cy.get(CQLEditorPage.savedDefinitionsTab).should('contain.text', 'Saved Definitions (0)').click()
@@ -428,15 +429,11 @@ describe('Qi-Core CQL Definitions Builder', () => {
 })
 
 describe('Qi-Core CQL Definitions - Expression Editor Name Option Validations', () => {
-
     afterEach('Clean up and Logout', () => {
-
-        
         Utilities.deleteMeasure(measureName, CqlLibraryName, false, false, 0)
     })
 
-    it.only('Qi-Core CQL Definitions Expression editor Name options are not available when CQL has errors', () => {
-
+    it('Qi-Core CQL Definitions Expression editor Name options are not available when CQL has errors', () => {
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL_withError)
         OktaLogin.Login()
 
@@ -456,16 +453,18 @@ describe('Qi-Core CQL Definitions - Expression Editor Name Option Validations', 
         //Click on Definitions tab
         cy.get(CQLEditorPage.definitionsTab).click()
 
-        cy.get('[data-testid="cql-builder-errors"]').should('contain.text', 'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.')
+        cy.get('[data-testid="cql-builder-errors"]').should(
+            'contain.text',
+            'Unable to retrieve CQL builder lookups. Please verify CQL has no errors. If CQL is valid, please contact the help desk.'
+        )
 
         //Expression editor name dropdown should be empty when there are CQL errors
         cy.get(CQLEditorPage.definitionNameTextBox).type('test')
-        cy.get( CQLEditorPage.expressionEditorTypeDropdown ).click()
+        cy.get(CQLEditorPage.expressionEditorTypeDropdown).click()
         cy.get(CQLEditorPage.expressionEditorNameList).should('not.exist')
     })
 
     it('Qi-Core CQL Definitions throws specific error when Definition has no name', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, cqlMissingDefinitionName)
         OktaLogin.Login()
 
@@ -474,11 +473,14 @@ describe('Qi-Core CQL Definitions - Expression Editor Name Option Validations', 
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()
 
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, "Parse: 7:8 | Definition is missing a name.")
+        Utilities.validateErrors(
+            CQLEditorPage.errorInCQLEditorWindow,
+            CQLEditorPage.errorContainer,
+            'Parse: 7:8 | Definition is missing a name.'
+        )
     })
 
     it('Qi-Core CQL Definitions throws specific error when Definition name is a reserved keyword', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, cqlDefinitionNameKeyword)
         OktaLogin.Login()
 
@@ -487,27 +489,26 @@ describe('Qi-Core CQL Definitions - Expression Editor Name Option Validations', 
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(CQLEditorPage.expandCQLBuilder).click()
 
-        Utilities.validateErrors(CQLEditorPage.errorInCQLEditorWindow, CQLEditorPage.errorContainer, "Parse: 7:13 | Definition names must not be a reserved word.")
+        Utilities.validateErrors(
+            CQLEditorPage.errorInCQLEditorWindow,
+            CQLEditorPage.errorContainer,
+            'Parse: 7:13 | Definition names must not be a reserved word.'
+        )
     })
 })
 
 describe('Qi-Core CQL Definitions - Measure ownership Validations', () => {
-
     beforeEach('Create Measure and Login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         OktaLogin.SessionAltLogin()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
     })
 
     afterEach('Clean up and Logout', () => {
-
-        
         Utilities.deleteMeasure(measureName, CqlLibraryName, false, false, 0)
     })
 
     it('Verify Non Measure owner unable to Edit/Delete saved Definitions', () => {
-
         //Navigate to All Measures page
         cy.get(MeasuresPage.allMeasuresTab).click()
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseButtons.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDMTestCaseButtons.cy.ts
@@ -1,15 +1,17 @@
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { CreateMeasureOptions, CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasureActions, EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { TestCase, TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { Header } from "../../../../Shared/Header"
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
+import { CreateMeasureOptions, CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasureActions, EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { TestCase, TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { Header } from '../../../../Shared/Header'
+
+let randValue = Math.floor(Math.random() * 1000 + 1)
 const now = Date.now()
 const measure = {
     name: 'QDMTestCaseButtons' + now + randValue,
@@ -31,9 +33,7 @@ const testCase2: TestCase = {
 const measureData: CreateMeasureOptions = {}
 
 describe('Test case list page - Action Center icons for measure owner', () => {
-
     beforeEach('Create measure and login', () => {
-
         measureData.ecqmTitle = measure.name
         measureData.cqlLibraryName = measure.cqlLibraryName
         measureData.measureScoring = 'Proportion'
@@ -43,15 +43,18 @@ describe('Test case list page - Action Center icons for measure owner', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        TestCasesPage.CreateQDMTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase2.json,)
-        TestCasesPage.CreateQDMTestCaseAPI(testCase2.title, testCase2.group, testCase2.description, testCase2.json, true)
+        TestCasesPage.CreateQDMTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase2.json)
+        TestCasesPage.CreateQDMTestCaseAPI(
+            testCase2.title,
+            testCase2.group,
+            testCase2.description,
+            testCase2.json,
+            true
+        )
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 8500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
@@ -62,8 +65,8 @@ describe('Test case list page - Action Center icons for measure owner', () => {
         //navigate to the criteria section of the PC
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
-        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, "Denominator")
-        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, "Numerator")
+        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
+        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, 'Numerator')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         Utilities.waitForElementDisabled(MeasureGroupPage.saveMeasureGroupDetails, 9500)
 
@@ -73,23 +76,19 @@ describe('Test case list page - Action Center icons for measure owner', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
 
     it('Delete icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterDelete).should('be.disabled')
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterDelete).should('be.enabled')
         TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterDelete).should('be.enabled')
-
     })
 
     it('Clone icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterClone).should('be.enabled')
@@ -100,7 +99,11 @@ describe('Test case list page - Action Center icons for measure owner', () => {
     it('Export icon is present and enables correctly', () => {
         let currentUser = Cypress.env('selectedUser')
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
-        cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Test cases must be executed prior to exporting.')
+        cy.get('[data-testid="export-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Test cases must be executed prior to exporting.'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
@@ -114,8 +117,7 @@ describe('Test case list page - Action Center icons for measure owner', () => {
 
         let qrdaButton: string
         let excelButton: string
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').then(measureId => {
-
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').then((measureId) => {
             qrdaButton = '[data-testid="export-qrda-' + measureId + '"]'
             excelButton = '[data-testid="export-excel-' + measureId + '"]'
 
@@ -125,13 +127,20 @@ describe('Test case list page - Action Center icons for measure owner', () => {
     })
 
     it('Shift dates icon is present and enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterShiftDates).should('be.disabled')
-        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to shift test case dates')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Select test cases to shift test case dates'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
-        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should('have.attr', 'aria-label', 'Shift test case dates')
+        cy.get('[data-testid="shift-test-case-dates-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Shift test case dates'
+        )
 
         TestCasesPage.checkTestCase(1)
         cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
@@ -144,9 +153,7 @@ describe('Test case list page - Action Center icons for measure owner', () => {
 })
 
 describe('Test case list page - Action Center icons for versioned measure', () => {
-
     beforeEach('Create measure and login', () => {
-
         measureData.ecqmTitle = measure.name
         measureData.cqlLibraryName = measure.cqlLibraryName
         measureData.measureScoring = 'Proportion'
@@ -156,15 +163,18 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        TestCasesPage.CreateQDMTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase2.json,)
-        TestCasesPage.CreateQDMTestCaseAPI(testCase2.title, testCase2.group, testCase2.description, testCase2.json, true)
+        TestCasesPage.CreateQDMTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase2.json)
+        TestCasesPage.CreateQDMTestCaseAPI(
+            testCase2.title,
+            testCase2.group,
+            testCase2.description,
+            testCase2.json,
+            true
+        )
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 8500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
@@ -175,8 +185,8 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         //navigate to the criteria section of the PC
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
-        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, "Denominator")
-        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, "Numerator")
+        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
+        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, 'Numerator')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         Utilities.waitForElementDisabled(MeasureGroupPage.saveMeasureGroupDetails, 9500)
 
@@ -184,7 +194,6 @@ describe('Test case list page - Action Center icons for versioned measure', () =
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteVersionedMeasure(measure.name, measure.cqlLibraryName)
     })
@@ -196,9 +205,12 @@ describe('Test case list page - Action Center icons for versioned measure', () =
         cy.get(TestCasesPage.actionCenterDelete).should('be.disabled')
         cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
 
-
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
-        cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Test cases must be executed prior to exporting.')
+        cy.get('[data-testid="export-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Test cases must be executed prior to exporting.'
+        )
 
         cy.get(TestCasesPage.executeTestCaseButton).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 30500)
@@ -207,23 +219,24 @@ describe('Test case list page - Action Center icons for versioned measure', () =
 
         let qrdaButton: string
         let excelButton: string
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').then(measureId => {
-
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').then((measureId) => {
             qrdaButton = '[data-testid="export-qrda-' + measureId + '"]'
             excelButton = '[data-testid="export-excel-' + measureId + '"]'
 
             cy.get(qrdaButton).should('be.visible')
             cy.get(excelButton).should('be.visible').click()
         })
-
     })
 
     it('Copy To icon is present and it enables correctly', () => {
-
         cy.get(EditMeasurePage.testCasesTab).click()
 
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
-        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+        cy.get('[data-testid="copy-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Select test cases to copy to another measure'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
@@ -234,14 +247,11 @@ describe('Test case list page - Action Center icons for versioned measure', () =
 
         cy.contains('Copy To').should('be.visible')
         cy.get(MeasuresPage.measureListTitles).should('be.visible')
-
     })
 })
 
 describe('Test case list page - Action Center icons for non-owner', () => {
-
     beforeEach('Create measure and login', () => {
-
         measureData.ecqmTitle = measure.name
         measureData.cqlLibraryName = measure.cqlLibraryName
         measureData.measureScoring = 'Proportion'
@@ -251,15 +261,18 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         measureData.mpEndDate = '2025-12-31'
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
-        TestCasesPage.CreateQDMTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase2.json,)
-        TestCasesPage.CreateQDMTestCaseAPI(testCase2.title, testCase2.group, testCase2.description, testCase2.json, true)
+        TestCasesPage.CreateQDMTestCaseAPI(testCase1.title, testCase1.group, testCase1.description, testCase2.json)
+        TestCasesPage.CreateQDMTestCaseAPI(
+            testCase2.title,
+            testCase2.group,
+            testCase2.description,
+            testCase2.json,
+            true
+        )
 
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 8500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.measures).click()
         MeasuresPage.actionCenter('edit')
@@ -270,8 +283,8 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         //navigate to the criteria section of the PC
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Initial Population')
-        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, "Denominator")
-        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, "Numerator")
+        Utilities.populationSelect(MeasureGroupPage.denominatorSelect, 'Denominator')
+        Utilities.populationSelect(MeasureGroupPage.numeratorSelect, 'Numerator')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         Utilities.waitForElementDisabled(MeasureGroupPage.saveMeasureGroupDetails, 9500)
         OktaLogin.UILogout()
@@ -283,7 +296,6 @@ describe('Test case list page - Action Center icons for non-owner', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         OktaLogin.UILogout()
         Utilities.deleteMeasure(measure.name, measure.cqlLibraryName)
     })
@@ -295,7 +307,11 @@ describe('Test case list page - Action Center icons for non-owner', () => {
         cy.get(TestCasesPage.actionCenterClone).should('not.exist')
 
         cy.get(TestCasesPage.actionCenterExport).should('be.disabled')
-        cy.get('[data-testid="export-tooltip"]').should('have.attr', 'aria-label', 'Test cases must be executed prior to exporting.')
+        cy.get('[data-testid="export-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Test cases must be executed prior to exporting.'
+        )
 
         cy.get(TestCasesPage.executeTestCaseButton).click()
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 30500)
@@ -304,21 +320,22 @@ describe('Test case list page - Action Center icons for non-owner', () => {
 
         let qrdaButton: string
         let excelButton: string
-        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').then(measureId => {
-
+        cy.readFile('cypress/fixtures/' + currentUser + '/measureId').then((measureId) => {
             qrdaButton = '[data-testid="export-qrda-' + measureId + '"]'
             excelButton = '[data-testid="export-excel-' + measureId + '"]'
 
             cy.get(qrdaButton).should('be.visible')
             cy.get(excelButton).should('be.visible').click()
         })
-
     })
 
     it('Non-owner sees Copy To icon; it enables correctly', () => {
-
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
-        cy.get('[data-testid="copy-tooltip"]').should('have.attr', 'aria-label', 'Select test cases to copy to another measure')
+        cy.get('[data-testid="copy-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Select test cases to copy to another measure'
+        )
 
         TestCasesPage.checkTestCase(2)
         cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
@@ -329,7 +346,5 @@ describe('Test case list page - Action Center icons for non-owner', () => {
 
         cy.contains('Copy To').should('be.visible')
         cy.get(MeasuresPage.measureListTitles).should('be.visible')
-
     })
 })
-

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationActualValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationActualValues.cy.ts
@@ -59,11 +59,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{movetoEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorExpandCollapseBtn).click()
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         //Click on the measure group tab
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -92,7 +88,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -118,10 +114,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         //Click on the measure group tab
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -168,7 +161,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -209,10 +202,7 @@ describe('Boolean Measure Observation Actual values', () => {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         //Click on the measure group tab
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -235,7 +225,7 @@ describe('Boolean Measure Observation Actual values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -261,10 +251,7 @@ describe('Boolean Measure Observation Actual values', () => {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         //Click on the measure group tab
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -305,7 +292,7 @@ describe('Boolean Measure Observation Actual values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
@@ -326,7 +326,7 @@ describe('Attempting to create a test case without a title', () => {
     })
 })
 
-describe.only('Duplicate Test Case Title and Group validations', () => {
+describe('Duplicate Test Case Title and Group validations', () => {
     beforeEach('Create Measure, Test case and Login', () => {
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Procedure')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
@@ -1,14 +1,14 @@
-import { OktaLogin } from "../../../../../Shared/OktaLogin"
-import { CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
-import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
-import { Utilities } from "../../../../../Shared/Utilities"
-import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
-import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
-import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
-import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
-import { Header } from "../../../../../Shared/Header"
+import { OktaLogin } from '../../../../../Shared/OktaLogin'
+import { CreateMeasurePage } from '../../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../../Shared/EditMeasurePage'
+import { MeasureGroupPage } from '../../../../../Shared/MeasureGroupPage'
+import { Utilities } from '../../../../../Shared/Utilities'
+import { MeasureCQL } from '../../../../../Shared/MeasureCQL'
+import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
+import { TestCaseJson } from '../../../../../Shared/TestCaseJson'
+import { CQLEditorPage } from '../../../../../Shared/CQLEditorPage'
+import { Header } from '../../../../../Shared/Header'
 
 const now = Date.now()
 let measureName = 'TCValidations' + now
@@ -18,24 +18,22 @@ let testCaseDescription = 'DENOMFail' + now
 let validTestCaseJson = TestCaseJson.TestCaseJson_Valid
 let measureCQL = MeasureCQL.ICFCleanTest_CQL
 let testCaseSeries = 'SBTestSeries'
-let twoFiftyTwoCharacters = 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr'
+let twoFiftyTwoCharacters =
+    'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr'
 let updatedTestCaseDescription = testCaseDescription + ' ' + 'UpdatedTestCaseDescription'
 let updatedTestCaseSeries = 'CMSTestSeries'
 
 describe('Test Case Validations', () => {
-
     beforeEach('Login', () => {
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
         OktaLogin.Login()
     })
 
     afterEach('Logout', () => {
-        
         Utilities.deleteMeasure(measureName, CqlLibraryName)
     })
 
     it('Create Test Case: Description more than 250 characters', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -48,7 +46,6 @@ describe('Test Case Validations', () => {
     })
 
     it('Edit Test Case: Description more than 250 characters', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -63,11 +60,14 @@ describe('Test Case Validations', () => {
         cy.get(TestCasesPage.testCaseDescriptionTextBox).clear()
         cy.get(TestCasesPage.testCaseDescriptionTextBox).type(twoFiftyTwoCharacters, { delay: 0 })
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.editTCSaveTooltip).should('have.attr', 'aria-label', 'description: Test Case Description cannot be more than 250 characters.')
+        cy.get(TestCasesPage.editTCSaveTooltip).should(
+            'have.attr',
+            'aria-label',
+            'description: Test Case Description cannot be more than 250 characters.'
+        )
     })
 
     it('Create Test Case: Title more than 250 characters', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -83,12 +83,12 @@ describe('Test Case Validations', () => {
         cy.get(TestCasesPage.createTestCaseTitleInput).type(twoFiftyTwoCharacters)
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type(testCaseDescription)
         cy.get(TestCasesPage.createTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.createTestCaseTitleInlineError).contains('Test Case Title cannot be more ' +
-            'than 250 characters.')
+        cy.get(TestCasesPage.createTestCaseTitleInlineError).contains(
+            'Test Case Title cannot be more ' + 'than 250 characters.'
+        )
     })
 
     it('Edit Test Case: Title more than 250 characters', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -110,12 +110,12 @@ describe('Test Case Validations', () => {
         cy.get(TestCasesPage.testCaseTitle).type(twoFiftyTwoCharacters, { delay: 0 })
         cy.get(TestCasesPage.createTestCaseGroupInput).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.editTestCaseTitleInlineError).contains('Test Case Title cannot be more ' +
-            'than 250 characters.')
+        cy.get(TestCasesPage.editTestCaseTitleInlineError).contains(
+            'Test Case Title cannot be more ' + 'than 250 characters.'
+        )
     })
 
     it('Create Test Case: Group has more than 250 characters', () => {
-    
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -132,12 +132,12 @@ describe('Test Case Validations', () => {
         cy.get(TestCasesPage.createTestCaseGroupInput).type(twoFiftyTwoCharacters)
         cy.get('[data-testid*="Add"]').last().click()
         cy.get(TestCasesPage.createTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.testCaseGroupInlineError).contains('Test Case Group cannot be more ' +
-            'than 250 characters.')
+        cy.get(TestCasesPage.testCaseGroupInlineError).contains(
+            'Test Case Group cannot be more ' + 'than 250 characters.'
+        )
     })
 
     it('Edit Test Case: Group more than 250 characters', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -157,22 +157,24 @@ describe('Test Case Validations', () => {
 })
 
 describe('Attempting to create a test case without a title', () => {
-
     beforeEach('Create measure and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateRatioMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Surgical Absence of Cervix', 'Surgical Absence of Cervix', 'Procedure')
+        MeasureGroupPage.CreateRatioMeasureGroupAPI(
+            false,
+            false,
+            'Surgical Absence of Cervix',
+            'Surgical Absence of Cervix',
+            'Surgical Absence of Cervix',
+            'Procedure'
+        )
         OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
-        
         Utilities.deleteMeasure(measureName, CqlLibraryName)
     })
 
     it('Create Test Case without a title', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -188,7 +190,6 @@ describe('Attempting to create a test case without a title', () => {
     })
 
     it('Edit and update test case to have no title', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -325,32 +326,23 @@ describe('Attempting to create a test case without a title', () => {
     })
 })
 
-describe('Duplicate Test Case Title and Group validations', () => {
-
+describe.only('Duplicate Test Case Title and Group validations', () => {
     beforeEach('Create Measure, Test case and Login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Procedure')
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 16500)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
     })
 
     afterEach('Cleanup and Logout', () => {
-
         Utilities.deleteMeasure(measureName, CqlLibraryName)
-        
     })
 
     it('Create Test Case: Verify error message when the Test case Title and group names are duplicate', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -381,11 +373,13 @@ describe('Duplicate Test Case Title and Group validations', () => {
 
         cy.get(TestCasesPage.createTestCaseSaveButton).click()
 
-        cy.get(EditMeasurePage.errorMessage).should('contain.text', 'An error occurred while creating the test case: The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
+        cy.get(EditMeasurePage.errorMessage).should(
+            'contain.text',
+            'An error occurred while creating the test case: The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.'
+        )
     })
 
     it('Edit Test Case: Verify error message when the Test case Title and group names are duplicate', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -418,12 +412,18 @@ describe('Duplicate Test Case Title and Group validations', () => {
         //Edit First Test case
         TestCasesPage.clickEditforCreatedTestCase()
         cy.get(TestCasesPage.detailsTab).click()
-        cy.get(TestCasesPage.testCaseTitle).clear().type('{selectall}{backspace}{selectall}{backspace}').type('SecondTestCase'.toString())
+        cy.get(TestCasesPage.testCaseTitle)
+            .clear()
+            .type('{selectall}{backspace}{selectall}{backspace}')
+            .type('SecondTestCase'.toString())
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
         cy.get(TestCasesPage.createTestCaseGroupInput).clear().type('SecondTestCaseGroup').type('{downArrow}{enter}')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.errorToastMsg).should('contain.text', 'The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.')
+        cy.get(TestCasesPage.errorToastMsg).should(
+            'contain.text',
+            'The Test Case Group and Title combination is not unique. The combination must be unique (case insensitive, spaces ignored) across all test cases associated with the measure.'
+        )
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
@@ -1,13 +1,13 @@
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
 
 let measureName = 'ProportionEpisode' + Date.now()
 let CqlLibraryName = 'ProportionEpisode' + Date.now()
@@ -16,10 +16,11 @@ let testCaseTitle = 'PASS'
 let testCaseDescription = 'PASS' + Date.now()
 let testCaseSeries = 'SBTestSeries'
 let testCaseJson = TestCaseJson.ProportionEpisode_PASS
-let measureCQL = 'library ProportionEpisodeMeasure version \'0.0.000\'\n\n' +
-    'using QICore version \'4.1.1\'\n\n' +
-    'include FHIRHelpers version \'4.1.000\' called FHIRHelpers\n' +
-    'include CQMCommon version \'1.0.000\' called Global\n\n' +
+let measureCQL =
+    "library ProportionEpisodeMeasure version '0.0.000'\n\n" +
+    "using QICore version '4.1.1'\n\n" +
+    "include FHIRHelpers version '4.1.000' called FHIRHelpers\n" +
+    "include CQMCommon version '1.0.000' called Global\n\n" +
     'codesystem "SNOMED": \'http://snomed.info/sct\'\n\n' +
     'valueset "Encounter Inpatient": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.666.5.307\'\n\n' +
     'code "Unscheduled (qualifier value)": \'103390000\' from "SNOMED" display \'Unscheduled (qualifier value)\'\n\n' +
@@ -28,7 +29,7 @@ let measureCQL = 'library ProportionEpisodeMeasure version \'0.0.000\'\n\n' +
     'context Patient\n\n' +
     'define "Initial Population":\n' +
     '   [Encounter: "Encounter Inpatient"] InptEncounter\n' +
-    '      where InptEncounter.status = \'finished\' \n\n' +
+    "      where InptEncounter.status = 'finished' \n\n" +
     'define "Denominator":\n' +
     '    "Initial Population" IP\n' +
     '      where IP.period ends during day of "Measurement Period"\n\n' +
@@ -41,30 +42,40 @@ let measureCQL = 'library ProportionEpisodeMeasure version \'0.0.000\'\n\n' +
     '          where Enc.priority ~ "Unscheduled (qualifier value)"\n' +
     '          })'
 
-
 describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => {
-
     beforeEach('Create Measure, Test Case and Login', () => {
-
         CqlLibraryName = 'ProportionEpisode' + Date.now()
 
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL, 0, false,
-            '2023-01-01', '2023-12-31')
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            measureName,
+            CqlLibraryName,
+            measureCQL,
+            0,
+            false,
+            '2023-01-01',
+            '2023-12-31'
+        )
 
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial Population',
-            '', '', 'Numerator', '', 'Denominator', 'Encounter')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial Population',
+            '',
+            '',
+            'Numerator',
+            '',
+            'Denominator',
+            'Encounter'
+        )
 
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries, testCaseJson)
 
         OktaLogin.Login()
 
         //Click on Edit Button
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(Header.mainMadiePageButton).click()
 
@@ -91,16 +102,14 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
     })
 
     after('Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Versioned Measure: Create New Test Case, delete is enabled', () => {
-
         let currentUser = Cypress.env('selectedUser')
         let filePath = 'cypress/fixtures/' + currentUser + '/measureId'
         //Click on Edit Button
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -128,8 +137,10 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         cy.get(TestCasesPage.detailsTab).should('be.visible')
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.successMsg).should('contain.text', 'Test case updated successfully ' +
-            'with warnings in JSON')
+        cy.get(TestCasesPage.successMsg).should(
+            'contain.text',
+            'Test case updated successfully ' + 'with warnings in JSON'
+        )
 
         cy.get(EditMeasurePage.testCasesTab).click()
 
@@ -155,11 +166,15 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
         MeasuresPage.actionCenter('draft')
 
-        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type('DraftedMeasure0001' + Date.now())
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox)
+            .clear()
+            .type('DraftedMeasure0001' + Date.now())
         //intercept draft id once measure is drafted
-        cy.readFile(filePath).should('exist').then((fileContents) => {
-            cy.intercept('POST', '/api/measures/' + fileContents + '/draft').as('draft')
-        })
+        cy.readFile(filePath)
+            .should('exist')
+            .then((fileContents) => {
+                cy.intercept('POST', '/api/measures/' + fileContents + '/draft').as('draft')
+            })
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.wait('@draft', { timeout: 60000 }).then((request) => {
             cy.writeFile(filePath, request?.response?.body.id)
@@ -170,7 +185,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         //navigate back to the main MADiE / measure list page
         cy.get(Header.mainMadiePageButton).scrollIntoView().click()
         //Click on Edit Button
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         //Navigate to Test Cases page
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -187,12 +202,11 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
     })
 
     it('Versioned Measure: Edit Test Case, delete is disabled', () => {
-
         let currentUser = Cypress.env('selectedUser')
         let filePath = 'cypress/fixtures/' + currentUser + '/measureId'
 
         //Click on Edit Button
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         //Navigate to Test Cases page and add Test Case details
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -215,7 +229,10 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
-        cy.get('[data-testid="test-case-alerts"]').should('have.text', 'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.')
+        cy.get('[data-testid="test-case-alerts"]').should(
+            'have.text',
+            'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.'
+        )
         cy.get(EditMeasurePage.testCasesTab).click()
 
         cy.get(TestCasesPage.executeTestCaseButton).should('exist')
@@ -238,11 +255,15 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
         MeasuresPage.actionCenter('draft')
 
-        cy.get(MeasuresPage.updateDraftedMeasuresTextBox).clear().type('DraftedMeasure0001' + Date.now())
+        cy.get(MeasuresPage.updateDraftedMeasuresTextBox)
+            .clear()
+            .type('DraftedMeasure0001' + Date.now())
         //intercept draft id once measure is drafted
-        cy.readFile(filePath).should('exist').then((fileContents) => {
-            cy.intercept('POST', '/api/measures/' + fileContents + '/draft').as('draft')
-        })
+        cy.readFile(filePath)
+            .should('exist')
+            .then((fileContents) => {
+                cy.intercept('POST', '/api/measures/' + fileContents + '/draft').as('draft')
+            })
         cy.get(MeasuresPage.createDraftContinueBtn).click()
         cy.wait('@draft', { timeout: 60000 }).then((request) => {
             cy.writeFile(filePath, request?.response?.body.id)
@@ -253,7 +274,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
         //navigate back to the main MADiE / measure list page
         cy.get(Header.mainMadiePageButton).scrollIntoView().click()
         //Click on Edit Button
-        MeasuresPage.actionCenter("edit")
+        MeasuresPage.actionCenter('edit')
 
         //Navigate to Test Cases page
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')


### PR DESCRIPTION
## Summary

Adds follow-up regression fixes across measure observations, measure history, measure buttons, QI-Core CQL definitions, QDM test case buttons, QI-Core test case validations, and versioned measure test case workflows.

## Changes

- Updated Measure Observations regression coverage.
- Updated Measure History regression coverage.
- Updated Edit Measure button workflow coverage.
- Updated QI-Core CQL Definitions regression coverage.
- Updated QDM Test Case button workflow coverage.
- Updated QI-Core Test Case validation coverage.
- Updated Versioned Measure create/edit/delete test case coverage.
- Removed focused `.only` markers from affected regression specs.

## Validation

- `npm run compile`
- `git diff --check`