### PR TITLE
Improve rerun reporting clarity

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -267,6 +267,7 @@ pipeline {
             *)
               set +e
               FAILED_TEST_SUMMARY=${WORKSPACE}/failure-summary-${BUILD_NUMBER}.json \
+                RERUN_TARGETING_FILE=${WORKSPACE}/rerun-targeting-1-${BUILD_NUMBER}.json \
                 CYPRESS_RERUN_CONFIG=test \
                 timeout 4h npm run ${RERUN_SCRIPT}
               RERUN_STATUS=$?
@@ -279,6 +280,7 @@ pipeline {
           fi
 
           # Extract failures and human-readable failure details from rerun #1
+          RERUN_TARGETING_FILE=${WORKSPACE}/rerun-targeting-1-${BUILD_NUMBER}.json \
           node scripts/extract-failure-details.js \
             ${WORKSPACE}/failures-rerun1-${BUILD_NUMBER}.txt \
             ${WORKSPACE}/failure-details-rerun1-${BUILD_NUMBER}.txt \
@@ -325,6 +327,7 @@ pipeline {
             *)
               set +e
               FAILED_TEST_SUMMARY=${WORKSPACE}/failure-summary-rerun1-${BUILD_NUMBER}.json \
+                RERUN_TARGETING_FILE=${WORKSPACE}/rerun-targeting-2-${BUILD_NUMBER}.json \
                 CYPRESS_RERUN_CONFIG=test \
                 timeout 4h npm run ${RERUN_SCRIPT}
               RERUN_STATUS=$?
@@ -337,6 +340,7 @@ pipeline {
           fi
 
           # Extract failures and human-readable failure details from rerun #2
+          RERUN_TARGETING_FILE=${WORKSPACE}/rerun-targeting-2-${BUILD_NUMBER}.json \
           node scripts/extract-failure-details.js \
             ${WORKSPACE}/failures-rerun2-${BUILD_NUMBER}.txt \
             ${WORKSPACE}/failure-details-rerun2-${BUILD_NUMBER}.txt \
@@ -385,8 +389,10 @@ pipeline {
     always {
       script {
         try {
+          def jsonSlurper = new groovy.json.JsonSlurperClassic()
           String ws = env.WORKSPACE
           String bn = env.BUILD_NUMBER
+          String trendPath = "${ws}/failure-trend-${bn}.json"
 
           def readList = { String p -> fileExists(p) ? readFile(p).readLines().findAll { it?.trim() } : [] }
           List<String> l0 = readList("${ws}/failures-${bn}.txt")
@@ -412,6 +418,55 @@ pipeline {
           String urlDetailsR1   = "${env.BUILD_URL}artifact/failure-details-rerun1-${bn}.txt"
           String urlDetailsR2   = "${env.BUILD_URL}artifact/failure-details-rerun2-${bn}.txt"
           String urlTrend       = "${env.BUILD_URL}artifact/failure-trend-${bn}.md"
+          String normalizedSummary = ''
+
+          if (fileExists(trendPath)) {
+            def trend = jsonSlurper.parseText(readFile(trendPath))
+            def initialRun = trend.runs?.initial ?: [:]
+            def rerun1Run = trend.runs?.rerun1 ?: [:]
+            def rerun2Run = trend.runs?.rerun2 ?: [:]
+            def initialExecution = initialRun.execution ?: [:]
+            def rerun1Execution = rerun1Run.execution ?: [:]
+            def rerun2Execution = rerun2Run.execution ?: [:]
+            def rerun1Targeting = rerun1Run.targeting ?: [:]
+            def rerun2Targeting = rerun2Run.targeting ?: [:]
+
+            outcome = trend.outcome ? "✅ ${trend.outcome}." : outcome
+            passed = !(trend.outcome ?: '').toString().startsWith('Failures remained')
+
+            normalizedSummary = """\
+Normalized summary:
+• Initial run: ${initialExecution.executedSpecCount ?: 0} specs, ${initialExecution.testsRegistered ?: 0} registered, ${initialExecution.testsPassing ?: 0} passed, ${initialExecution.testsFailing ?: 0} failed, ${initialExecution.testsSkipped ?: 0} skipped
+• Rerun #1: ${rerun1Targeting.targetedSpecCount ?: 0} targeted specs, ${rerun1Targeting.targetedTestCount ?: 0} targeted failed tests, ${rerun1Execution.testsRegistered ?: 0} registered in opened specs, ${rerun1Execution.filteredOut ?: 0} filtered out, ${rerun1Run.failedSpecCount ?: 0} failed specs remaining
+• Rerun #2: ${rerun2Targeting.targetedSpecCount ?: 0} targeted specs, ${rerun2Targeting.targetedTestCount ?: 0} targeted failed tests, ${rerun2Execution.testsRegistered ?: 0} registered in opened specs, ${rerun2Execution.filteredOut ?: 0} filtered out, ${rerun2Run.failedSpecCount ?: 0} failed specs remaining
+""".stripIndent().trim()
+
+            echo """
+=== Normalized Failure Summary ===
+Outcome: ${trend.outcome ?: outcome}
+
+Initial run:
+  specs executed: ${initialExecution.executedSpecCount ?: 0}
+  tests registered: ${initialExecution.testsRegistered ?: 0}
+  passed: ${initialExecution.testsPassing ?: 0}
+  failed: ${initialExecution.testsFailing ?: 0}
+  skipped: ${initialExecution.testsSkipped ?: 0}
+
+Rerun #1:
+  targeted specs: ${rerun1Targeting.targetedSpecCount ?: 0}
+  targeted failed tests: ${rerun1Targeting.targetedTestCount ?: 0}
+  tests registered in opened specs: ${rerun1Execution.testsRegistered ?: 0}
+  filtered out: ${rerun1Execution.filteredOut ?: 0}
+  remaining failed specs: ${rerun1Run.failedSpecCount ?: 0}
+
+Rerun #2:
+  targeted specs: ${rerun2Targeting.targetedSpecCount ?: 0}
+  targeted failed tests: ${rerun2Targeting.targetedTestCount ?: 0}
+  tests registered in opened specs: ${rerun2Execution.testsRegistered ?: 0}
+  filtered out: ${rerun2Execution.filteredOut ?: 0}
+  remaining failed specs: ${rerun2Run.failedSpecCount ?: 0}
+""".stripIndent()
+          }
 
           String msg = """\
 ${passed ? "All test cases passed" : "Failures remain after 2nd rerun"}
@@ -421,6 +476,8 @@ Counts:
 • Initial failures: ${c0}
 • After rerun #1:  ${c1}
 • After rerun #2:  ${c2}
+
+${normalizedSummary ? normalizedSummary + "\n" : ""}
 
 Reports:
 • initial: ${urlInit}

--- a/cypress/support/failedTestFilter.ts
+++ b/cypress/support/failedTestFilter.ts
@@ -101,21 +101,21 @@ if (failedTestTitles.size) {
   const wrapIt = (itFn: any) => {
     const wrapped = function (title: string, fn?: Mocha.Func) {
       const shouldRun = failedTestTitles.has(fullTitle(title))
-      const test = itFn(title, shouldRun ? fn : undefined)
       if (!shouldRun) {
-        test.pending = true
+        // Do not register filtered-out rerun tests at all. Marking them pending
+        // makes the rerun report look incomplete even though the rerun did finish.
+        return undefined
       }
-      return test
+      return itFn(title, fn)
     }
 
     wrapped.only = itFn.only
       ? function (title: string, fn?: Mocha.Func) {
           const shouldRun = failedTestTitles.has(fullTitle(title))
-          const test = itFn.only(title, shouldRun ? fn : undefined)
           if (!shouldRun) {
-            test.pending = true
+            return undefined
           }
-          return test
+          return itFn.only(title, fn)
         }
       : undefined
     wrapped.skip = itFn.skip ? itFn.skip.bind(itFn) : undefined

--- a/scripts/extract-failure-details.js
+++ b/scripts/extract-failure-details.js
@@ -22,6 +22,7 @@ const hasSummaryOutput = Boolean(
 )
 const summaryJsonFile = hasSummaryOutput ? maybeSummaryJsonFile : null
 const runLabel = (hasSummaryOutput ? process.argv[5] : process.argv[4]) || 'Cypress failures'
+const rerunTargetingFile = process.env.RERUN_TARGETING_FILE || ''
 
 if (!specOutputFile || !detailsOutputFile) {
   console.error('Usage: node scripts/extract-failure-details.js spec-output-file details-output-file [summary-json-file] [run-label]')
@@ -40,6 +41,19 @@ const resolvedSummaryJsonFile = summaryJsonFile ? resolveOutputPath(summaryJsonF
 const failedSpecs = new Set()
 const failures = []
 const seenFailures = new Set()
+const runMetrics = {
+  executedSpecs: new Set(),
+  testsRegistered: 0,
+  testsPassing: 0,
+  testsFailing: 0,
+  testsPending: 0,
+  testsSkipped: 0,
+  screenshots: 0,
+  durationMs: 0,
+  usedMochawesome: false,
+  usedRunnerResultsFallback: false
+}
+const rerunTargeting = readRerunTargeting(rerunTargetingFile)
 
 function isInsideDir(filePath, dirPath) {
   const relativePath = path.relative(dirPath, filePath)
@@ -222,9 +236,75 @@ function buildSummary(specs) {
     generatedAt: new Date().toISOString(),
     failedSpecCount: specs.length,
     failedTestCount: enrichedFailures.length,
+    execution: {
+      executedSpecCount: runMetrics.executedSpecs.size,
+      testsRegistered: runMetrics.testsRegistered,
+      testsPassing: runMetrics.testsPassing,
+      testsFailing: runMetrics.testsFailing,
+      testsPending: runMetrics.testsPending,
+      testsSkipped: runMetrics.testsSkipped,
+      filteredOut: 0,
+      screenshots: runMetrics.screenshots,
+      durationMs: runMetrics.durationMs,
+      source: runMetrics.usedMochawesome
+        ? 'mochawesome'
+        : runMetrics.usedRunnerResultsFallback
+          ? 'runner-results fallback'
+          : 'no report data'
+    },
+    targeting: rerunTargeting,
     failureTypes,
     topErrorSignatures: topCounts(errorSignatures),
     failures: enrichedFailures
+  }
+}
+
+function emptyRerunTargeting() {
+  return {
+    sourceFailureCount: 0,
+    targetableFailureCount: 0,
+    targetedSpecCount: 0,
+    targetedTestCount: 0,
+    fallbackSpecCount: 0,
+    targetedTestsBySpec: {},
+    fallbackSpecs: []
+  }
+}
+
+function readRerunTargeting(filePath) {
+  if (!filePath) {
+    return emptyRerunTargeting()
+  }
+
+  const resolvedPath = path.resolve(filePath)
+  if (!fs.existsSync(resolvedPath)) {
+    return emptyRerunTargeting()
+  }
+
+  try {
+    const targeting = JSON.parse(fs.readFileSync(resolvedPath, 'utf8'))
+    const targetedTestsBySpec = targeting.targetedTestsBySpec && typeof targeting.targetedTestsBySpec === 'object'
+      ? targeting.targetedTestsBySpec
+      : {}
+    const fallbackSpecs = Array.isArray(targeting.fallbackSpecs) ? targeting.fallbackSpecs : []
+    const targetedSpecCount = Number(targeting.targetedSpecCount) || Object.keys(targetedTestsBySpec).length
+    const targetedTestCount = Number(targeting.targetedTestCount) || Object.values(targetedTestsBySpec).reduce(
+      (count, titles) => count + (Array.isArray(titles) ? titles.length : 0),
+      0
+    )
+
+    return {
+      sourceFailureCount: Number(targeting.sourceFailureCount) || 0,
+      targetableFailureCount: Number(targeting.targetableFailureCount) || targetedTestCount,
+      targetedSpecCount,
+      targetedTestCount,
+      fallbackSpecCount: Number(targeting.fallbackSpecCount) || fallbackSpecs.length,
+      targetedTestsBySpec,
+      fallbackSpecs
+    }
+  } catch (err) {
+    console.warn(`WARNING: Could not parse rerun targeting file ${resolvedPath}: ${err.message}`)
+    return emptyRerunTargeting()
   }
 }
 
@@ -289,9 +369,22 @@ function extractFromMochawesome() {
       continue
     }
 
+    runMetrics.usedMochawesome = true
+    runMetrics.testsRegistered += Number(report.stats && report.stats.tests) || 0
+    runMetrics.testsPassing += Number(report.stats && report.stats.passes) || 0
+    runMetrics.testsFailing += Number(report.stats && report.stats.failures) || 0
+    runMetrics.testsPending += Number(report.stats && report.stats.pending) || 0
+    runMetrics.testsSkipped += Number(report.stats && report.stats.skipped) || 0
+    runMetrics.screenshots += Number(report.stats && report.stats.screenshots) || 0
+    runMetrics.durationMs += Number(report.stats && report.stats.duration) || 0
+
     for (const result of report.results || []) {
       const specFile = result.fullFile || result.file
       const failuresBeforeResult = failures.length
+
+      if (specFile) {
+        runMetrics.executedSpecs.add(specFile)
+      }
 
       for (const hook of result.beforeHooks || []) {
         if (isFailed(hook)) {
@@ -338,6 +431,7 @@ function extractFallbackFromRunnerResults() {
   }
 
   const jsonFiles = fs.readdirSync(runnerResultsDir).filter(file => file.endsWith('.json'))
+  runMetrics.usedRunnerResultsFallback = jsonFiles.length > 0
 
   for (const jsonFile of jsonFiles) {
     let report
@@ -349,6 +443,7 @@ function extractFallbackFromRunnerResults() {
     }
 
     if (report.failures > 0 && report.file) {
+      runMetrics.executedSpecs.add(report.file)
       addFailure(report.file, 'Failure details unavailable from runner-results JSON. See Mochawesome report or Cypress console output.', '')
     }
   }

--- a/scripts/rerun-failed-tests.js
+++ b/scripts/rerun-failed-tests.js
@@ -9,6 +9,7 @@ const summaryFile =
   process.env.FAILED_TEST_SUMMARY ||
   (process.env.BUILD_NUMBER ? `failure-summary-${process.env.BUILD_NUMBER}.json` : '')
 const configFile = process.argv[3] || process.env.CYPRESS_RERUN_CONFIG || 'test'
+const rerunMetadataFile = process.argv[4] || process.env.RERUN_METADATA_FILE || ''
 const browser = process.env.CYPRESS_RERUN_BROWSER || 'chrome'
 const headed = process.env.CYPRESS_RERUN_HEADED !== 'false'
 
@@ -54,6 +55,37 @@ const targetSpecs = Array.from(targetTitlesBySpec.keys())
 const fallbackSpecs = Array.from(fullSpecFallbacks)
 const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx'
 
+function ensureParentDir(filePath) {
+  fs.mkdirSync(path.dirname(path.resolve(filePath)), { recursive: true })
+}
+
+function writeRerunMetadata() {
+  if (!rerunMetadataFile) {
+    return
+  }
+
+  const targetedTestsBySpec = Object.fromEntries(
+    Array.from(targetTitlesBySpec.entries()).map(([spec, titles]) => [spec, Array.from(titles)])
+  )
+  const targetedTestCount = Object.values(targetedTestsBySpec).reduce((count, titles) => count + titles.length, 0)
+  const metadata = {
+    generatedAt: new Date().toISOString(),
+    summaryFile: path.resolve(summaryFile),
+    configFile,
+    sourceFailureCount: failures.length,
+    targetableFailureCount: targetedTestCount,
+    targetedSpecCount: targetSpecs.length,
+    targetedTestCount,
+    fallbackSpecCount: fallbackSpecs.length,
+    targetedTestsBySpec,
+    fallbackSpecs
+  }
+
+  ensureParentDir(rerunMetadataFile)
+  fs.writeFileSync(path.resolve(rerunMetadataFile), JSON.stringify(metadata, null, 2) + '\n')
+  console.log(`Wrote rerun metadata -> ${path.resolve(rerunMetadataFile)}`)
+}
+
 function runCypress(specs, extraEnv = {}) {
   if (!specs.length) {
     return 0
@@ -93,6 +125,8 @@ function runCypress(specs, extraEnv = {}) {
 }
 
 let status = 0
+
+writeRerunMetadata()
 
 if (targetSpecs.length) {
   const failedTestsBySpec = Object.fromEntries(

--- a/scripts/summarize-failure-runs.js
+++ b/scripts/summarize-failure-runs.js
@@ -61,6 +61,8 @@ function readSummary(filePath, fallbackLabel) {
     runLabel: summary.runLabel || fallbackLabel,
     failedSpecCount: summary.failedSpecCount || 0,
     failedTestCount: summary.failedTestCount || 0,
+    execution: normalizeExecution(summary.execution),
+    targeting: normalizeTargeting(summary.targeting),
     failureTypes: summary.failureTypes || {},
     topErrorSignatures: summary.topErrorSignatures || [],
     failures: Array.isArray(summary.failures) ? summary.failures : []
@@ -72,9 +74,47 @@ function emptySummary(runLabel) {
     runLabel,
     failedSpecCount: 0,
     failedTestCount: 0,
+    execution: normalizeExecution(null),
+    targeting: normalizeTargeting(null),
     failureTypes: {},
     topErrorSignatures: [],
     failures: []
+  }
+}
+
+function normalizeExecution(execution) {
+  return {
+    executedSpecCount: Number(execution && execution.executedSpecCount) || 0,
+    testsRegistered: Number(execution && execution.testsRegistered) || 0,
+    testsPassing: Number(execution && execution.testsPassing) || 0,
+    testsFailing: Number(execution && execution.testsFailing) || 0,
+    testsPending: Number(execution && execution.testsPending) || 0,
+    testsSkipped: Number(execution && execution.testsSkipped) || 0,
+    filteredOut: Number(execution && execution.filteredOut) || 0,
+    screenshots: Number(execution && execution.screenshots) || 0,
+    durationMs: Number(execution && execution.durationMs) || 0,
+    source: (execution && execution.source) || 'no report data'
+  }
+}
+
+function normalizeTargeting(targeting) {
+  const targetedTestsBySpec = targeting && targeting.targetedTestsBySpec && typeof targeting.targetedTestsBySpec === 'object'
+    ? targeting.targetedTestsBySpec
+    : {}
+  const fallbackSpecs = targeting && Array.isArray(targeting.fallbackSpecs) ? targeting.fallbackSpecs : []
+  const targetedSpecCount = Number(targeting && targeting.targetedSpecCount) || Object.keys(targetedTestsBySpec).length
+  const targetedTestCount = Number(targeting && targeting.targetedTestCount) || Object.values(targetedTestsBySpec).reduce(
+    (count, titles) => count + (Array.isArray(titles) ? titles.length : 0),
+    0
+  )
+  return {
+    sourceFailureCount: Number(targeting && targeting.sourceFailureCount) || 0,
+    targetableFailureCount: Number(targeting && targeting.targetableFailureCount) || targetedTestCount,
+    targetedSpecCount,
+    targetedTestCount,
+    fallbackSpecCount: Number(targeting && targeting.fallbackSpecCount) || fallbackSpecs.length,
+    targetedTestsBySpec,
+    fallbackSpecs
   }
 }
 
@@ -130,9 +170,11 @@ function buildTrend(initialSummary, rerun1Summary, rerun2Summary) {
   const persistentFailures = classifiedFailures.filter(failure => failure.status === 'Persistent failure')
   const flakyFailures = classifiedFailures.filter(failure => failure.status.startsWith('Flaky'))
   const newRerunFailures = classifiedFailures.filter(failure => failure.status === 'New rerun failure')
+  const runPhases = buildRunPhases(initialSummary, rerun1Summary, rerun2Summary)
 
   return {
     generatedAt: new Date().toISOString(),
+    outcome: classifyOverallOutcome(initialSummary, rerun1Summary, rerun2Summary),
     counts: {
       initialFailedSpecs: initialSummary.failedSpecCount,
       initialFailedTests: initialSummary.failedTestCount,
@@ -144,11 +186,55 @@ function buildTrend(initialSummary, rerun1Summary, rerun2Summary) {
       persistentFailures: persistentFailures.length,
       newRerunFailures: newRerunFailures.length
     },
+    runs: runPhases,
     statusCounts,
     topPersistentErrorTypes: topCounts(countBy(persistentFailures, failure => failure.errorType)),
     topFlakyErrorTypes: topCounts(countBy(flakyFailures, failure => failure.errorType)),
     classifiedFailures
   }
+}
+
+function buildRunPhases(initialSummary, rerun1Summary, rerun2Summary) {
+  const initial = {
+    name: 'Initial run',
+    execution: initialSummary.execution,
+    failedSpecCount: initialSummary.failedSpecCount,
+    failedTestCount: initialSummary.failedTestCount
+  }
+
+  const rerun1 = buildRerunPhase('Rerun #1', rerun1Summary)
+  const rerun2 = buildRerunPhase('Rerun #2', rerun2Summary)
+
+  return { initial, rerun1, rerun2 }
+}
+
+function buildRerunPhase(name, summary) {
+  const execution = { ...summary.execution }
+  execution.filteredOut = Math.max(execution.testsRegistered - execution.testsPassing - execution.testsFailing, 0)
+
+  return {
+    name,
+    execution,
+    targeting: summary.targeting,
+    failedSpecCount: summary.failedSpecCount,
+    failedTestCount: summary.failedTestCount
+  }
+}
+
+function classifyOverallOutcome(initialSummary, rerun1Summary, rerun2Summary) {
+  if (initialSummary.failedSpecCount === 0) {
+    return 'Passed on initial run'
+  }
+
+  if (rerun1Summary.failedSpecCount === 0) {
+    return 'Passed after rerun #1'
+  }
+
+  if (rerun2Summary.failedSpecCount === 0) {
+    return 'Passed after rerun #2'
+  }
+
+  return 'Failures remained after rerun #2'
 }
 
 function classifyRunStatus(failedInitial, failedRerun1, failedRerun2) {
@@ -175,7 +261,16 @@ function renderTrendMarkdown(trend) {
   const lines = [
     '# Failure Trend Summary',
     '',
-    '## Counts',
+    `Outcome: ${trend.outcome}`,
+    '',
+    '## Run Metrics',
+    ...renderInitialRunSection(trend.runs.initial),
+    '',
+    ...renderRerunSection(trend.runs.rerun1),
+    '',
+    ...renderRerunSection(trend.runs.rerun2),
+    '',
+    '## Failure Counts',
     `- Initial failed specs: ${trend.counts.initialFailedSpecs}`,
     `- Initial failed tests/hooks: ${trend.counts.initialFailedTests}`,
     `- Rerun #1 failed specs: ${trend.counts.rerun1FailedSpecs}`,
@@ -210,6 +305,41 @@ function renderTrendMarkdown(trend) {
   appendFailures(lines, trend.classifiedFailures.filter(failure => failure.status === 'New rerun failure'))
 
   return `${lines.join('\n')}\n`
+}
+
+function renderInitialRunSection(run) {
+  return [
+    '### Initial run',
+    `- Executed specs: ${run.execution.executedSpecCount}`,
+    `- Tests registered: ${run.execution.testsRegistered}`,
+    `- Tests passed: ${run.execution.testsPassing}`,
+    `- Tests failed: ${run.execution.testsFailing}`,
+    `- Tests skipped: ${run.execution.testsSkipped}`,
+    `- Tests pending: ${run.execution.testsPending}`,
+    `- Failure detail rows: ${run.failedTestCount}`,
+    `- Failed specs remaining: ${run.failedSpecCount}`,
+    `- Metrics source: ${run.execution.source}`
+  ]
+}
+
+function renderRerunSection(run) {
+  return [
+    `### ${run.name}`,
+    `- Source failures considered: ${run.targeting.sourceFailureCount}`,
+    `- Targetable failures: ${run.targeting.targetableFailureCount}`,
+    `- Targeted specs opened: ${run.targeting.targetedSpecCount}`,
+    `- Targeted failed tests: ${run.targeting.targetedTestCount}`,
+    `- Full-spec fallback count: ${run.targeting.fallbackSpecCount}`,
+    `- Tests registered in opened specs: ${run.execution.testsRegistered}`,
+    `- Tests executed and passed: ${run.execution.testsPassing}`,
+    `- Tests executed and failed: ${run.execution.testsFailing}`,
+    `- Tests filtered out of rerun: ${run.execution.filteredOut}`,
+    `- Tests skipped: ${run.execution.testsSkipped}`,
+    `- Tests pending: ${run.execution.testsPending}`,
+    `- Failed specs remaining: ${run.failedSpecCount}`,
+    `- Failure detail rows remaining: ${run.failedTestCount}`,
+    `- Metrics source: ${run.execution.source}`
+  ]
 }
 
 function appendFailures(lines, failures) {


### PR DESCRIPTION
## Summary
- embed execution and rerun-targeting metrics into failure summary JSON
- improve failure trend reporting so reruns show registered vs executed vs filtered-out tests
- update Jenkins post-build output and Slack messaging to use normalized trend data
- stop filtered rerun tests from being reported as fake pending tests

## What changed
- `scripts/extract-failure-details.js`
  - adds execution metrics to `failure-summary-*.json`
  - folds rerun targeting metadata into the existing summary JSON
- `scripts/rerun-failed-tests.js`
  - writes rerun targeting data for downstream reporting
- `scripts/summarize-failure-runs.js`
  - renders clearer normalized run/rerun summaries
- `Jenkinsfile`
  - passes rerun targeting into summary generation
  - prints normalized console summary
  - includes normalized Slack summary content
- `cypress/support/failedTestFilter.ts`
  - stops registering filtered-out rerun tests as pending

## Validation
- `npm run compile`
- serial services run:
  - `38` specs
  - `254` tests
  - `254` passing
- parallel services run:
  - reproduced `429` contention failures during setup/cleanup hooks across measure-heavy specs
  - confirms services are not currently safe to run fully parallel in this environment