### PR TITLE
Fix Jenkins slack summary sandbox issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -389,7 +389,6 @@ pipeline {
     always {
       script {
         try {
-          def jsonSlurper = new groovy.json.JsonSlurperClassic()
           String ws = env.WORKSPACE
           String bn = env.BUILD_NUMBER
           String trendPath = "${ws}/failure-trend-${bn}.json"
@@ -421,51 +420,34 @@ pipeline {
           String normalizedSummary = ''
 
           if (fileExists(trendPath)) {
-            def trend = jsonSlurper.parseText(readFile(trendPath))
-            def initialRun = trend.runs?.initial ?: [:]
-            def rerun1Run = trend.runs?.rerun1 ?: [:]
-            def rerun2Run = trend.runs?.rerun2 ?: [:]
-            def initialExecution = initialRun.execution ?: [:]
-            def rerun1Execution = rerun1Run.execution ?: [:]
-            def rerun2Execution = rerun2Run.execution ?: [:]
-            def rerun1Targeting = rerun1Run.targeting ?: [:]
-            def rerun2Targeting = rerun2Run.targeting ?: [:]
+            normalizedSummary = sh(
+              returnStdout: true,
+              script: "node scripts/render-trend-summary.js '${trendPath}' slack"
+            ).trim()
 
-            outcome = trend.outcome ? "✅ ${trend.outcome}." : outcome
-            passed = !(trend.outcome ?: '').toString().startsWith('Failures remained')
+            String consoleSummary = sh(
+              returnStdout: true,
+              script: "node scripts/render-trend-summary.js '${trendPath}' console"
+            ).trim()
 
-            normalizedSummary = """\
-Normalized summary:
-• Initial run: ${initialExecution.executedSpecCount ?: 0} specs, ${initialExecution.testsRegistered ?: 0} registered, ${initialExecution.testsPassing ?: 0} passed, ${initialExecution.testsFailing ?: 0} failed, ${initialExecution.testsSkipped ?: 0} skipped
-• Rerun #1: ${rerun1Targeting.targetedSpecCount ?: 0} targeted specs, ${rerun1Targeting.targetedTestCount ?: 0} targeted failed tests, ${rerun1Execution.testsRegistered ?: 0} registered in opened specs, ${rerun1Execution.filteredOut ?: 0} filtered out, ${rerun1Run.failedSpecCount ?: 0} failed specs remaining
-• Rerun #2: ${rerun2Targeting.targetedSpecCount ?: 0} targeted specs, ${rerun2Targeting.targetedTestCount ?: 0} targeted failed tests, ${rerun2Execution.testsRegistered ?: 0} registered in opened specs, ${rerun2Execution.filteredOut ?: 0} filtered out, ${rerun2Run.failedSpecCount ?: 0} failed specs remaining
-""".stripIndent().trim()
+            if (normalizedSummary) {
+              echo consoleSummary
+            }
 
-            echo """
-=== Normalized Failure Summary ===
-Outcome: ${trend.outcome ?: outcome}
-
-Initial run:
-  specs executed: ${initialExecution.executedSpecCount ?: 0}
-  tests registered: ${initialExecution.testsRegistered ?: 0}
-  passed: ${initialExecution.testsPassing ?: 0}
-  failed: ${initialExecution.testsFailing ?: 0}
-  skipped: ${initialExecution.testsSkipped ?: 0}
-
-Rerun #1:
-  targeted specs: ${rerun1Targeting.targetedSpecCount ?: 0}
-  targeted failed tests: ${rerun1Targeting.targetedTestCount ?: 0}
-  tests registered in opened specs: ${rerun1Execution.testsRegistered ?: 0}
-  filtered out: ${rerun1Execution.filteredOut ?: 0}
-  remaining failed specs: ${rerun1Run.failedSpecCount ?: 0}
-
-Rerun #2:
-  targeted specs: ${rerun2Targeting.targetedSpecCount ?: 0}
-  targeted failed tests: ${rerun2Targeting.targetedTestCount ?: 0}
-  tests registered in opened specs: ${rerun2Execution.testsRegistered ?: 0}
-  filtered out: ${rerun2Execution.filteredOut ?: 0}
-  remaining failed specs: ${rerun2Run.failedSpecCount ?: 0}
-""".stripIndent()
+            String trendText = readFile(trendPath)
+            if (trendText.contains('"outcome": "Passed on initial run"')) {
+              outcome = '✅ Passed on initial run.'
+              passed = true
+            } else if (trendText.contains('"outcome": "Passed after rerun #1"')) {
+              outcome = '✅ Passed after rerun #1.'
+              passed = true
+            } else if (trendText.contains('"outcome": "Passed after rerun #2"')) {
+              outcome = '✅ Passed after rerun #2.'
+              passed = true
+            } else if (trendText.contains('"outcome": "Failures remained after rerun #2"')) {
+              outcome = '❌ Failures remained after rerun #2.'
+              passed = false
+            }
           }
 
           String msg = """\

--- a/scripts/render-trend-summary.js
+++ b/scripts/render-trend-summary.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+const trendFile = process.argv[2]
+const format = process.argv[3] || 'slack'
+
+if (!trendFile) {
+  console.error('Usage: node scripts/render-trend-summary.js trend-json-file [slack|console]')
+  process.exit(1)
+}
+
+const resolvedTrendFile = path.resolve(trendFile)
+
+if (!fs.existsSync(resolvedTrendFile)) {
+  process.exit(0)
+}
+
+const content = fs.readFileSync(resolvedTrendFile, 'utf8').trim()
+if (!content) {
+  process.exit(0)
+}
+
+const trend = JSON.parse(content)
+const initialRun = trend.runs && trend.runs.initial ? trend.runs.initial : {}
+const rerun1Run = trend.runs && trend.runs.rerun1 ? trend.runs.rerun1 : {}
+const rerun2Run = trend.runs && trend.runs.rerun2 ? trend.runs.rerun2 : {}
+const initialExecution = initialRun.execution || {}
+const rerun1Execution = rerun1Run.execution || {}
+const rerun2Execution = rerun2Run.execution || {}
+const rerun1Targeting = rerun1Run.targeting || {}
+const rerun2Targeting = rerun2Run.targeting || {}
+
+function value(number) {
+  return Number(number) || 0
+}
+
+const slackSummary = [
+  'Normalized summary:',
+  `• Initial run: ${value(initialExecution.executedSpecCount)} specs, ${value(initialExecution.testsRegistered)} registered, ${value(initialExecution.testsPassing)} passed, ${value(initialExecution.testsFailing)} failed, ${value(initialExecution.testsSkipped)} skipped`,
+  `• Rerun #1: ${value(rerun1Targeting.targetedSpecCount)} targeted specs, ${value(rerun1Targeting.targetedTestCount)} targeted failed tests, ${value(rerun1Execution.testsRegistered)} registered in opened specs, ${value(rerun1Execution.filteredOut)} filtered out, ${value(rerun1Run.failedSpecCount)} failed specs remaining`,
+  `• Rerun #2: ${value(rerun2Targeting.targetedSpecCount)} targeted specs, ${value(rerun2Targeting.targetedTestCount)} targeted failed tests, ${value(rerun2Execution.testsRegistered)} registered in opened specs, ${value(rerun2Execution.filteredOut)} filtered out, ${value(rerun2Run.failedSpecCount)} failed specs remaining`
+].join('\n')
+
+const consoleSummary = [
+  '=== Normalized Failure Summary ===',
+  `Outcome: ${trend.outcome || 'Unknown'}`,
+  '',
+  'Initial run:',
+  `  specs executed: ${value(initialExecution.executedSpecCount)}`,
+  `  tests registered: ${value(initialExecution.testsRegistered)}`,
+  `  passed: ${value(initialExecution.testsPassing)}`,
+  `  failed: ${value(initialExecution.testsFailing)}`,
+  `  skipped: ${value(initialExecution.testsSkipped)}`,
+  '',
+  'Rerun #1:',
+  `  targeted specs: ${value(rerun1Targeting.targetedSpecCount)}`,
+  `  targeted failed tests: ${value(rerun1Targeting.targetedTestCount)}`,
+  `  tests registered in opened specs: ${value(rerun1Execution.testsRegistered)}`,
+  `  filtered out: ${value(rerun1Execution.filteredOut)}`,
+  `  remaining failed specs: ${value(rerun1Run.failedSpecCount)}`,
+  '',
+  'Rerun #2:',
+  `  targeted specs: ${value(rerun2Targeting.targetedSpecCount)}`,
+  `  targeted failed tests: ${value(rerun2Targeting.targetedTestCount)}`,
+  `  tests registered in opened specs: ${value(rerun2Execution.testsRegistered)}`,
+  `  filtered out: ${value(rerun2Execution.filteredOut)}`,
+  `  remaining failed specs: ${value(rerun2Run.failedSpecCount)}`
+].join('\n')
+
+if (format === 'console') {
+  process.stdout.write(`${consoleSummary}\n`)
+  process.exit(0)
+}
+
+process.stdout.write(`${slackSummary}\n`)


### PR DESCRIPTION
###Summary:
 - This PR fixes Jenkins post-build summary delivery for the rerun reporting work. The previous implementation generated the normalized failure trend artifacts correctly, but Slack and console summary rendering relied on Groovy JSON parsing in the Jenkins sandbox, which caused the post step to fail in build 246.
 - To remove that risk, this change moves normalized summary rendering into a repo-owned Node script and has Jenkins call that script instead of instantiating JsonSlurperClassic in the pipeline sandbox. That keeps the richer rerun reporting intact while making the post-build Slack and console summary path Jenkins-safe.
###Validation:
- confirmed the build 246 failure mode from the Jenkins log
- verified the new renderer script with node --check
- verified formatting with git diff --check

_This PR does not change the rerun reporting model itself. It only makes the Slack/console delivery path safe and reliable in Jenkins._