### PR TITLE
Refresh quality backlog and continue service helper refactors

### DIFF
--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -7,6 +7,7 @@ import { CQLEditorPage } from './CQLEditorPage'
 import { SupportedModels } from './CreateMeasurePage'
 import { MeasureRow } from './MeasuresPage'
 import { OktaLogin } from './OktaLogin'
+import { FixtureOwner, TestData } from './TestData'
 
 export enum EditLibraryActions {
     delete,
@@ -28,6 +29,10 @@ export type CreateLibraryOptions = {
 }
 
 export class CQLLibraryPage {
+    private static fixtureOwner(altUser?: boolean): FixtureOwner {
+        return altUser ? 'selectedAltUser' : 'selectedUser'
+    }
+
     public static readonly ownedLibrariesTab = '[data-testid="owned-libraries-tab"]'
     public static readonly sharedLibrariesTab = '[data-testid="shared-libraries-tab"]'
     public static readonly allLibrariesTab = '[data-testid="all-libraries-tab"]'
@@ -136,18 +141,14 @@ export class CQLLibraryPage {
         cy.get(Header.cqlLibraryTab).should('be.visible')
         cy.get(Header.cqlLibraryTab).click()
 
-        const currentUser = Cypress.env('selectedUser')
-        cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId')
-            .should('exist')
-            .then((fileContents) => {
-                cy.get('[data-testid="cqlLibrary-button-' + fileContents + '-content"]').should('contain', CQLLibraryName)
-                // ToDo?: add a check here for model
-            })
+        TestData.readCqlLibraryId().then((libraryId) => {
+            cy.get(`[data-testid="cqlLibrary-button-${libraryId}-content"]`).should('contain', CQLLibraryName)
+            // ToDo?: add a check here for model
+        })
         cy.log('CQL Library Created Successfully')
     }
 
     public static clickCreateLibraryButton(): void {
-        const currentUser = Cypress.env('selectedUser')
         let alias = 'library' + (Date.now().valueOf() + 1).toString()
         const libraryAlias: `@${string}` = `@${alias}`
         //setup for grabbing the measure create call
@@ -157,7 +158,7 @@ export class CQLLibraryPage {
         //saving measureID to file to use later
         cy.wait(libraryAlias).then(({ response }) => {
             expect(response?.statusCode).to.eq(201)
-            cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId', response?.body.id)
+            TestData.writeFixture('cqlLibraryId', response?.body.id)
         })
     }
 
@@ -168,49 +169,24 @@ export class CQLLibraryPage {
         altUser?: boolean,
         cql?: string,
     ): string {
-        let user = ''
-        if (cql === undefined || cql === null) {
-            cql = ''
-        }
+        const owner = this.fixtureOwner(altUser)
+        const user = TestData.setupUserScope(owner)
+        const fixtureName = twoLibraries === true ? 'cqlLibraryId2' : 'cqlLibraryId'
 
-        if (altUser === undefined || altUser === null) {
-            altUser = false
-        }
-
-        user = OktaLogin.setupUserSession(altUser)
-
-        //Create New CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value,
-                },
-                method: 'POST',
-                body: {
-                    cqlLibraryName: CqlLibraryName,
-                    model: 'QI-Core v4.1.1',
-                    createdBy: user,
-                    librarySetId: uuidv4(),
-                    description: 'description',
-                    publisher: CQLLibraryPublisher,
-                    cql: cql,
-                },
-            }).then((response) => {
-                let currentUser = Cypress.env('selectedUser')
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
-                expect(response.body.cqlLibraryName).to.eql(CqlLibraryName)
-                if (altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                if (twoLibraries === true) {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId2', response.body.id)
-                } else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId', response.body.id)
-                }
-            })
+        TestData.requestCqlLibrary({
+            cqlLibraryName: CqlLibraryName,
+            model: 'QI-Core v4.1.1',
+            createdBy: user,
+            description: 'description',
+            publisher: CQLLibraryPublisher,
+            cql: cql ?? ''
+        }).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            expect(response.body.cqlLibraryName).to.eql(CqlLibraryName)
+            TestData.writeFixture(fixtureName, response.body.id, owner)
         })
+
         return user
     }
 
@@ -223,24 +199,8 @@ export class CQLLibraryPage {
     }
 
     public static versionLibraryAPI(expectedVersionNumber: string) {
-        const currentUser = Cypress.env('selectedUser')
-        const filePath = 'cypress/fixtures/' + currentUser + '/cqlLibraryId'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(filePath)
-                .should('exist')
-                .then((cqlLibraryId) => {
-                    cy.request({
-                        url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                        method: 'PUT',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value,
-                        },
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql(expectedVersionNumber)
-                    })
-                })
+        TestData.versionCqlLibrary(expectedVersionNumber).then((response) => {
+            expect(response.status).to.eql(200)
         })
     }
 
@@ -312,70 +272,25 @@ export class CQLLibraryPage {
     }
 
     public static createLibraryAPI(libraryName: string, model: SupportedModels, options?: CreateLibraryOptions) {
-        let user: string,
-            description: string,
-            publisher: string,
-            cql: string,
-            cqlErrors = false,
-            altUser = false
+        const owner = this.fixtureOwner(options?.altUser)
+        const user = TestData.setupUserScope(owner)
+        const fixtureName = options?.libraryNumber ? `cqlLibraryId${options.libraryNumber}` : 'cqlLibraryId'
 
-        const currentUser = Cypress.env('selectedUser')
-
-        if (options && options.altUser) {
-            altUser = true
-        }
-        user = OktaLogin.setupUserSession(altUser)
-
-        if (options && options.description) {
-            description = options.description
-        } else {
-            description = 'testing library functionality'
-        }
-        if (options && options.publisher) {
-            publisher = options.publisher
-        } else {
-            publisher = 'ICF'
-        }
-        if (options && options.cql) {
-            cql = options.cql
-        } else {
-            cql = ''
-        }
-        if (options && options.cqlErrors) {
-            cqlErrors = true
-        }
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value,
-                },
-                method: 'POST',
-                body: {
-                    cqlLibraryName: libraryName,
-                    model: model,
-                    createdBy: user,
-                    librarySetId: uuidv4(),
-                    description: description,
-                    publisher: publisher,
-                    cql: cql,
-                    cqlErrors: cqlErrors,
-                },
-            }).then((response) => {
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
-                expect(response.body.cqlLibraryName).to.eql(libraryName)
-                if (options && options.libraryNumber) {
-                    cy.writeFile(
-                        'cypress/fixtures/' + currentUser + '/cqlLibraryId' + options.libraryNumber,
-                        response.body.id,
-                    )
-                } else {
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/cqlLibraryId', response.body.id)
-                }
-            })
+        TestData.requestCqlLibrary({
+            cqlLibraryName: libraryName,
+            model,
+            createdBy: user,
+            description: options?.description ?? 'testing library functionality',
+            publisher: options?.publisher ?? 'ICF',
+            cql: options?.cql ?? '',
+            cqlErrors: options?.cqlErrors ?? false
+        }).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            expect(response.body.cqlLibraryName).to.eql(libraryName)
+            TestData.writeFixture(fixtureName, response.body.id, owner)
         })
+
         return user
     }
 

--- a/cypress/Shared/TestData.ts
+++ b/cypress/Shared/TestData.ts
@@ -314,6 +314,20 @@ export class TestData {
         })
     }
 
+    public static requestMeasureExport<T = unknown>(
+        options: Partial<Cypress.RequestOptions> = {},
+        measureNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.readMeasureId(measureNumber, owner).then((measureId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/measures/${measureId}/exports`,
+                method: 'GET'
+            })
+        })
+    }
+
     public static requestMeasureById<T = MeasureBody>(
         method: 'GET' | 'PUT' | 'DELETE',
         measureId: string,
@@ -506,6 +520,23 @@ export class TestData {
         }) as Cypress.Chainable<Cypress.Response<T>>
     }
 
+    public static requestMeasureGroupById<T = MeasureGroupBody>(
+        method: 'DELETE',
+        groupId: string,
+        body: Cypress.RequestBody,
+        measureNumber = 0,
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.readMeasureId(measureNumber).then((measureId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/measures/${measureId}/groups/${groupId}`,
+                method,
+                body
+            })
+        }) as Cypress.Chainable<Cypress.Response<T>>
+    }
+
     public static requestMeasureGroupStratification<T = StratificationDefinition>(
         method: 'POST' | 'PUT' | 'DELETE',
         body?: StratificationDefinition | ((stratificationId: string) => StratificationDefinition),
@@ -547,7 +578,7 @@ export class TestData {
     }
 
     public static versionMeasure(
-        versionType: 'major' | 'minor' = 'major',
+        versionType: 'major' | 'minor' | 'patch' = 'major',
         measureNumber = 0,
         options: Partial<Cypress.RequestOptions> = {}
     ): Cypress.Chainable<Cypress.Response<VersionedMeasureResponse>> {

--- a/cypress/Shared/TestData.ts
+++ b/cypress/Shared/TestData.ts
@@ -132,6 +132,38 @@ export type CqlTranslationResponse = {
     xml: string
 }
 
+export type CqlLibraryBody = {
+    id?: string
+    cqlLibraryName: string
+    model: string
+    createdBy?: string
+    description?: string
+    publisher?: string
+    librarySetId?: string
+    version?: string
+    cql?: string
+    cqlErrors?: boolean
+    [key: string]: any
+}
+
+export type CqlLibrarySearchBody = {
+    searchField: string
+    optionalSearchProperties: string[]
+}
+
+export type CqlLibrarySearchResponse<T = CqlLibraryBody> = {
+    content: T[]
+    totalPages?: number
+    totalElements?: number
+}
+
+export type CqlLibraryDraftBody = {
+    id?: string
+    cqlLibraryName: string
+    model: string
+    [key: string]: any
+}
+
 export type MeasureCqlSaveOptions = {
     measureNumber?: number
     owner?: TestUserScope
@@ -275,6 +307,14 @@ export class TestData {
         } as MeasureBody
     }
 
+    public static cqlLibraryBody(body: Partial<CqlLibraryBody>): CqlLibraryBody {
+        return {
+            librarySetId: uuidv4(),
+            cql: '',
+            ...body
+        } as CqlLibraryBody
+    }
+
     public static requestMeasure<T = any>(
         body: Partial<MeasureBody>,
         options: Partial<Cypress.RequestOptions> = {}
@@ -284,6 +324,145 @@ export class TestData {
             url: '/api/measure',
             method: 'POST',
             body: this.measureBody(body)
+        })
+    }
+
+    public static requestCqlLibrary<T = CqlLibraryBody>(
+        body: Partial<CqlLibraryBody>,
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.requestWithAccessToken<T>({
+            ...options,
+            url: '/api/cql-libraries',
+            method: 'POST',
+            body: this.cqlLibraryBody(body)
+        })
+    }
+
+    public static readCqlLibrary<T = CqlLibraryBody>(
+        libraryNumber = 0,
+        options: Partial<Cypress.RequestOptions> = {},
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.readCqlLibraryId(libraryNumber, owner).then((libraryId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/cql-libraries/${libraryId}`,
+                method: 'GET'
+            })
+        })
+    }
+
+    public static requestCqlLibraryById<T = CqlLibraryBody>(
+        method: 'GET' | 'PUT' | 'DELETE',
+        libraryId: string,
+        options: Partial<Cypress.RequestOptions> = {},
+        body?: Partial<CqlLibraryBody>
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.requestWithAccessToken<T>({
+            ...options,
+            url: `/api/cql-libraries/${libraryId}`,
+            method,
+            ...(body ? { body } : {})
+        })
+    }
+
+    public static updateCqlLibrary<T = CqlLibraryBody>(
+        body: CqlLibraryBody,
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.requestWithAccessToken<T>({
+            ...options,
+            url: `/api/cql-libraries/${body.id}`,
+            method: 'PUT',
+            body
+        })
+    }
+
+    public static updateCurrentCqlLibrary<T = CqlLibraryBody>(
+        body: (libraryId: string) => Partial<CqlLibraryBody>,
+        options: Partial<Cypress.RequestOptions> = {},
+        libraryNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.readCqlLibraryId(libraryNumber, owner).then((libraryId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/cql-libraries/${libraryId}`,
+                method: 'PUT',
+                body: body(libraryId)
+            })
+        })
+    }
+
+    public static searchCqlLibraries<T = CqlLibrarySearchResponse>(
+        body: Partial<CqlLibrarySearchBody> = {},
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.requestWithAccessToken<T>({
+            ...options,
+            url: '/api/cql-libraries/searches',
+            method: 'PUT',
+            body: {
+                searchField: '',
+                optionalSearchProperties: [''],
+                ...body
+            }
+        })
+    }
+
+    public static versionCqlLibrary<T extends CqlLibraryBody = CqlLibraryBody>(
+        expectedVersionNumber?: string,
+        libraryNumber = 0,
+        owner: FixtureOwner = 'selectedUser',
+        options: Partial<Cypress.RequestOptions> = {},
+        fixtureOwner: FixtureOwner = owner
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        this.setupUserScope(owner)
+
+        return this.readCqlLibraryId(libraryNumber, fixtureOwner).then((libraryId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/cql-libraries/version/${libraryId}?isMajor=true`,
+                method: 'PUT'
+            }).then((response) => {
+                if (expectedVersionNumber !== undefined) {
+                    expect(response.body.version).to.eql(expectedVersionNumber)
+                }
+
+                return response
+            })
+        })
+    }
+
+    public static draftCqlLibrary<T = CqlLibraryBody>(
+        body: (libraryId: string) => CqlLibraryDraftBody,
+        options: Partial<Cypress.RequestOptions> = {},
+        libraryNumber = 0,
+        owner: FixtureOwner = 'selectedUser',
+        fixtureOwner: FixtureOwner = owner
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        this.setupUserScope(owner)
+
+        return this.readCqlLibraryId(libraryNumber, fixtureOwner).then((libraryId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/cql-libraries/draft/${libraryId}`,
+                method: 'POST',
+                body: body(libraryId)
+            })
+        })
+    }
+
+    public static requestVersionedCqlLibrary<T = CqlLibraryBody>(
+        libraryName: string,
+        version: string,
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.requestWithAccessToken<T>({
+            ...options,
+            url: `/api/cql-libraries/versioned?name=${libraryName}&version=${version}`,
+            method: 'GET'
         })
     }
 

--- a/cypress/e2e/Services/CQL Library Service/CreateCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/CreateCQL-Library.cy.ts
@@ -1,382 +1,234 @@
 import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
-import { v4 as uuidv4 } from 'uuid'
-import { OktaLogin } from "../../../Shared/OktaLogin"
+import {
+    CqlLibraryBody,
+    CqlLibrarySearchResponse,
+    TestData
+} from "../../../Shared/TestData"
 
-let CQLLibraryName = ''
-let model = 'QI-Core v4.1.1'
-let harpUser = ''
+const defaultModel = 'QI-Core v4.1.1'
+
+const requestCreateLibrary = (
+    body: Partial<CqlLibraryBody>,
+    options: Partial<Cypress.RequestOptions> = {}
+): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.requestCqlLibrary<CqlLibraryBody>(
+        {
+            model: defaultModel,
+            ...body
+        },
+        options
+    )
+}
+
+const requestLibrarySearch = (
+    options: Partial<Cypress.RequestOptions> = {}
+): Cypress.Chainable<Cypress.Response<CqlLibrarySearchResponse>> => {
+    return TestData.searchCqlLibraries(
+        {
+            searchField: '',
+            optionalSearchProperties: ['']
+        },
+        options
+    )
+}
 
 describe('CQL Library Service: Create CQL Library', () => {
+    let harpUser = ''
+
+    beforeEach(() => {
+        harpUser = TestData.setupUserScope()
+    })
 
     it('Create QI-Core CQL Library, successful creation', () => {
+        const cqlLibraryName = `QICoreCqlLibrary${Date.now()}`
 
-        harpUser = OktaLogin.setupUserSession(false)
-
-        let setId = uuidv4()
-
-        CQLLibraryName = 'QICoreCqlLibrary' + Date.now()
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "model": model,
-                    "cql": "",
-                    "librarySetId": setId,
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
-                expect(response.body.cqlLibraryName).to.eql(CQLLibraryName)
-                expect(response.body.model).to.eql(model)
-                expect(response.body.librarySetId).to.be.exist
-                expect(response.body.createdBy).to.eql(harpUser)
-            })
+        requestCreateLibrary({
+            cqlLibraryName,
+            createdBy: harpUser
+        }).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            expect(response.body.cqlLibraryName).to.eql(cqlLibraryName)
+            expect(response.body.model).to.eql(defaultModel)
+            expect(response.body.librarySetId).to.be.exist
+            expect(response.body.createdBy).to.eql(harpUser)
         })
     })
 
     it('Create QDM CQL Library, successful creation', () => {
+        const cqlLibraryName = `QDMCqlLibrary${Date.now()}`
 
-        harpUser = OktaLogin.setupUserSession(false)
-
-        CQLLibraryName = 'QDMCqlLibrary' + Date.now()
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "model": 'QDM v5.6',
-                    "cql": "",
-                    "librarySetId": uuidv4(),
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(201)
-                expect(response.body.id).to.be.exist
-                expect(response.body.cqlLibraryName).to.eql(CQLLibraryName)
-                expect(response.body.model).to.eql('QDM v5.6')
-                expect(response.body.librarySetId).to.be.exist
-                expect(response.body.createdBy).to.eql(harpUser)
-            })
+        requestCreateLibrary({
+            cqlLibraryName,
+            model: 'QDM v5.6',
+            createdBy: harpUser
+        }).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            expect(response.body.cqlLibraryName).to.eql(cqlLibraryName)
+            expect(response.body.model).to.eql('QDM v5.6')
+            expect(response.body.librarySetId).to.be.exist
+            expect(response.body.createdBy).to.eql(harpUser)
         })
     })
 
     it('Get All CQL Libraries', () => {
-
-        OktaLogin.setupUserSession(false)
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries/searches',
-                method: 'PUT',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    'searchField': "", optionalSearchProperties: [""]  //can be ["libraryName", "version"]
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(200)
-                expect(response.body).to.not.be.null
-                expect(response.body.content).to.be.a('array')
-                expect(response.body.content[0].id).to.be.exist
-            })
+        requestLibrarySearch().then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body).to.not.be.null
+            expect(response.body.content).to.be.a('array')
+            expect(response.body.content[0].id).to.be.exist
         })
     })
 
     it('Get specific CQL Library', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-        OktaLogin.setupUserSession(false)
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body).to.not.be.null
-                    expect(response.body.id).to.be.exist
-                })
-            })
+        TestData.readCqlLibrary().then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body).to.not.be.null
+            expect(response.body.id).to.be.exist
         })
     })
 
     it('Get All CQL Libraries created by logged in User', () => {
-
-        harpUser = OktaLogin.setupUserSession(false)
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries/searches?currentUser=true',
-                method: 'PUT',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    'searchField': "", optionalSearchProperties: [""]  //can be ["libraryName", "version"]
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(200)
-                expect(response.body).to.not.be.null
-                expect(response.body.content).to.be.a('array')
-                expect(response.body.content[0].id).to.be.exist
-                expect(response.body.content[0].librarySet.owner).to.eql(harpUser)
-            })
+        requestLibrarySearch({
+            url: '/api/cql-libraries/searches?currentUser=true'
+        }).then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body).to.not.be.null
+            expect(response.body.content).to.be.a('array')
+            expect(response.body.content[0].id).to.be.exist
+            expect(response.body.content[0].librarySet.owner).to.eql(harpUser)
         })
     })
 })
 
 describe('CQL Library Name validations', () => {
+    let apiCqlLibraryName = ''
+    const cqlLibraryPublisher = 'SemanticBits'
 
-    let apiCQLLibraryName = 'TestLibrary' + Date.now()
-    let CQLLibraryPublisher = 'SemanticBits'
-
-    before('Create CQL Library', () => {
-
-        CQLLibraryPage.createCQLLibraryAPI(apiCQLLibraryName, CQLLibraryPublisher)
+    before(() => {
+        apiCqlLibraryName = `TestLibrary${Date.now()}`
+        CQLLibraryPage.createCQLLibraryAPI(apiCqlLibraryName, cqlLibraryPublisher)
     })
 
-    beforeEach('Set Access Token', () => {
-
-        OktaLogin.setupUserSession(false)
+    beforeEach(() => {
+        TestData.setupUserScope()
     })
 
     it('Validation Error: CQL Library Name empty', () => {
-
-        CQLLibraryName = " "
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "model": model,
-                    "librarySetId": uuidv4(),
-                    "cql": ""
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name is required.')
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: ' '
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name is required.')
         })
     })
 
     it('Validation Error: CQL Library Name has special characters', () => {
-
-        CQLLibraryName = 'Test_Measure'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": model
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors).to.be.exist
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: 'Test_Measure'
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors).to.be.exist
         })
     })
 
     it('Validation Error: CQL Library Name does not start with an Upper Case letter', () => {
-
-        CQLLibraryName = 'testMeasure'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": model
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors).to.be.exist
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: 'testMeasure'
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors).to.be.exist
         })
     })
 
     it('Validation Error: CQL Library Name contains spaces', () => {
-
-        CQLLibraryName = 'Test  Measure'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": model
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors).to.be.exist
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: 'Test  Measure'
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors).to.be.exist
         })
     })
 
     it('Validation Error: CQL Library Name has only numbers', () => {
-
-        CQLLibraryName = '1234565'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": model
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors).to.be.exist
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: '1234565'
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors).to.be.exist
         })
     })
 
     it('Validation Error: CQL Library Name has more than 255 characters', () => {
-
-        CQLLibraryName = 'Abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": model
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name cannot be more than 64 characters.')
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName:
+                    'Abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw'
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name cannot be more than 64 characters.')
         })
     })
 
     it('Validation Error: Duplicate CQL Library Name', () => {
-
-        CQLLibraryName = apiCQLLibraryName
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": model
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name must be unique.')
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: apiCqlLibraryName
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name must be unique.')
         })
     })
 })
 
 describe('CQL Library Model Validations', () => {
-
-    beforeEach('Set Access Token', () => {
-
-        OktaLogin.setupUserSession(false)
+    beforeEach(() => {
+        TestData.setupUserScope()
     })
 
     it('Validation Error: CQL Library Model empty', () => {
-
-        CQLLibraryName = 'TestCqlLibrary' + Date.now()
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": ""
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors.model).to.eql('Model must be one of the supported types in MADiE.')
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: `TestCqlLibrary${Date.now()}`,
+                model: ''
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.model).to.eql('Model must be one of the supported types in MADiE.')
         })
     })
 
     it('Validation Error: Invalid CQL Library Model', () => {
-
-        CQLLibraryName = 'TestCqlLibrary' + Date.now()
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                failOnStatusCode: false,
-                url: '/api/cql-libraries',
-                method: 'POST',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "cqlLibraryName": CQLLibraryName,
-                    "librarySetId": uuidv4(),
-                    "model": 'QI-CoreINVALID'
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(400)
-                expect(response.body.validationErrors.model).to.eql('Model must be one of the supported types in MADiE.')
-            })
+        requestCreateLibrary(
+            {
+                cqlLibraryName: `TestCqlLibrary${Date.now()}`,
+                model: 'QI-CoreINVALID'
+            },
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.model).to.eql('Model must be one of the supported types in MADiE.')
         })
     })
 })

--- a/cypress/e2e/Services/CQL Library Service/EditCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/EditCQL-Library.cy.ts
@@ -1,271 +1,136 @@
 import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
-import { v4 as uuidv4 } from 'uuid'
-import {OktaLogin} from "../../../Shared/OktaLogin"
-import {Utilities} from "../../../Shared/Utilities"
+import { CqlLibraryBody, TestData } from "../../../Shared/TestData"
+import { Utilities } from "../../../Shared/Utilities"
 
-let CQLLibraryName = ''
-let updatedCQLLibraryName = ''
-let model = 'QI-Core v4.1.1'
-let CQLLibraryPublisher = 'SemanticBits'
-let harpUserALT = ''
+const defaultModel = 'QI-Core v4.1.1'
+const cqlLibraryPublisher = 'SemanticBits'
+const invalidNameMessage =
+    'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+
+const requestLibraryUpdate = (
+    cqlLibraryName: string,
+    options: Partial<Cypress.RequestOptions> = {},
+    owner: 'selectedUser' | 'selectedAltUser' = 'selectedUser',
+    fixtureOwner: 'selectedUser' | 'selectedAltUser' = owner
+): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.readCqlLibrary<CqlLibraryBody>(0, {}, fixtureOwner).then((libraryResponse) => {
+        expect(libraryResponse.status).to.eql(200)
+
+        return TestData.readCqlLibraryId(0, fixtureOwner).then((libraryId) => {
+            return TestData.requestWithAccessToken<CqlLibraryBody>({
+                ...options,
+                url: `/api/cql-libraries/${libraryId}`,
+                method: 'PUT',
+                body: {
+                    ...libraryResponse.body,
+                    id: libraryId,
+                    cqlLibraryName,
+                    model: defaultModel,
+                    cql: libraryResponse.body.cql ?? ''
+                }
+            })
+        })
+    })
+}
 
 describe('Edit CQL Library', () => {
+    let cqlLibraryName = ''
 
-    CQLLibraryName = 'TestCqlLibrary' + Date.now()
-
-    before('Create CQL Library', () => {
-
-        //Create CQL Library with Regular User
-        CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
-
+    before(() => {
+        cqlLibraryName = `TestCqlLibrary${Date.now()}`
+        CQLLibraryPage.createCQLLibraryAPI(cqlLibraryName, cqlLibraryPublisher)
     })
 
-    beforeEach('Set Access Token', () => {
-
-        OktaLogin.setupUserSession(false)
-
+    beforeEach(() => {
+        TestData.setupUserScope()
     })
 
     it('Edit CQL Library : Successful Update', () => {
+        const updatedCqlLibraryName = `UpdatedCQLLibrary${Date.now()}`
 
-        updatedCQLLibraryName = 'UpdatedCQLLibrary' + Date.now()
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId,
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "model": model,
-                        "librarySetId": uuidv4(),
-                        "cql": ""
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.id).to.be.exist
-                    expect(response.body.cqlLibraryName).to.eql(updatedCQLLibraryName)
-                })
-            })
+        requestLibraryUpdate(updatedCqlLibraryName).then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body.id).to.be.exist
+            expect(response.body.cqlLibraryName).to.eql(updatedCqlLibraryName)
         })
+
         cy.log('CQL Library Name Updated Successfully')
     })
 
     it('Validation Error: Edit CQL Library Name empty', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-
-        updatedCQLLibraryName = " "
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name is required.')
-                })
-            })
+        requestLibraryUpdate(' ', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name is required.')
         })
     })
 
     it('Validation Error: Edit CQL Library Name has special characters', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-
-        updatedCQLLibraryName = 'Test_Measure'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibrary).to.eql('Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.')
-                })
-            })
+        requestLibraryUpdate('Test_Measure', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibrary).to.eql(invalidNameMessage)
         })
     })
 
     it('Validation Error: Edit CQL Library Name does not start with an Upper Case letter', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-
-        updatedCQLLibraryName = 'testMeasure'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibrary).to.eql('Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.')
-                })
-            })
+        requestLibraryUpdate('testMeasure', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibrary).to.eql(invalidNameMessage)
         })
     })
 
     it('Validation Error: Edit CQL Library Name contains spaces', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-
-        updatedCQLLibraryName = 'Test  Measure'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibrary).to.eql('Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.')
-                })
-            })
+        requestLibraryUpdate('Test  Measure', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibrary).to.eql(invalidNameMessage)
         })
     })
 
     it('Validation Error: Edit CQL Library Name has only numbers', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-
-        updatedCQLLibraryName = '1234565'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibrary).to.eql('Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.')
-                })
-            })
+        requestLibraryUpdate('1234565', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibrary).to.eql(invalidNameMessage)
         })
     })
 
     it('Validation Error: Edit CQL Library Name has more than 64 characters', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-
-        updatedCQLLibraryName = 'Abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw'
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name cannot be more than 64 characters.')
-                })
-            })
+        requestLibraryUpdate(
+            'Abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw',
+            { failOnStatusCode: false }
+        ).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name cannot be more than 64 characters.')
         })
     })
 })
 
 describe('Edi CQL Library - Ownership Validations', () => {
+    let cqlLibraryName = ''
+    let harpUserAlt = ''
 
-    before('Create CQL Library', () => {
-
-    CQLLibraryName = 'TestCqlLibrary' + Date.now()
-    //Create CQL Library with Regular User
-    CQLLibraryPage.createCQLLibraryAPI(CQLLibraryName, CQLLibraryPublisher)
-
+    before(() => {
+        cqlLibraryName = `TestCqlLibrary${Date.now()}`
+        CQLLibraryPage.createCQLLibraryAPI(cqlLibraryName, cqlLibraryPublisher)
     })
 
-    after('Delete CQL Library', () => {
-
-        Utilities.deleteLibrary(CQLLibraryName)
+    after(() => {
+        Utilities.deleteLibrary(cqlLibraryName)
     })
 
     it('Verify non Library owner unable to Edit CQL Library', () => {
+        const updatedCqlLibraryName = `UpdatedCQLLibrary${Date.now()}`
+        harpUserAlt = TestData.setupUserScope('selectedAltUser')
 
-        const currentUser = Cypress.env('selectedUser')
-        harpUserALT = OktaLogin.setupUserSession(true)
-
-        updatedCQLLibraryName = 'UpdatedCQLLibrary' + Date.now()
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId2) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId2,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId2,
-                        "cqlLibraryName": updatedCQLLibraryName,
-                        "librarySetId": uuidv4(),
-                        "model": model
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUserALT + ' cannot modify resource CQL Library with id: ' + cqlLibraryId2)
-
-                })
+        TestData.readCqlLibraryId().then((libraryId) => {
+            requestLibraryUpdate(
+                updatedCqlLibraryName,
+                { failOnStatusCode: false },
+                'selectedAltUser',
+                'selectedUser'
+            ).then((response) => {
+                expect(response.status).to.eql(403)
+                expect(response.body.message).to.eql(
+                    `User ${harpUserAlt} cannot modify resource CQL Library with id: ${libraryId}`
+                )
             })
         })
     })

--- a/cypress/e2e/Services/CQL Library Service/VersionAndDraftCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/VersionAndDraftCQL-Library.cy.ts
@@ -1,265 +1,195 @@
 import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { SupportedModels } from "../../../Shared/CreateMeasurePage"
-import { v4 as uuidv4 } from 'uuid'
 import { LibraryCQL } from "../../../Shared/LibraryCQL"
-import { OktaLogin } from "../../../Shared/OktaLogin"
+import { CqlLibraryBody, TestData } from "../../../Shared/TestData"
 
 let harpUser = ''
-let harpUserALT = ''
-let CqlLibraryOne = ''
-let CqlLibraryTwo = ''
-let updatedCqlLibraryName = 'UpdatedTestLibrary' + Date.now()
+let harpUserAlt = ''
+let cqlLibraryOne = ''
+let cqlLibraryTwo = ''
+
+const updatedCqlLibraryName = `UpdatedTestLibrary${Date.now()}`
 const model = 'QI-Core v4.1.1'
-const CQLLibraryPublisher = 'SemanticBits'
+const cqlLibraryPublisher = 'SemanticBits'
 const versionNumber = '1.0.000'
 const invalidLibraryCql = LibraryCQL.invalidFhir4Lib
 const validCql = LibraryCQL.validCQL4QICORELib
+const invalidDraftNameMessage =
+    'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters.'
+
+const requestLibraryDraft = (
+    cqlLibraryName: string,
+    options: Partial<Cypress.RequestOptions> = {},
+    owner: 'selectedUser' | 'selectedAltUser' = 'selectedUser',
+    fixtureOwner: 'selectedUser' | 'selectedAltUser' = owner
+): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.draftCqlLibrary<CqlLibraryBody>(
+        (libraryId) => ({
+            id: libraryId,
+            cqlLibraryName,
+            model
+        }),
+        options,
+        0,
+        owner,
+        fixtureOwner
+    )
+}
+
+const requestVersionedLibraryUpdate = (
+    cqlLibraryName: string,
+    options: Partial<Cypress.RequestOptions> = {}
+): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.readCqlLibrary<CqlLibraryBody>().then((libraryResponse) => {
+        expect(libraryResponse.status).to.eql(200)
+
+        return TestData.updateCurrentCqlLibrary<CqlLibraryBody>(
+            (libraryId) => ({
+                ...libraryResponse.body,
+                id: libraryId,
+                cqlLibraryName,
+                model,
+                draft: false,
+                cql: libraryResponse.body.cql ?? ''
+            }),
+            options
+        )
+    })
+}
 
 describe('Version and Draft CQL Library', () => {
-
-    beforeEach('Set Access Token', () => {
-
-        harpUser = OktaLogin.setupUserSession(false)
-        harpUserALT = OktaLogin.getUser(true)
+    beforeEach(() => {
+        harpUser = TestData.setupUserScope()
+        harpUserAlt = TestData.selectedUser('selectedAltUser')
     })
 
-    before('Create CQL Library', () => {
+    before(() => {
+        cqlLibraryOne = `TestLibrary1${Date.now()}`
+        CQLLibraryPage.createLibraryAPI(cqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
 
-        //Create CQL Library with Regular User
-        CqlLibraryOne = 'TestLibrary1' + Date.now()
-        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
-
-        //Create Measure with Alternate User
-        CqlLibraryTwo = 'TestLibrary2' + Date.now()
-        CQLLibraryPage.createLibraryAPI(CqlLibraryTwo, SupportedModels.qiCore4, { cql: validCql, libraryNumber: 2, altUser: true })
+        cqlLibraryTwo = `TestLibrary2${Date.now()}`
+        CQLLibraryPage.createLibraryAPI(cqlLibraryTwo, SupportedModels.qiCore4, {
+            cql: validCql,
+            libraryNumber: 2,
+            altUser: true
+        })
     })
 
     it('Add Version to the CQL Library', () => {
-
         CQLLibraryPage.versionLibraryAPI(versionNumber)
     })
 
     it('User can not draft CQL Library if the CQL Library naming validations fail', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/draft/' + cqlLibraryId,
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId,
-                        "cqlLibraryName": "testLibrary",
-                        "model": model
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibraryName).to.eql("Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters.")
-                })
-            })
+        requestLibraryDraft('testLibrary', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql(invalidDraftNameMessage)
         })
     })
 
     it('User can not draft CQL Library if the CQL Library name is empty', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/draft/' + cqlLibraryId,
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId,
-                        "cqlLibraryName": "",
-                        "model": model
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.cqlLibraryName).to.eql("Library name is required.")
-
-                })
-            })
+        requestLibraryDraft('', { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(400)
+            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name is required.')
         })
     })
 
     it('Add Draft to the Versioned Library', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/draft/' + cqlLibraryId,
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId,
-                        "cqlLibraryName": updatedCqlLibraryName,
-                        "model": model
-                    }
-
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.draft).to.eql(true)
-                })
-            })
+        requestLibraryDraft(updatedCqlLibraryName).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.draft).to.eql(true)
         })
     })
 
     it('Verify non Library owner unable to create Version', () => {
+        const actingUser = TestData.setupUserScope('selectedAltUser')
 
-        const currentUser = Cypress.env('selectedUser')
-        OktaLogin.setupUserSession(true)
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUserALT + ' cannot modify resource CQL Library with id: ' + cqlLibraryId)
-                })
+        TestData.readCqlLibraryId().then((libraryId) => {
+            TestData.versionCqlLibrary(
+                undefined,
+                0,
+                'selectedAltUser',
+                { failOnStatusCode: false },
+                'selectedUser'
+            ).then((response) => {
+                expect(response.status).to.eql(403)
+                expect(response.body.message).to.eql(
+                    `User ${actingUser} cannot modify resource CQL Library with id: ${libraryId}`
+                )
             })
         })
     })
 })
 
 describe('Draft and Version Validations', () => {
+    beforeEach(() => {
+        harpUser = TestData.setupUserScope()
+        harpUserAlt = TestData.selectedUser('selectedAltUser')
 
-    beforeEach('Set Access Token and create CQL Library', () => {
-
-        harpUser = OktaLogin.setupUserSession(false)
-        harpUserALT = OktaLogin.getUser(true)
-
-        CqlLibraryOne = 'TestLibraryOne' + Date.now()
-        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
+        cqlLibraryOne = `TestLibraryOne${Date.now()}`
+        CQLLibraryPage.createLibraryAPI(cqlLibraryOne, SupportedModels.qiCore4, { cql: validCql })
     })
 
     it('Verify the CQL Library updates are restricted after Version is created', () => {
-
-        const currentUser = Cypress.env('selectedUser')
-        //Add Version to the CQL Library
         CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-        //Edit Library Name after versioned
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId,
-                        "cqlLibraryName": updatedCqlLibraryName,
-                        "model": model,
-                        "draft": false,
-                        "librarySetId": uuidv4()
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Could not update resource CQL Library with id: ' + cqlLibraryId + '. Resource is not a Draft.')
-                })
-            })
+        requestVersionedLibraryUpdate(updatedCqlLibraryName, { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(409)
+            expect(response.body.message).to.contain('Resource is not a Draft.')
         })
     })
 
     it('Elm data is generated on the fly per GET versioned library request', () => {
-        //Add Version to the CQL Library
         CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-        //hit the cql-library-service versioned end point and validate that elm data is returned / generated
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries/versioned?name=' + CqlLibraryOne + '&version=1.0.000',
-                method: 'GET',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value
-                }
-            }).then((response) => {
-                expect(response.status).to.eql(200)
-                expect(response.body.elmJson).to.not.be.null
-                expect(response.body.elmXml).to.not.be.null
-            })
+        TestData.requestVersionedCqlLibrary<CqlLibraryBody>(cqlLibraryOne, versionNumber).then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body.elmJson).to.not.be.null
+            expect(response.body.elmXml).to.not.be.null
         })
     })
 })
 
 describe('Version CQL Library without CQL', () => {
+    before(() => {
+        harpUser = TestData.setupUserScope()
+        harpUserAlt = TestData.selectedUser('selectedAltUser')
 
-    before('Set Access Token and create CQL Library', () => {
-
-        harpUser = OktaLogin.setupUserSession(false)
-        harpUserALT = OktaLogin.getUser(true)
-
-        CqlLibraryOne = 'CQLLibraryWithoutCQL' + Date.now()
-        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4)
+        cqlLibraryOne = `CQLLibraryWithoutCQL${Date.now()}`
+        CQLLibraryPage.createLibraryAPI(cqlLibraryOne, SupportedModels.qiCore4)
     })
 
     it('User can not version CQL Library if there is no CQL', () => {
-        const currentUser = Cypress.env('selectedUser')
-        //Add Version to the CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version resource CQL Library with id: ' + cqlLibraryId + ' as there is no associated Cql with this library')
-                })
+        TestData.readCqlLibraryId().then((libraryId) => {
+            TestData.versionCqlLibrary(undefined, 0, 'selectedUser', { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.message).to.eql(
+                    `User ${harpUser} cannot version resource CQL Library with id: ${libraryId} as there is no associated Cql with this library`
+                )
             })
         })
     })
-
 })
 
 describe('Version CQL Library with invalid CQL', () => {
+    before(() => {
+        harpUser = TestData.setupUserScope()
+        harpUserAlt = TestData.selectedUser('selectedAltUser')
 
-    before('Set Access Token and create CQL Library', () => {
-
-        harpUser = OktaLogin.setupUserSession(false)
-        harpUserALT = OktaLogin.getUser(true)
-
-        CqlLibraryOne = 'CQLLibraryWithInvalidCQL' + Date.now()
-        CQLLibraryPage.createLibraryAPI(CqlLibraryOne, SupportedModels.qiCore4, { publisher: CQLLibraryPublisher, cql: invalidLibraryCql, cqlErrors: true })
+        cqlLibraryOne = `CQLLibraryWithInvalidCQL${Date.now()}`
+        CQLLibraryPage.createLibraryAPI(cqlLibraryOne, SupportedModels.qiCore4, {
+            publisher: cqlLibraryPublisher,
+            cql: invalidLibraryCql,
+            cqlErrors: true
+        })
     })
 
     it('User can not version the CQL library if the CQL has errors', () => {
-        const currentUser = Cypress.env('selectedUser')
-        //Add Version to the CQL Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/version/' + cqlLibraryId + '?isMajor=true',
-                    method: 'PUT',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version resource CQL Library with id: ' + cqlLibraryId + ' as the Cql has errors in it')
-                })
+        TestData.readCqlLibraryId().then((libraryId) => {
+            TestData.versionCqlLibrary(undefined, 0, 'selectedUser', { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.message).to.eql(
+                    `User ${harpUser} cannot version resource CQL Library with id: ${libraryId} as the Cql has errors in it`
+                )
             })
         })
     })

--- a/cypress/e2e/Services/Measure Service/DraftMeasure.cy.ts
+++ b/cypress/e2e/Services/Measure Service/DraftMeasure.cy.ts
@@ -29,6 +29,30 @@ const draftBody = (): MeasureDraftBody => ({
     measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z'
 })
 
+const requestCurrentDraft = (options: Partial<Cypress.RequestOptions> = {}) => {
+    return TestData.requestMeasureDraft(draftBody(), 0, options)
+}
+
+const setCurrentMeasureId = (measureId: string): Cypress.Chainable<null> => {
+    return TestData.writeFixture('measureId', measureId)
+}
+
+const expectCurrentVersion = (versionType: 'major' | 'minor' | 'patch', expectedVersion: string): void => {
+    TestData.versionMeasure(versionType).then((response) => {
+        expect(response.status).to.eql(200)
+        expect(response.body.version).to.eql(expectedVersion)
+    })
+}
+
+const expectCurrentDraftStatus = (expectedDraftable: boolean): void => {
+    TestData.readMeasureSetId().then((measureSetId) => {
+        TestData.requestDraftStatus().then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body).has.property(measureSetId).and.is.eql(expectedDraftable)
+        })
+    })
+}
+
 describe('Version and Draft CQL Library', () => {
     beforeEach('Create Measure, and add Cohort group', () => {
         harpUser = OktaLogin.setupUserSession(false)
@@ -53,7 +77,7 @@ describe('Version and Draft CQL Library', () => {
             expect(response.body.version).to.eql('1.0.000')
         })
 
-        TestData.requestMeasureDraft(draftBody()).then((response) => {
+        requestCurrentDraft().then((response) => {
             expect(response.status).to.eql(201)
             TestData.writeFixture('draftId', response.body.id)
         })
@@ -70,11 +94,11 @@ describe('Version and Draft CQL Library', () => {
             newerMeasureName = response.body.measureName
         })
 
-        TestData.requestMeasureDraft(draftBody()).then((response) => {
+        requestCurrentDraft().then((response) => {
             expect(response.status).to.eql(201)
         })
 
-        TestData.requestMeasureDraft(draftBody(), 0, { failOnStatusCode: false }).then((response) => {
+        requestCurrentDraft({ failOnStatusCode: false }).then((response) => {
             expect(response.status).to.eql(400)
             expect(response.body.message).to.eql(
                 'Can not create a draft for the measure "' +
@@ -104,356 +128,44 @@ describe('Draftable API end point tests', () => {
         MeasureGroupPage.CreateCohortMeasureGroupAPI()
     })
     it('Draftable end point return measure set id that was used in request and false if the measure is not version', () => {
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(false)
 
-        let mIdFilePath = 'cypress/fixtures/' + currentUser + '/measureId'
-        let mSetIdPath = 'cypress/fixtures/' + currentUser + '/measureSetId'
-        let mVersionIdPath = 'cypress/fixtures/' + currentUser + '/versionId'
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mSetIdPath)
-                .should('exist')
-                .then((mSetId) => {
-                    cy.request({
-                        url: '/api/measures/draftstatus',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'POST',
-                        body: [mSetId]
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body).has.property(mSetId).and.is.eql(false)
-                    })
-                })
-        })
+        expectCurrentDraftStatus(false)
     })
     it('Draftable end point return measure set id that was used in request and false if another measure, in that measure family, is in a draft status', () => {
-        let newerMeasureName = ''
-
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(false)
 
-        let mIdFilePath = 'cypress/fixtures/' + currentUser + '/measureId'
-        let mSetIdPath = 'cypress/fixtures/' + currentUser + '/measureSetId'
-        let mVersionIdPath = 'cypress/fixtures/' + currentUser + '/versionId'
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.request({
-                        url: '/api/measures/' + measureId + '/version?versionType=major',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.0.000')
-                        newerMeasureName = response.body.measureName
-                    })
-                })
+        expectCurrentVersion('major', '1.0.000')
+        requestCurrentDraft().then((response) => {
+            expect(response.status).to.eql(201)
+            setCurrentMeasureId(response.body.id)
         })
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mIdFilePath)
-                .should('exist')
-                .then((measureAID) => {
-                    cy.readFile(mSetIdPath)
-                        .should('exist')
-                        .then((mSetId) => {
-                            cy.readFile(mVersionIdPath)
-                                .should('exist')
-                                .then((mVersionId) => {
-                                    cy.request({
-                                        url: '/api/measures/' + measureAID + '/draft',
-                                        method: 'POST',
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        body: {
-                                            measureSetId: mSetId,
-                                            measureName: measureName,
-                                            cqlLibraryName: newCqlLibraryName,
-                                            model: 'QI-Core v4.1.1',
-                                            createdBy: harpUser,
-                                            cql: cohortMeasureCQL,
-                                            elmJson: elmJson,
-                                            ecqmTitle: 'ecqmTitle',
-                                            measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                                            measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z',
-                                            versionId: mVersionId
-                                        }
-                                    }).then((response) => {
-                                        let currentUser = Cypress.env('selectedUser')
-                                        expect(response.status).to.eql(201)
-                                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                                    })
-                                })
-                        })
-                })
+        expectCurrentVersion('minor', '1.1.000')
+        requestCurrentDraft().then((response) => {
+            expect(response.status).to.eql(201)
         })
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.request({
-                        url: '/api/measures/' + measureId + '/version?versionType=minor',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.1.000')
-                        newerMeasureName = response.body.measureName
-                    })
-                })
-        })
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mIdFilePath)
-                .should('exist')
-                .then((measureAID) => {
-                    cy.readFile(mSetIdPath)
-                        .should('exist')
-                        .then((mSetId) => {
-                            cy.readFile(mVersionIdPath)
-                                .should('exist')
-                                .then((mVersionId) => {
-                                    cy.request({
-                                        url: '/api/measures/' + measureAID + '/draft',
-                                        method: 'POST',
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        body: {
-                                            measureSetId: mSetId,
-                                            measureName: measureName,
-                                            cqlLibraryName: newCqlLibraryName,
-                                            model: 'QI-Core v4.1.1',
-                                            createdBy: harpUser,
-                                            cql: cohortMeasureCQL,
-                                            elmJson: elmJson,
-                                            ecqmTitle: 'ecqmTitle',
-                                            measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                                            measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z',
-                                            versionId: mVersionId
-                                        }
-                                    }).then((response) => {
-                                        expect(response.status).to.eql(201)
-                                    })
-                                })
-                        })
-                })
-        })
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mSetIdPath)
-                .should('exist')
-                .then((mSetId) => {
-                    cy.request({
-                        url: '/api/measures/draftstatus',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'POST',
-                        body: [mSetId]
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body).has.property(mSetId).and.is.eql(false)
-                    })
-                })
-        })
+        expectCurrentDraftStatus(false)
     })
     it('Draftable end point return measure set id that was used in request and true if the measure is versioned, regardless of version type (major, minor, or patch)', () => {
-        let newerMeasureName = ''
-
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(false)
 
-        let mIdFilePath = 'cypress/fixtures/' + currentUser + '/measureId'
-        let mSetIdPath = 'cypress/fixtures/' + currentUser + '/measureSetId'
-        let mVersionIdPath = 'cypress/fixtures/' + currentUser + '/versionId'
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.request({
-                        url: '/api/measures/' + measureId + '/version?versionType=major',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.0.000')
-                        newerMeasureName = response.body.measureName
-                    })
-                })
-        })
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mSetIdPath)
-                .should('exist')
-                .then((mSetId) => {
-                    cy.request({
-                        url: '/api/measures/draftstatus',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'POST',
-                        body: [mSetId]
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body).has.property(mSetId).and.is.eql(true)
-                    })
-                })
+        expectCurrentVersion('major', '1.0.000')
+        expectCurrentDraftStatus(true)
+
+        requestCurrentDraft().then((response) => {
+            expect(response.status).to.eql(201)
+            setCurrentMeasureId(response.body.id)
         })
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mIdFilePath)
-                .should('exist')
-                .then((measureAID) => {
-                    cy.readFile(mSetIdPath)
-                        .should('exist')
-                        .then((mSetId) => {
-                            cy.readFile(mVersionIdPath)
-                                .should('exist')
-                                .then((mVersionId) => {
-                                    cy.request({
-                                        url: '/api/measures/' + measureAID + '/draft',
-                                        method: 'POST',
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        body: {
-                                            measureSetId: mSetId,
-                                            measureName: measureName,
-                                            cqlLibraryName: newCqlLibraryName,
-                                            model: 'QI-Core v4.1.1',
-                                            createdBy: harpUser,
-                                            cql: cohortMeasureCQL,
-                                            elmJson: elmJson,
-                                            ecqmTitle: 'ecqmTitle',
-                                            measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                                            measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z',
-                                            versionId: mVersionId
-                                        }
-                                    }).then((response) => {
-                                        const currentUser = Cypress.env('selectedUser')
-                                        expect(response.status).to.eql(201)
-                                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                                    })
-                                })
-                        })
-                })
+        expectCurrentVersion('minor', '1.1.000')
+        expectCurrentDraftStatus(true)
+
+        requestCurrentDraft().then((response) => {
+            expect(response.status).to.eql(201)
+            setCurrentMeasureId(response.body.id)
         })
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.request({
-                        url: '/api/measures/' + measureId + '/version?versionType=minor',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.1.000')
-                        newerMeasureName = response.body.measureName
-                    })
-                })
-        })
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mSetIdPath)
-                .should('exist')
-                .then((mSetId) => {
-                    cy.request({
-                        url: '/api/measures/draftstatus',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'POST',
-                        body: [mSetId]
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body).has.property(mSetId).and.is.eql(true)
-                    })
-                })
-        })
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mIdFilePath)
-                .should('exist')
-                .then((measureAID) => {
-                    cy.readFile(mSetIdPath)
-                        .should('exist')
-                        .then((mSetId) => {
-                            cy.readFile(mVersionIdPath)
-                                .should('exist')
-                                .then((mVersionId) => {
-                                    cy.request({
-                                        url: '/api/measures/' + measureAID + '/draft',
-                                        method: 'POST',
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        body: {
-                                            measureSetId: mSetId,
-                                            measureName: measureName,
-                                            cqlLibraryName: newCqlLibraryName,
-                                            model: 'QI-Core v4.1.1',
-                                            createdBy: harpUser,
-                                            cql: cohortMeasureCQL,
-                                            elmJson: elmJson,
-                                            ecqmTitle: 'ecqmTitle',
-                                            measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                                            measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z',
-                                            versionId: mVersionId
-                                        }
-                                    }).then((response) => {
-                                        const currentUser = Cypress.env('selectedUser')
-                                        expect(response.status).to.eql(201)
-                                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                                    })
-                                })
-                        })
-                })
-        })
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.request({
-                        url: '/api/measures/' + measureId + '/version?versionType=patch',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'PUT'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.version).to.eql('1.1.001')
-                        newerMeasureName = response.body.measureName
-                    })
-                })
-        })
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(mSetIdPath)
-                .should('exist')
-                .then((mSetId) => {
-                    cy.request({
-                        url: '/api/measures/draftstatus',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken.value
-                        },
-                        method: 'POST',
-                        body: [mSetId]
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body).has.property(mSetId).and.is.eql(true)
-                    })
-                })
-        })
+        expectCurrentVersion('patch', '1.1.001')
+        expectCurrentDraftStatus(true)
     })
 })

--- a/cypress/e2e/Services/Measure Service/MeasureExport.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureExport.cy.ts
@@ -1,5 +1,4 @@
 import { CreateMeasurePage, CreateMeasureOptions } from "../../../Shared/CreateMeasurePage"
-import { v4 as uuidv4 } from 'uuid'
 import { Utilities } from "../../../Shared/Utilities"
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
@@ -52,13 +51,72 @@ const PopDenom = 'denom'
 const PopDenex = 'ipp'
 const PopDenexcep = 'denom'
 const PopNumex = 'numeratorExclusion'
+const steward = {
+    name: "SemanticBits",
+    id: "64120f265de35122e68dac40",
+    oid: "02c84f54-919b-4464-bf51-a1438f2710e2",
+    url: "https://semanticbits.com/"
+}
+const developers = [
+    {
+        id: "64120f265de35122e68dabf7",
+        name: "Academy of Nutrition and Dietetics",
+        oid: "2.16.840.1.113883.3.6308",
+        url: "www.eatrightpro.org"
+    }
+]
+const qiCoreExportGroup = {
+    scoring: 'Proportion',
+    populationBasis: 'Boolean',
+    populations: [
+        TestData.population('initialPopulation', PopIniPop),
+        TestData.population('denominator', PopDenom),
+        TestData.population('denominatorExclusion', PopDenex),
+        TestData.population('denominatorException', PopDenexcep),
+        TestData.population('numerator', PopNum),
+        TestData.population('numeratorExclusion', PopNumex)
+    ],
+    scoringUnit: {
+        label: "ml milliLiters",
+        value: {
+            code: "ml",
+            name: "milliLiters",
+            guidance: "",
+            system: "https://clinicaltables.nlm.nih.gov/"
+        }
+    },
+    measureGroupTypes: ["Outcome"],
+    improvementNotation: "Increased score indicates improvement"
+}
 
 const measureData: CreateMeasureOptions = {}
+
+const writeCurrentMeasureFixtures = (responseBody: {
+    id: string
+    versionId: string
+    measureSetId: string
+}): void => {
+    TestData.writeFixture('measureId', responseBody.id)
+    TestData.writeFixture('versionId', responseBody.versionId)
+    TestData.writeFixture('measureSetId', responseBody.measureSetId)
+}
+
+const requestCurrentMeasureExport = (options: Partial<Cypress.RequestOptions> = {}) => {
+    return TestData.requestMeasureExport<any>(options)
+}
+
+const expectExportFailure = (expectedMessage: (measureId: string) => string): void => {
+    TestData.readMeasureId().then((measureId) => {
+        requestCurrentMeasureExport({ failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(409)
+            expect(response.body.message).to.eql(expectedMessage(measureId))
+        })
+    })
+}
 
 describe('QI-Core Measure Export', () => {
 
     beforeEach('Create Measure and set access token', () => {
-        const currentUser = Cypress.env('selectedUser')
         newMeasureName = measureName + randValue
         newCqlLibraryName = CqlLibraryName + randValue
 
@@ -67,70 +125,10 @@ describe('QI-Core Measure Export', () => {
             TestData.expectSavedMeasureCql(response)
         })
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((retrievedMeasureID) => {
-                cy.request({
-                    url: '/api/measures/' + retrievedMeasureID + '/groups',
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "scoring": 'Proportion',
-                        "populationBasis": 'Boolean',
-                        "populations": [
-                            {
-                                "id": uuidv4(),
-                                "name": "initialPopulation",
-                                "definition": PopIniPop
-                            },
-                            {
-                                "id": uuidv4(),
-                                "name": "denominator",
-                                "definition": PopDenom
-                            },
-                            {
-                                "id": uuidv4(),
-                                "name": "denominatorExclusion",
-                                "definition": PopDenex
-                            },
-                            {
-                                "id": uuidv4(),
-                                "name": "denominatorException",
-                                "definition": PopDenexcep
-                            },
-                            {
-                                "id": uuidv4(),
-                                "name": "numerator",
-                                "definition": PopNum
-                            },
-                            {
-                                "id": uuidv4(),
-                                "name": "numeratorExclusion",
-                                "definition": PopNumex
-                            }
-                        ],
-                        "scoringUnit": {
-                            "label": "ml milliLiters",
-                            "value": {
-                                "code": "ml",
-                                "name": "milliLiters",
-                                "guidance": "",
-                                "system": "https://clinicaltables.nlm.nih.gov/"
-                            }
-                        },
-                        "measureGroupTypes": [
-                            "Outcome"
-                        ],
-                        "improvementNotation": "Increased score indicates improvement"
-                    }
-                }).then((response) => {
-                    const currentUser = Cypress.env('selectedUser')
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/groupId', response.body.id)
-                })
-            })
+        TestData.requestMeasureGroup('POST', qiCoreExportGroup).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            TestData.writeFixture('groupId', response.body.id)
         })
 
         OktaLogin.setupUserSession(false)
@@ -143,21 +141,9 @@ describe('QI-Core Measure Export', () => {
     })
 
     it('Confirm the export end point returns a contentType of "application/zip" for QI-Core Measure', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(201)
-                    expect(response.body).is.not.null
-                })
-            })
+        requestCurrentMeasureExport().then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body).is.not.null
         })
     })
 })
@@ -178,23 +164,12 @@ describe('Error Message on Measure Export when the Measure does not have CQL', (
     })
 
     it('Verify error message on Measure Export when the Measure does not have CQL', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Response could not be completed for Measure with ID ' + id + ', since there is no population criteria on the measure.')
-                })
-            })
-        })
+        expectExportFailure(
+            (measureId) =>
+                'Response could not be completed for Measure with ID ' +
+                measureId +
+                ', since there is no population criteria on the measure.'
+        )
     })
 })
 
@@ -214,23 +189,12 @@ describe('Error Message on Measure Export when the Measure CQL has errors', () =
     })
 
     it('Verify error message on Measure Export when the Measure CQL has errors', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Response could not be completed for Measure with ID ' + id + ', since there is no population criteria on the measure.')
-                })
-            })
-        })
+        expectExportFailure(
+            (measureId) =>
+                'Response could not be completed for Measure with ID ' +
+                measureId +
+                ', since there is no population criteria on the measure.'
+        )
     })
 })
 
@@ -250,23 +214,12 @@ describe('Error Message on Measure Export when the Measure does not have Populat
     })
 
     it('Verify error message on Measure Export when the Measure does not have Population Criteria', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Response could not be completed for Measure with ID ' + id + ', since there is no population criteria on the measure.')
-                })
-            })
-        })
+        expectExportFailure(
+            (measureId) =>
+                'Response could not be completed for Measure with ID ' +
+                measureId +
+                ', since there is no population criteria on the measure.'
+        )
     })
 })
 
@@ -279,34 +232,20 @@ describe('Error Message on Measure Export when the Measure does not have Steward
 
         OktaLogin.setupUserSession(false)
 
-        //Create Measure with out Steward and Developer
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/measure',
-                method: 'POST',
-                headers: {
-                    Authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "measureName": newMeasureName,
-                    "cqlLibraryName": newCqlLibraryName,
-                    "model": 'QI-Core v4.1.1',
-                    "versionId": uuidv4(),
-                    "measureSetId": uuidv4(),
-                    "ecqmTitle": 'eCQMTitle',
-                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
-                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
-                    'measureMetaData': {
-                        "experimental": false,
-                        "description": "SemanticBits"
-                    }
-                }
-            }).then((response) => {
-                const currentUser = Cypress.env('selectedUser')
-                expect(response.status).to.eql(201)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-            })
+        TestData.requestMeasure({
+            measureName: newMeasureName,
+            cqlLibraryName: newCqlLibraryName,
+            model: 'QI-Core v4.1.1',
+            ecqmTitle: 'eCQMTitle',
+            measurementPeriodStart: mpStartDate + "T00:00:00.000Z",
+            measurementPeriodEnd: mpEndDate + "T00:00:00.000Z",
+            measureMetaData: {
+                experimental: false,
+                description: "SemanticBits"
+            }
+        }).then((response) => {
+            expect(response.status).to.eql(201)
+            writeCurrentMeasureFixtures(response.body)
         })
     })
 
@@ -316,23 +255,12 @@ describe('Error Message on Measure Export when the Measure does not have Steward
     })
 
     it('Verify error message on Measure Export when the Measure does not have Steward and Developer', () => {
-        const currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Response could not be completed for Measure with ID ' + id + ', since there are no associated developers in metadata.')
-                })
-            })
-        })
+        expectExportFailure(
+            (measureId) =>
+                'Response could not be completed for Measure with ID ' +
+                measureId +
+                ', since there are no associated developers in metadata.'
+        )
     })
 })
 
@@ -345,46 +273,21 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
 
         OktaLogin.setupUserSession(false)
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/measure',
-                method: 'POST',
-                headers: {
-                    Authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "measureName": newMeasureName,
-                    "cqlLibraryName": newCqlLibraryName,
-                    "model": 'QI-Core v4.1.1',
-                    "versionId": uuidv4(),
-                    "measureSetId": uuidv4(),
-                    "ecqmTitle": 'eCQMTitle',
-                    'measurementPeriodStart': mpStartDate + "T00:00:00.000Z",
-                    'measurementPeriodEnd': mpEndDate + "T00:00:00.000Z",
-                    'measureMetaData': {
-                        "experimental": false,
-                        "steward": {
-                            "name": "SemanticBits",
-                            "id": "64120f265de35122e68dac40",
-                            "oid": "02c84f54-919b-4464-bf51-a1438f2710e2",
-                            "url": "https://semanticbits.com/"
-
-                        }, "developers": [
-                            {
-                                "id": "64120f265de35122e68dabf7",
-                                "name": "Academy of Nutrition and Dietetics",
-                                "oid": "2.16.840.1.113883.3.6308",
-                                "url": "www.eatrightpro.org"
-                            }
-                        ]
-                    }
-                }
-            }).then((response) => {
-                const currentUser = Cypress.env('selectedUser')
-                expect(response.status).to.eql(201)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-            })
+        TestData.requestMeasure({
+            measureName: newMeasureName,
+            cqlLibraryName: newCqlLibraryName,
+            model: 'QI-Core v4.1.1',
+            ecqmTitle: 'eCQMTitle',
+            measurementPeriodStart: mpStartDate + "T00:00:00.000Z",
+            measurementPeriodEnd: mpEndDate + "T00:00:00.000Z",
+            measureMetaData: {
+                experimental: false,
+                steward,
+                developers
+            }
+        }).then((response) => {
+            expect(response.status).to.eql(201)
+            writeCurrentMeasureFixtures(response.body)
         })
     })
 
@@ -394,23 +297,12 @@ describe('Error Message on Measure Export when the Measure does not have Descrip
     })
 
     it('Verify error message on Measure Export when the Measure does not have Description', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Response could not be completed for Measure with ID ' + id + ', since there is no description in metadata.')
-                })
-            })
-        })
+        expectExportFailure(
+            (measureId) =>
+                'Response could not be completed for Measure with ID ' +
+                measureId +
+                ', since there is no description in metadata.'
+        )
     })
 })
 
@@ -442,21 +334,9 @@ describe('QDM Measure Export', () => {
     })
 
     it('Successful QDM Measure Export', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/exports',
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    console.log(response)
-                    expect(response.status).to.eql(201)
-                    expect(response.body).is.not.null
-                })
-            })
+        requestCurrentMeasureExport().then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body).is.not.null
         })
     })
 })

--- a/cypress/e2e/Services/Measure Service/MeasureVersion.cy.ts
+++ b/cypress/e2e/Services/Measure Service/MeasureVersion.cy.ts
@@ -24,6 +24,10 @@ let newMeasureName = ''
 let newCQLLibraryName = ''
 let harpUser = ''
 let harpUserALT = ''
+const versionedMeasureError = (measureId: string) =>
+    'Response could not be completed for measure with ID ' +
+    measureId +
+    ', since the measure is not in a draft status'
 
 const measureCQL =
     'library ' +
@@ -57,6 +61,75 @@ const measureCQL_WithParsingAndVSACErrors =
     'valueset "Preventive Care Services - Established Office Visit, 18 and Up": \'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1025\'\n' +
     'valueset "HPV Test": \'\'\n' +
     'define "ipp": true)'
+
+const writeCurrentMeasureFixtures = (responseBody: {
+    id: string
+    versionId: string
+    measureSetId: string
+}): void => {
+    TestData.writeFixture('measureId', responseBody.id)
+    TestData.writeFixture('versionId', responseBody.versionId)
+    TestData.writeFixture('measureSetId', responseBody.measureSetId)
+}
+
+const versionedMeasureUpdateBody = (measureId: string, versionId: string) => ({
+    id: measureId,
+    measureName: 'UpdatedTestMeasure' + randValue,
+    cqlLibraryName: 'UpdatedCqlLibrary' + randValue,
+    model: 'QI-Core v4.1.1',
+    measureScoring: 'Ratio',
+    versionId,
+    measureSetId: uuidv4(),
+    version: '1.0.000',
+    ecqmTitle: 'ecqmTitle',
+    measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
+    measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z'
+})
+
+const versionedMeasureGroupUpdateBody = (measureId: string) => ({
+    id: measureId,
+    scoring: 'Ratio',
+    populations: [
+        TestData.population('initialPopulation', 'num'),
+        TestData.population('numerator', 'denom'),
+        TestData.population('numeratorExclusion', 'ipp'),
+        TestData.population('denominator', 'num')
+    ],
+    measureGroupTypes: ['Outcome'],
+    populationBasis: 'Boolean'
+})
+
+const versionedMeasureGroupDeleteBody = (measureId: string, groupId: string) => ({
+    id: measureId,
+    groups: [
+        {
+            id: groupId,
+            scoring: 'Cohort',
+            populations: [
+                {
+                    id: uuidv4(),
+                    name: 'initialPopulation',
+                    definition: 'ipp',
+                    associationType: null,
+                    description: null
+                }
+            ],
+            measureGroupTypes: ['Outcome'],
+            scoringUnit: '',
+            stratifications: [],
+            populationBasis: 'boolean'
+        }
+    ]
+})
+
+const versionedTestCaseUpdateBody = (testCaseId: string) => ({
+    id: testCaseId,
+    name: 'IPPPass',
+    series: 'WhenBPLessThan120',
+    title: 'test case title edited',
+    description: 'IPP Pass Test BP Less Than 120',
+    json: '{ \n  Encounter: "Office Visit union" \n  Id: "Identifier" \n  value: "Visit out of hours (procedure)" \n}'
+})
 
 describe('Measure Versioning', () => {
     beforeEach('Create Measure and Set Access Token', () => {
@@ -128,29 +201,22 @@ describe('Version Measure with invalid CQL', () => {
 
         OktaLogin.setupUserSession(false)
 
-        TestData.requestWithAccessToken<any>({
-            failOnStatusCode: false,
-            url: '/api/measure',
-            method: 'POST',
-            body: {
-                measureName: newMeasureName,
-                cqlLibraryName: newCQLLibraryName,
-                model: 'QI-Core v4.1.1',
-                ecqmTitle: 'eCQMTitle',
-                cql: measureCQL_WithParsingAndVSACErrors,
-                measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z',
-                versionId: uuidv4(),
-                measureSetId: uuidv4()
-            }
+        TestData.requestMeasure<any>({
+            measureName: newMeasureName,
+            cqlLibraryName: newCQLLibraryName,
+            model: 'QI-Core v4.1.1',
+            ecqmTitle: 'eCQMTitle',
+            cql: measureCQL_WithParsingAndVSACErrors,
+            measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
+            measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z'
+        }, {
+            failOnStatusCode: false
         }).then((response) => {
             expect(response.status).to.eql(201)
             expect(response.body.id).to.be.exist
             expect(response.body.errors[0]).to.include('ERRORS_ELM_JSON')
 
-            TestData.writeFixture('measureId', response.body.id)
-            TestData.writeFixture('versionId', response.body.versionId)
-            TestData.writeFixture('measureSetId', response.body.measureSetId)
+            writeCurrentMeasureFixtures(response.body)
         })
     })
 
@@ -223,126 +289,43 @@ describe('Edit validations for versioned Measure', () => {
     })
 
     it('Verify error messages when user try to edit Measure details, Measure Groups or Test cases for versioned Measure', () => {
-        let currentUser = Cypress.env('selectedUser')
         cy.log('Version the Measure')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.readFile('cypress/fixtures/' + currentUser + '/versionId')
-                        .should('exist')
-                        .then((vId) => {
-                            cy.request({
-                                url: '/api/measures/' + measureId + '/version?versionType=major',
-                                headers: {
-                                    authorization: 'Bearer ' + accessToken.value
-                                },
-                                method: 'PUT'
-                            }).then((response) => {
-                                expect(response.status).to.eql(200)
-                                expect(response.body.version).to.eql('1.0.000')
-                            })
+        TestData.versionMeasure().then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body.version).to.eql('1.0.000')
+        })
 
-                            cy.log('Verify error message on editing Measure details')
-                            cy.request({
-                                failOnStatusCode: false,
-                                url: '/api/measures/' + measureId,
-                                headers: {
-                                    authorization: 'Bearer ' + accessToken.value
-                                },
-                                method: 'PUT',
-                                body: {
-                                    id: measureId,
-                                    measureName: 'UpdatedTestMeasure' + randValue,
-                                    cqlLibraryName: 'UpdatedCqlLibrary' + randValue,
-                                    model: 'QI-Core v4.1.1',
-                                    measureScoring: 'Ratio',
-                                    versionId: vId,
-                                    measureSetId: uuidv4(),
-                                    version: '1.0.000',
-                                    ecqmTitle: 'ecqmTitle',
-                                    measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                                    measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z'
-                                }
-                            }).then((response) => {
-                                expect(response.status).to.eql(409)
-                                expect(response.body.message).to.include(
-                                    'Response could not be completed for measure with ID ' +
-                                        measureId +
-                                        ', since the measure is not in a draft status'
-                                )
-                            })
+        cy.log('Verify error message on editing Measure details')
+        TestData.readMeasureId().then((measureId) => {
+            TestData.updateCurrentMeasure(
+                ({ versionId }) => versionedMeasureUpdateBody(measureId, versionId),
+                { failOnStatusCode: false }
+            ).then((response) => {
+                expect(response.status).to.eql(409)
+                expect(response.body.message).to.include(versionedMeasureError(measureId))
+            })
+        })
 
-                            cy.log('Verify error message on editing Measure group')
-                            cy.request({
-                                failOnStatusCode: false,
-                                url: '/api/measures/' + measureId + '/groups',
-                                method: 'PUT',
-                                headers: {
-                                    authorization: 'Bearer ' + accessToken.value
-                                },
-                                body: {
-                                    id: measureId,
-                                    scoring: 'Ratio',
-                                    populations: [
-                                        {
-                                            id: uuidv4(),
-                                            name: 'initialPopulation',
-                                            definition: 'num'
-                                        },
-                                        {
-                                            id: uuidv4(),
-                                            name: 'numerator',
-                                            definition: 'denom'
-                                        },
-                                        {
-                                            id: uuidv4(),
-                                            name: 'numeratorExclusion',
-                                            definition: 'ipp'
-                                        },
-                                        {
-                                            id: uuidv4(),
-                                            name: 'denominator',
-                                            definition: 'num'
-                                        }
-                                    ],
-                                    measureGroupTypes: ['Outcome'],
-                                    populationBasis: 'Boolean'
-                                }
-                            }).then((response) => {
-                                expect(response.status).to.eql(409)
-                                expect(response.body.message).to.include(
-                                    'Response could not be completed for measure with ID ' +
-                                        measureId +
-                                        ', since the measure is not in a draft status'
-                                )
-                            })
+        cy.log('Verify error message on editing Measure group')
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestMeasureGroup<any>('PUT', versionedMeasureGroupUpdateBody(measureId), 0, {
+                failOnStatusCode: false
+            }).then((response) => {
+                expect(response.status).to.eql(409)
+                expect(response.body.message).to.include(versionedMeasureError(measureId))
+            })
+        })
 
-                            cy.log('Verify error message on editing Test case')
-                            cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId')
-                                .should('exist')
-                                .then((testcaseid) => {
-                                    cy.request({
-                                        failOnStatusCode: false,
-                                        url: '/api/measures/' + measureId + '/test-cases/' + testcaseid,
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        method: 'PUT',
-                                        body: {
-                                            id: testcaseid,
-                                            name: 'IPPPass',
-                                            series: 'WhenBPLessThan120',
-                                            title: 'test case title edited',
-                                            description: 'IPP Pass Test BP Less Than 120',
-                                            json: '{ \n  Encounter: "Office Visit union" \n  Id: "Identifier" \n  value: "Visit out of hours (procedure)" \n}'
-                                        }
-                                    }).then((response) => {
-                                        expect(response.status).to.eql(200)
-                                    })
-                                })
-                        })
-                })
+        cy.log('Verify error message on editing Test case')
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestMeasureTestCase(
+                'PUT',
+                ({ testCaseId }) => versionedTestCaseUpdateBody(testCaseId ?? ''),
+                { failOnStatusCode: false }
+            ).then((response) => {
+                expect(response.status).to.eql(200)
+                expect(response.body.id).to.exist
+            })
         })
     })
 })
@@ -378,121 +361,43 @@ describe('Delete validations for versioned Measure', () => {
     })
 
     it('Verify error messages when user try to delete Measure, Measure Groups or Test cases for versioned Measures', () => {
-        let currentUser = Cypress.env('selectedUser')
         cy.log('Version the Measure')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
-                .should('exist')
-                .then((measureId) => {
-                    cy.readFile('cypress/fixtures/' + currentUser + '/versionId')
-                        .should('exist')
-                        .then((vId) => {
-                            cy.request({
-                                url: '/api/measures/' + measureId + '/version?versionType=major',
-                                headers: {
-                                    authorization: 'Bearer ' + accessToken.value
-                                },
-                                method: 'PUT'
-                            }).then((response) => {
-                                expect(response.status).to.eql(200)
-                                expect(response.body.version).to.include('1.0.000')
-                            })
+        TestData.versionMeasure().then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body.version).to.include('1.0.000')
+        })
 
-                            cy.log('Verify error message on delete Measure')
-                            cy.request({
-                                failOnStatusCode: false,
-                                url: '/api/measures/' + measureId,
-                                headers: {
-                                    authorization: 'Bearer ' + accessToken.value
-                                },
-                                method: 'PUT',
-                                body: {
-                                    id: measureId,
-                                    measureName: 'UpdatedTestMeasure' + randValue,
-                                    cqlLibraryName: 'UpdatedCqlLibrary' + randValue,
-                                    model: 'QI-Core v4.1.1',
-                                    measureScoring: 'Ratio',
-                                    versionId: vId,
-                                    measureSetId: uuidv4(),
-                                    version: '1.0.000',
-                                    ecqmTitle: 'ecqmTitle',
-                                    measurementPeriodStart: mpStartDate + 'T00:00:00.000Z',
-                                    measurementPeriodEnd: mpEndDate + 'T00:00:00.000Z'
-                                }
-                            }).then((response) => {
-                                expect(response.status).to.eql(409)
-                                expect(response.body.message).to.include(
-                                    'Response could not be completed for measure with ID ' +
-                                        measureId +
-                                        ', since the measure is not in a draft status'
-                                )
-                            })
+        cy.log('Verify error message on delete Measure')
+        TestData.readMeasureId().then((measureId) => {
+            TestData.updateCurrentMeasure(
+                ({ versionId }) => versionedMeasureUpdateBody(measureId, versionId),
+                { failOnStatusCode: false }
+            ).then((response) => {
+                expect(response.status).to.eql(409)
+                expect(response.body.message).to.include(versionedMeasureError(measureId))
+            })
+        })
 
-                            cy.log('Verify error message on delete Measure group')
-                            cy.readFile('cypress/fixtures/' + currentUser + '/measureGroupId')
-                                .should('exist')
-                                .then((groupId) => {
-                                    cy.request({
-                                        failOnStatusCode: false,
-                                        url: '/api/measures/' + measureId + '/groups/' + groupId,
-                                        method: 'DELETE',
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        body: {
-                                            id: measureId,
-                                            groups: [
-                                                {
-                                                    id: groupId,
-                                                    scoring: 'Cohort',
-                                                    populations: [
-                                                        {
-                                                            id: uuidv4,
-                                                            name: 'initialPopulation',
-                                                            definition: 'ipp',
-                                                            associationType: null,
-                                                            description: null
-                                                        }
-                                                    ],
-                                                    measureGroupTypes: ['Outcome'],
-                                                    scoringUnit: '',
-                                                    stratifications: [],
-                                                    populationBasis: 'boolean'
-                                                }
-                                            ]
-                                        }
-                                    }).then((response) => {
-                                        expect(response.status).to.eql(409)
-                                        expect(response.body.message).to.include(
-                                            'Response could not be completed for measure with ID ' +
-                                                measureId +
-                                                ', since the measure is not in a draft status'
-                                        )
-                                    })
-                                })
-
-                            cy.log('Verify error message on delete Test case')
-                            cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId')
-                                .should('exist')
-                                .then((testcaseid) => {
-                                    cy.request({
-                                        failOnStatusCode: false,
-                                        url: '/api/measures/' + measureId + '/test-cases/' + testcaseid,
-                                        headers: {
-                                            authorization: 'Bearer ' + accessToken.value
-                                        },
-                                        method: 'DELETE',
-                                        body: {
-                                            id: testcaseid,
-                                            title: testCaseTitle
-                                        }
-                                    }).then((response) => {
-                                        expect(response.status).to.eql(405)
-                                        expect(response.body.error).to.include('Method Not Allowed')
-                                    })
-                                })
-                        })
+        cy.log('Verify error message on delete Measure group')
+        TestData.readMeasureId().then((measureId) => {
+            TestData.readFixture('measureGroupId').then((groupId) => {
+                TestData.requestMeasureGroupById<any>(
+                    'DELETE',
+                    groupId,
+                    versionedMeasureGroupDeleteBody(measureId, groupId),
+                    0,
+                    { failOnStatusCode: false }
+                ).then((response) => {
+                    expect(response.status).to.eql(409)
+                    expect(response.body.message).to.include(versionedMeasureError(measureId))
                 })
+            })
+        })
+
+        cy.log('Verify error message on delete Test case')
+        TestData.requestMeasureTestCase('DELETE', undefined, { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(405)
+            expect(response.body.error).to.include('Method Not Allowed')
         })
     })
 })

--- a/cypress/e2e/Services/QDM Measure Service/QDM Measure.cy.ts
+++ b/cypress/e2e/Services/QDM Measure Service/QDM Measure.cy.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { CreateMeasurePage } from "../../../Shared/CreateMeasurePage"
 import { OktaLogin } from "../../../Shared/OktaLogin"
 import { QdmCql } from "../../../Shared/QDMMeasuresCQL"
+import { TestData } from "../../../Shared/TestData"
 const now = require('dayjs')
 const mpStartDate = now().subtract('1', 'year').format('YYYY-MM-DD')
 const mpEndDate = now().format('YYYY-MM-DD')
@@ -13,6 +14,30 @@ const cql = QdmCql.qdmCQLPatientBasedTest
 let measureName = ''
 let CQLLibraryName = ''
 let harpUser = ''
+
+const writeCurrentMeasureFixtures = (responseBody: {
+    id: string
+    versionId: string
+    measureSetId: string
+}): void => {
+    TestData.writeFixture('measureId', responseBody.id)
+    TestData.writeFixture('versionId', responseBody.versionId)
+    TestData.writeFixture('measureSetId', responseBody.measureSetId)
+}
+
+const qdmMeasureBody = (overrides: Record<string, unknown> = {}) => ({
+    measureName,
+    cqlLibraryName: CQLLibraryName,
+    model: QDMModel,
+    ecqmTitle: eCQMTitle,
+    measurementPeriodStart: mpStartDate,
+    measurementPeriodEnd: mpEndDate,
+    testCaseConfiguration: {
+        id: null,
+        sdeIncluded: null
+    },
+    ...overrides
+})
 
 describe('Measure Service: QDM Measure', () => {
 
@@ -31,44 +56,19 @@ describe('Measure Service: QDM Measure', () => {
         measureName = 'SuccessQDMCreate' + Date.now()
         CQLLibraryName = 'SuccessQDMCreateLib' + Date.now()
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/measure',
-                method: 'POST',
-                headers: {
-                    Authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "measureName": measureName,
-                    "cqlLibraryName": CQLLibraryName,
-                    "model": QDMModel,
-                    "versionId": uuidv4(),
-                    "measureSetId": uuidv4(),
-                    "measureScoring": "Cohort",
-                    "ecqmTitle": eCQMTitle,
-                    "measurementPeriodStart": mpStartDate,
-                    "measurementPeriodEnd": mpEndDate,
-                    "rateAggregation": "Aggregation",
-                    "improvementNotation": "Increased score indicates improvement",
-                    "improvementNotationDescription": "This is a description for when the IN is set to \"Increased score indicates improvement\"",
-                    "testCaseConfiguration": {
-                        "id": null,
-                        "sdeIncluded": null
-                    },
-                }
-            }).then((response) => {
-                let currentUser = Cypress.env('selectedUser')
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
+        TestData.requestMeasure<any>(qdmMeasureBody({
+            measureScoring: "Cohort",
+            rateAggregation: "Aggregation",
+            improvementNotation: "Increased score indicates improvement",
+            improvementNotationDescription: "This is a description for when the IN is set to \"Increased score indicates improvement\""
+        })).then((response) => {
+            writeCurrentMeasureFixtures(response.body)
 
-                expect(response.status).to.eql(201)
-                expect(response.body.createdBy).to.eql(harpUser)
-                expect(response.body.rateAggregation).to.eql('Aggregation')
-                expect(response.body.improvementNotation).to.eql('Increased score indicates improvement')
-                expect(response.body.improvementNotationDescription).to.eql('This is a description for when the IN is set to \"Increased score indicates improvement\"')
-            })
-
+            expect(response.status).to.eql(201)
+            expect(response.body.createdBy).to.eql(harpUser)
+            expect(response.body.rateAggregation).to.eql('Aggregation')
+            expect(response.body.improvementNotation).to.eql('Increased score indicates improvement')
+            expect(response.body.improvementNotationDescription).to.eql('This is a description for when the IN is set to \"Increased score indicates improvement\"')
         })
     })
 
@@ -77,47 +77,23 @@ describe('Measure Service: QDM Measure', () => {
         measureName = 'BaseConfigCreation' + Date.now()
         CQLLibraryName = 'BaseConfigCreationLib' + Date.now()
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/measure',
-                method: 'POST',
-                headers: {
-                    Authorization: 'Bearer ' + accessToken?.value
-                },
-                body: {
-                    "measureName": measureName,
-                    "cqlLibraryName": CQLLibraryName,
-                    "model": QDMModel,
-                    "versionId": uuidv4(),
-                    "measureSetId": uuidv4(),
-                    "measureScoring": "Cohort",
-                    "baseConfigurationTypes": [
-                        "Efficiency",
-                        "Outcome",
-                        "Process"
-                    ],
-                    "patientBasis": true,
-                    "ecqmTitle": eCQMTitle,
-                    "measurementPeriodStart": mpStartDate,
-                    "measurementPeriodEnd": mpEndDate,
-                    "testCaseConfiguration": {
-                        "id": null,
-                        "sdeIncluded": null
-                    },
-                }
-            }).then((response) => {
-                let currentUser = Cypress.env('selectedUser')
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
+        TestData.requestMeasure<any>(qdmMeasureBody({
+            measureScoring: "Cohort",
+            baseConfigurationTypes: [
+                "Efficiency",
+                "Outcome",
+                "Process"
+            ],
+            patientBasis: true
+        })).then((response) => {
+            writeCurrentMeasureFixtures(response.body)
 
-                expect(response.status).to.eql(201)
-                expect(response.body.createdBy).to.eql(harpUser)
-                expect(response.body.baseConfigurationTypes[0]).to.eql('Efficiency')
-                expect(response.body.baseConfigurationTypes[1]).to.eql('Outcome')
-                expect(response.body.baseConfigurationTypes[2]).to.eql('Process')
-                expect(response.body.patientBasis).to.eql(true)
-            })
+            expect(response.status).to.eql(201)
+            expect(response.body.createdBy).to.eql(harpUser)
+            expect(response.body.baseConfigurationTypes[0]).to.eql('Efficiency')
+            expect(response.body.baseConfigurationTypes[1]).to.eql('Outcome')
+            expect(response.body.baseConfigurationTypes[2]).to.eql('Process')
+            expect(response.body.patientBasis).to.eql(true)
         })
     })
 
@@ -126,64 +102,40 @@ describe('Measure Service: QDM Measure', () => {
         measureName = 'QdmSdeRav' + Date.now()
         CQLLibraryName = 'QdmSdeRavLib' + Date.now()
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/measure',
-                method: 'POST',
-                headers: {
-                    Authorization: 'Bearer ' + accessToken?.value
+        TestData.requestMeasure<any>(qdmMeasureBody({
+            supplementalData: [
+                {
+                    definition: "supplementalDataDefinition",
+                    description: "supplementalDataDescription"
                 },
-                body: {
-                    "measureName": measureName,
-                    "cqlLibraryName": CQLLibraryName,
-                    "model": QDMModel,
-                    "versionId": uuidv4(),
-                    "measureSetId": uuidv4(),
-                    "ecqmTitle": eCQMTitle,
-                    "measurementPeriodStart": mpStartDate,
-                    "measurementPeriodEnd": mpEndDate,
-                    "testCaseConfiguration": {
-                        "id": null,
-                        "sdeIncluded": null
-                    },
-                    "supplementalData": [
-                        {
-                            "definition": "supplementalDataDefinition",
-                            "description": "supplementalDataDescription"
-                        },
-                        {
-                            "definition": "supplementalDataDefinition2",
-                            "description": "supplementalDataDescription2"
-                        }
-                    ],
-                    "riskAdjustments": [
-                        {
-                            "definition": "riskAdjustmentDefinition",
-                            "description": "riskAdjustmentDescription"
-                        },
-                        {
-                            "definition": "riskAdjustmentDefinition2",
-                            "description": "riskAdjustmentDescription2"
-                        }
-                    ]
+                {
+                    definition: "supplementalDataDefinition2",
+                    description: "supplementalDataDescription2"
                 }
-            }).then((response) => {
-                let currentUser = Cypress.env('selectedUser')
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
+            ],
+            riskAdjustments: [
+                {
+                    definition: "riskAdjustmentDefinition",
+                    description: "riskAdjustmentDescription"
+                },
+                {
+                    definition: "riskAdjustmentDefinition2",
+                    description: "riskAdjustmentDescription2"
+                }
+            ]
+        })).then((response) => {
+            writeCurrentMeasureFixtures(response.body)
 
-                expect(response.status).to.eql(201)
-                expect(response.body.createdBy).to.eql(harpUser)
-                expect(response.body.supplementalData[0].definition).to.eql('supplementalDataDefinition')
-                expect(response.body.supplementalData[0].description).to.eql('supplementalDataDescription')
-                expect(response.body.supplementalData[1].definition).to.eql('supplementalDataDefinition2')
-                expect(response.body.supplementalData[1].description).to.eql('supplementalDataDescription2')
-                expect(response.body.riskAdjustments[0].definition).to.eql('riskAdjustmentDefinition')
-                expect(response.body.riskAdjustments[0].description).to.eql('riskAdjustmentDescription')
-                expect(response.body.riskAdjustments[1].definition).to.eql('riskAdjustmentDefinition2')
-                expect(response.body.riskAdjustments[1].description).to.eql('riskAdjustmentDescription2')
-            })
+            expect(response.status).to.eql(201)
+            expect(response.body.createdBy).to.eql(harpUser)
+            expect(response.body.supplementalData[0].definition).to.eql('supplementalDataDefinition')
+            expect(response.body.supplementalData[0].description).to.eql('supplementalDataDescription')
+            expect(response.body.supplementalData[1].definition).to.eql('supplementalDataDefinition2')
+            expect(response.body.supplementalData[1].description).to.eql('supplementalDataDescription2')
+            expect(response.body.riskAdjustments[0].definition).to.eql('riskAdjustmentDefinition')
+            expect(response.body.riskAdjustments[0].description).to.eql('riskAdjustmentDescription')
+            expect(response.body.riskAdjustments[1].definition).to.eql('riskAdjustmentDefinition2')
+            expect(response.body.riskAdjustments[1].description).to.eql('riskAdjustmentDescription2')
         })
     })
 })
@@ -205,66 +157,49 @@ describe('QDM Measure: Transmission format', () => {
     })
 
     it('Add Transmission format to the QDM Measure', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/versionId').should('exist').then((vId) => {
-                    cy.request({
-                        url: '/api/measures/' + id,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            "id": id,
-                            "measureName": measureName,
-                            "cqlLibraryName": CQLLibraryName,
-                            "model": QDMModel,
-                            "cql": cql,
-                            "version": "0.0.000",
-                            "measureScoring": "Ratio",
-                            "versionId": vId,
-                            "measureSetId": uuidv4(),
-                            "measureMetaData": { 
-                                "experimental": false, 
-                                "draft": true, 
-                                "transmissionFormat": "Test Transmission format"
-                            },
-                            "reviewMetaData": {
-                                "approvalDate": null,
-                                "lastReviewDate": null
-                            },
-                            "measureSet": {
-                                "id": "68ac804018f2135a1f3a17d3",
-                                "cmsId": null,
-                                "measureSetId": "db336d58-3f9c-407f-88f6-890cec960a83",
-                                "owner": "test.ReUser6408",
-                                "acls": null
-                            },
-                            "ecqmTitle": "ecqmTitle",
-                            "measurementPeriodStart": mpStartDate + "T00:00:00.000Z",
-                            "measurementPeriodEnd": mpEndDate + "T00:00:00.000Z",
-                            "testCaseConfiguration": {
-                                "id": null,
-                                "sdeIncluded": null
-                            },
-                            "scoring": null,
-                            "baseConfigurationTypes": null,
-                            "patientBasis": true,
-                            "rateAggregation": null,
-                            "improvementNotation": null,
-                            "improvementNotationDescription": null
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.measureMetaData.transmissionFormat).to.eql('Test Transmission format')
-
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureId', response.body.id)
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/versionId', response.body.versionId)
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/measureSetId', response.body.measureSetId)
-                    })
-                })
-            })
+        TestData.updateCurrentMeasure<any>(({ measureId, versionId }) => ({
+            id: measureId,
+            measureName,
+            cqlLibraryName: CQLLibraryName,
+            model: QDMModel,
+            cql,
+            version: "0.0.000",
+            measureScoring: "Ratio",
+            versionId,
+            measureSetId: uuidv4(),
+            measureMetaData: {
+                experimental: false,
+                draft: true,
+                transmissionFormat: "Test Transmission format"
+            },
+            reviewMetaData: {
+                approvalDate: null,
+                lastReviewDate: null
+            },
+            measureSet: {
+                id: "68ac804018f2135a1f3a17d3",
+                cmsId: null,
+                measureSetId: "db336d58-3f9c-407f-88f6-890cec960a83",
+                owner: "test.ReUser6408",
+                acls: null
+            },
+            ecqmTitle: "ecqmTitle",
+            measurementPeriodStart: mpStartDate + "T00:00:00.000Z",
+            measurementPeriodEnd: mpEndDate + "T00:00:00.000Z",
+            testCaseConfiguration: {
+                id: null,
+                sdeIncluded: null
+            },
+            scoring: null,
+            baseConfigurationTypes: null,
+            patientBasis: true,
+            rateAggregation: null,
+            improvementNotation: null,
+            improvementNotationDescription: null
+        })).then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body.measureMetaData.transmissionFormat).to.eql('Test Transmission format')
+            writeCurrentMeasureFixtures(response.body)
         })
     })
 })

--- a/cypress/e2e/Services/QDM Measure Service/QDM Test-Cases.cy.ts
+++ b/cypress/e2e/Services/QDM Measure Service/QDM Test-Cases.cy.ts
@@ -27,12 +27,108 @@ let TCDescription = 'DENOMFail1651609688032'
 let TCJson = TestCaseJson.QDMTestCaseJson
 
 const measureData: CreateMeasureOptions = {}
+const qdmPopulationValues = [
+    {
+        name: 'initialPopulation',
+        expected: false,
+        actual: false
+    },
+    {
+        name: 'denominator',
+        expected: false,
+        actual: false
+    },
+    {
+        name: 'denominatorExclusion',
+        expected: false,
+        actual: false
+    },
+    {
+        name: 'denominatorException',
+        expected: false,
+        actual: false
+    },
+    {
+        name: 'numerator',
+        expected: false,
+        actual: false
+    },
+    {
+        name: 'numeratorExclusion',
+        expected: false,
+        actual: false
+    }
+]
+
+const qdmGroupBody = () => ({
+    scoring: measureScoring,
+    populationBasis: 'true',
+    populations: [
+        TestData.population('initialPopulation', 'Initial Population', {
+            associationType: null,
+            description: ''
+        })
+    ],
+    measureObservations: null,
+    groupDescription: '',
+    improvementNotation: '',
+    rateAggregation: '',
+    measureGroupTypes: null,
+    scoringUnit: '',
+    stratifications: []
+})
+
+const qdmTestCaseBody = (
+    overrides: Record<string, unknown> = {},
+    withGroupPopulations = false
+): Cypress.Chainable<any> => {
+    if (!withGroupPopulations) {
+        return cy.wrap({
+            name: TCName,
+            title: TCTitle,
+            series: TCSeries,
+            description: TCDescription,
+            json: TCJson,
+            ...overrides
+        })
+    }
+
+    return TestData.readMeasureGroupId().then((groupId) => ({
+        name: TCName,
+        title: TCTitle,
+        series: TCSeries,
+        description: TCDescription,
+        json: TCJson,
+        hapiOperationOutcome: {
+            code: 201,
+            message: null,
+            outcomeResponse: null
+        },
+        groupPopulations: [
+            {
+                groupId,
+                scoring: measureScoring,
+                populationValues: qdmPopulationValues
+            }
+        ],
+        ...overrides
+    }))
+}
+
+const qdmTestCaseListBody = (count = 3): Record<string, unknown>[] => {
+    return Array.from({ length: count }, (_, index) => ({
+        name: TCName + String(index + 1),
+        title: TCTitle + String(index + 1),
+        series: TCSeries,
+        description: TCDescription,
+        json: TCJson
+    }))
+}
 
 describe('Test Case population values based on Measure Group population definitions', () => {
 
     beforeEach('Create Measure and measure group', () => {
 
-        const currentUser = Cypress.env('selectedUser')
         let randTCNameValue = (Math.floor((Math.random() * 2000) + 3))
         TCName = 'TCName' + randTCNameValue
 
@@ -54,114 +150,21 @@ describe('Test Case population values based on Measure Group population definiti
             TestData.expectSavedMeasureCql(response)
         })
 
-        //create group
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-                cy.request({
-                    url: '/api/measures/' + fileContents + '/groups',
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "scoring": "Cohort",
-                        "populationBasis": "true",
-                        "populations": [
-                            {
-                                "id": uuidv4(),
-                                "name": "initialPopulation",
-                                "definition": "Initial Population",
-                                "associationType": null,
-                                "description": ""
-                            }
-                        ],
-                        "measureObservations": null,
-                        "groupDescription": "",
-                        "improvementNotation": "",
-                        "rateAggregation": "",
-                        "measureGroupTypes": null,
-                        "scoringUnit": "",
-                        "stratifications": [],
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
-                    cy.writeFile('cypress/fixtures/groupId', response.body.id)
-                })
-            })
+        TestData.requestMeasureGroup<any>('POST', qdmGroupBody() as any).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            TestData.writeFixture('groupId', response.body.id)
         })
 
-        //create test case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/groupId').should('exist').then((groupIdFc) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'POST',
-                        body: {
-                            "name": TCName,
-                            "title": TCTitle,
-                            "series": TCSeries,
-                            "description": TCDescription,
-                            "json": TCJson,
-                            "hapiOperationOutcome": {
-                                "code": 201,
-                                "message": null,
-                                "outcomeResponse": null
-                            },
-                            "groupPopulations": [{
-                                "groupId": groupIdFc,
-                                "scoring": measureScoring,
-                                "populationValues": [
-                                    {
-                                        "name": "initialPopulation",
-                                        "expected": false,
-                                        "actual": false
-                                    },
-                                    {
-                                        "name": "denominator",
-                                        "expected": false,
-                                        "actual": false
-                                    },
-                                    {
-                                        "name": "denominatorExclusion",
-                                        "expected": false,
-                                        "actual": false
-                                    },
-                                    {
-                                        "name": "denominatorException",
-                                        "expected": false,
-                                        "actual": false
-                                    },
-                                    {
-                                        "name": "numerator",
-                                        "expected": false,
-                                        "actual": false
-                                    },
-                                    {
-                                        "name": "numeratorExclusion",
-                                        "expected": false,
-                                        "actual": false
-                                    }
-
-                                ]
-                            }]
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        expect(response.body.series).to.eql(TCSeries)
-                        expect(response.body.title).to.eql(TCTitle)
-                        expect(response.body.description).to.eql(TCDescription)
-                        expect(response.body.json).to.be.exist
-
-                        let currentUser = Cypress.env('selectedUser')
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/testCaseId', response.body.id)
-                    })
-                })
+        qdmTestCaseBody({}, true).then((body) => {
+            TestData.requestMeasureTestCase<any>('POST', body as any).then((response) => {
+                expect(response.status).to.eql(201)
+                expect(response.body.id).to.be.exist
+                expect(response.body.series).to.eql(TCSeries)
+                expect(response.body.title).to.eql(TCTitle)
+                expect(response.body.description).to.eql(TCDescription)
+                expect(response.body.json).to.be.exist
+                TestData.writeFixture('testCaseId', response.body.id)
             })
         })
     })
@@ -172,32 +175,20 @@ describe('Test Case population values based on Measure Group population definiti
     })
 
     it('Test Case population value check boxes match that of the measure group definitons -- all are defined', () => {
-
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId').should('exist').then((testCaseId) => {
-                    cy.request({
-                        url: '/api/measures/' + id + '/test-cases/' + testCaseId,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'GET',
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.id).to.eql(testCaseId)
-                        expect(response.body.series).to.eql(TCSeries)
-                        expect(response.body.json).to.be.exist
-                        expect(response.body.json).to.eql(TCJson)
-                        expect(response.body.title).to.eql(TCTitle)
-                        expect(response.body.groupPopulations[0].populationValues[0].name).to.eq('initialPopulation')
-                        expect(response.body['groupPopulations'][0].populationValues[1].name).to.eq('denominator')
-                        expect(response.body['groupPopulations'][0].populationValues[2].name).to.eq('denominatorExclusion')
-                        expect(response.body['groupPopulations'][0].populationValues[3].name).to.eq('denominatorException')
-                        expect(response.body['groupPopulations'][0].populationValues[4].name).to.eq('numerator')
-                        expect(response.body['groupPopulations'][0].populationValues[5].name).to.eq('numeratorExclusion')
-                    })
-                })
+        TestData.readTestCaseId().then((testCaseId) => {
+            TestData.requestMeasureTestCase<any>('GET').then((response) => {
+                expect(response.status).to.eql(200)
+                expect(response.body.id).to.eql(testCaseId)
+                expect(response.body.series).to.eql(TCSeries)
+                expect(response.body.json).to.be.exist
+                expect(response.body.json).to.eql(TCJson)
+                expect(response.body.title).to.eql(TCTitle)
+                expect(response.body.groupPopulations[0].populationValues[0].name).to.eq('initialPopulation')
+                expect(response.body['groupPopulations'][0].populationValues[1].name).to.eq('denominator')
+                expect(response.body['groupPopulations'][0].populationValues[2].name).to.eq('denominatorExclusion')
+                expect(response.body['groupPopulations'][0].populationValues[3].name).to.eq('denominatorException')
+                expect(response.body['groupPopulations'][0].populationValues[4].name).to.eq('numerator')
+                expect(response.body['groupPopulations'][0].populationValues[5].name).to.eq('numeratorExclusion')
             })
         })
     })
@@ -233,73 +224,51 @@ describe('Measure Service: Test Case Endpoints: Create and Edit', () => {
     })
 
     it('Create Test Case', () => {
-        let currentUser = Cypress.env('selectedUser')
         let randValue = (Math.floor((Math.random() * 2000) + 3))
         let title = 'test case title  - _'
         let series = 'test case series  - _'
         let description = 'DENOME pass Test HB - _'
-        //Add Test Case to the Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'POST',
-                    body: {
-                        "name": TCName + randValue + 4,
-                        "title": title,
-                        "series": series,
-                        "description": description,
-                        "json": TCJson,
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
-                    expect(response.body.series).to.eql(series)
-                    expect(response.body.title).to.eql(title)
-                    expect(response.body.description).to.eql(description)
-                    expect(response.body.json).to.be.exist
-                    expect(response.body.json).to.eql(TCJson)
 
-                    let currentUser = Cypress.env('selectedUser')
-                    cy.writeFile('cypress/fixtures/' + currentUser + '/testCaseId', response.body.id)
-                })
+        qdmTestCaseBody({
+            name: TCName + randValue + 4,
+            title,
+            series,
+            description
+        }).then((body) => {
+            TestData.requestMeasureTestCase<any>('POST', body as any).then((response) => {
+                expect(response.status).to.eql(201)
+                expect(response.body.id).to.be.exist
+                expect(response.body.series).to.eql(series)
+                expect(response.body.title).to.eql(title)
+                expect(response.body.description).to.eql(description)
+                expect(response.body.json).to.be.exist
+                expect(response.body.json).to.eql(TCJson)
+                TestData.writeFixture('testCaseId', response.body.id)
             })
         })
     })
 
     it('Edit Test Case', () => {
-        let currentUser = Cypress.env('selectedUser')
-        //Edit created Test Case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId').should('exist').then((testcaseid) => {
-                    cy.request({
-                        url: '/api/measures/' + measureId + '/test-cases/' + testcaseid,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testcaseid,
-                            'name': "IPPPass",
-                            'series': "WhenBP120",
-                            'title': TCTitle,
-                            'description': "IPP Pass Test BP <120",
-                            'json': newTCJson
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        expect(response.body.id).to.eql(testcaseid)
-                        expect(response.body.json).to.be.exist
-                        expect(response.body.json).to.eql(newTCJson)
-                        expect(response.body.series).to.eql("WhenBP120")
-                        expect(response.body.title).to.eql(TCTitle)
-                        expect(response.body.json).to.be.exist
-                        cy.writeFile('cypress/fixtures/' + currentUser + '/testCaseId', response.body.id)
-                    })
+        qdmTestCaseBody({
+            name: "IPPPass",
+            series: "WhenBP120",
+            title: TCTitle,
+            description: "IPP Pass Test BP <120",
+            json: newTCJson
+        }).then((body) => {
+            TestData.readTestCaseId().then((testCaseId) => {
+                TestData.requestMeasureTestCase<any>(
+                    'PUT',
+                    { ...body, id: testCaseId } as any
+                ).then((response) => {
+                    expect(response.status).to.eql(200)
+                    expect(response.body.id).to.eql(testCaseId)
+                    expect(response.body.json).to.be.exist
+                    expect(response.body.json).to.eql(newTCJson)
+                    expect(response.body.series).to.eql("WhenBP120")
+                    expect(response.body.title).to.eql(TCTitle)
+                    expect(response.body.json).to.be.exist
+                    TestData.writeFixture('testCaseId', response.body.id)
                 })
             })
         })
@@ -335,26 +304,36 @@ describe('Measure Service: Test Case Endpoints: Validations', () => {
     })
 
     it('Create Test Case: Description more than 250 characters', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'POST',
-                    body: {
-                        'name': "DENOMFail",
-                        'series': "WhenBP120",
-                        'title': "test case title",
-                        'description': "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
-                            "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
-                            "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr",
-                        'json': TCJson
-                    }
-                }).then((response) => {
+        qdmTestCaseBody({
+            name: "DENOMFail",
+            series: "WhenBP120",
+            title: "test case title",
+            description: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
+                "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
+                "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr"
+        }).then((body) => {
+            TestData.requestMeasureTestCase<any>('POST', body as any, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.validationErrors.description).to.eql('Test Case Description can not be more than 250 characters.')
+            })
+        })
+    })
+
+    it('Edit Test Case: Description more than 250 characters', () => {
+        qdmTestCaseBody({
+            name: "IPPPass",
+            series: "WhenBP<120",
+            title: "test case title edited",
+            description: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
+                "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
+                "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr"
+        }).then((body) => {
+            TestData.readTestCaseId().then((testCaseId) => {
+                TestData.requestMeasureTestCase<any>(
+                    'PUT',
+                    { ...body, id: testCaseId } as any,
+                    { failOnStatusCode: false }
+                ).then((response) => {
                     expect(response.status).to.eql(400)
                     expect(response.body.validationErrors.description).to.eql('Test Case Description can not be more than 250 characters.')
                 })
@@ -362,89 +341,34 @@ describe('Measure Service: Test Case Endpoints: Validations', () => {
         })
     })
 
-    it('Edit Test Case: Description more than 250 characters', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId').should('exist').then((testCaseId) => {
-                    cy.request({
-                        failOnStatusCode: false,
-                        url: '/api/measures/' + measureId + '/test-cases/' + testCaseId,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testCaseId,
-                            'name': "IPPPass",
-                            'series': "WhenBP<120",
-                            'title': "test case title edited",
-                            'description': "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
-                                "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
-                                "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr",
-                            'json': TCJson
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(400)
-                        expect(response.body.validationErrors.description).to.eql('Test Case Description can not be more than 250 characters.')
-                    })
-                })
-            })
-        })
-    })
-
     it('Create Test Case: Title more than 250 characters', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'POST',
-                    body: {
-                        'name': "DENOMFail",
-                        'series': "WhenBP120",
-                        'title': "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
-                            "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
-                            "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr",
-                        'description': "description",
-                        'json': TCJson
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.title).to.eql('Test Case Title can not be more than 250 characters.')
-                })
+        qdmTestCaseBody({
+            name: "DENOMFail",
+            series: "WhenBP120",
+            title: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
+                "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
+                "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr",
+            description: "description"
+        }).then((body) => {
+            TestData.requestMeasureTestCase<any>('POST', body as any, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.validationErrors.title).to.eql('Test Case Title can not be more than 250 characters.')
             })
         })
     })
 
     it('Create Test Case: Series more than 250 characters', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/test-cases',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'POST',
-                    body: {
-                        'name': "DENOMFail",
-                        'series': "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
-                            "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
-                            "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr",
-                        'title': "Title",
-                        'description': "description",
-                        'json': TCJson
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.validationErrors.series).to.eql('Test Case Series can not be more than 250 characters.')
-                })
+        qdmTestCaseBody({
+            name: "DENOMFail",
+            series: "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst" +
+                "uvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmn" +
+                "opqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr",
+            title: "Title",
+            description: "description"
+        }).then((body) => {
+            TestData.requestMeasureTestCase<any>('POST', body as any, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.validationErrors.series).to.eql('Test Case Series can not be more than 250 characters.')
             })
         })
     })
@@ -476,28 +400,22 @@ describe('Measure Service: Test Case Endpoints: Attempt to edit when user is not
 
     it('QDM Test Case Demographic fields are not available / editable for non-owner', () => {
 
-        const currentUser = Cypress.env('selectedAltUser')
         OktaLogin.setupUserSession(false)
-        //Edit created Test Case
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/testCaseId').should('exist').then((testcaseid) => {
-                    cy.request({
-                        failOnStatusCode: false,
-                        url: '/api/measures/' + measureId + '/test-cases/' + testcaseid,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'PUT',
-                        body: {
-                            'id': testcaseid,
-                            'name': "IPPPass",
-                            'series': "WhenBP120",
-                            'title': TCTitle,
-                            'description': "IPP Pass Test BP <120",
-                            'json': newTCJson
-                        }
-                    }).then((response) => {
+        qdmTestCaseBody({
+            name: "IPPPass",
+            series: "WhenBP120",
+            title: TCTitle,
+            description: "IPP Pass Test BP <120",
+            json: newTCJson
+        }).then((body) => {
+            TestData.readMeasureId(0, 'selectedAltUser').then((measureId) => {
+                TestData.readTestCaseId(0, 'selectedAltUser').then((testCaseId) => {
+                    TestData.requestMeasureTestCase<any>(
+                        'PUT',
+                        { ...body, id: testCaseId } as any,
+                        { failOnStatusCode: false },
+                        'selectedAltUser'
+                    ).then((response) => {
                         expect(response.status).to.eql(403)
                         expect(response.body.message).to.eql('User ' + harpUser + ' is not authorized for Measure with ID ' + measureId)
                     })
@@ -510,7 +428,6 @@ describe('Measure Service: Test Case Endpoints: Attempt to edit when user is not
 describe('Measure Service: Test Case Endpoint: User validation with test case import', () => {
     beforeEach('Create Measure and measure group', () => {
 
-        const currentUser = Cypress.env('selectedUser')
         let randTCNameValue = (Math.floor((Math.random() * 2000) + 3))
         TCName = 'TCName' + randTCNameValue
 
@@ -534,84 +451,19 @@ describe('Measure Service: Test Case Endpoint: User validation with test case im
             TestData.expectSavedMeasureCql(response)
         })
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-                cy.request({
-                    url: '/api/measures/' + fileContents + '/groups',
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "scoring": measureScoring,
-                        "populationBasis": "true",
-                        "populations": [
-                            {
-                                "id": uuidv4(),
-                                "name": "initialPopulation",
-                                "definition": "Initial Population",
-                                "associationType": null,
-                                "description": ""
-                            }
-                        ],
-                        "measureObservations": null,
-                        "groupDescription": "",
-                        "improvementNotation": "",
-                        "rateAggregation": "",
-                        "measureGroupTypes": null,
-                        "scoringUnit": "",
-                        "stratifications": [],
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.id).to.be.exist
-                    cy.writeFile('cypress/fixtures/groupId', response.body.id)
-                })
-            })
+        TestData.requestMeasureGroup<any>('POST', qdmGroupBody() as any).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            TestData.writeFixture('groupId', response.body.id)
         })
     })
 
     it('Non-owner or non-shared user cannot hit the end point to add test cases to a measure', () => {
 
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(true)
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + id + '/test-cases/list',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'POST',
-                    body: [
-                        {
-                        "name": TCName + '1',
-                        "title": TCTitle + '1',
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJson,
-                        },
-                        {
-                        "name": TCName + '2',
-                        "title": TCTitle + '2',
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJson,
-                        },
-                        {
-                        "name": TCName + '3',
-                        "title": TCTitle + '3',
-                        "series": TCSeries,
-                        "description": TCDescription,
-                        "json": TCJson,
-                        }
-                    ]
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                })
-            })
+        TestData.requestMeasureTestCaseList<any>(qdmTestCaseListBody() as any, { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(403)
         })
     })
 })

--- a/cypress/e2e/Services/QDM Measure Service/QDMMeasureVersion.cy.ts
+++ b/cypress/e2e/Services/QDM Measure Service/QDMMeasureVersion.cy.ts
@@ -102,45 +102,24 @@ describe('Measure Versioning', () => {
     })
 
     it('Unsuccessful Measure Versioning when measure does not have population criteria', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure does not have at least one Population Criteria.')
-                })
+        TestData.readMeasureId().then((measureId) => {
+            TestData.versionMeasure('major', 0, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure does not have at least one Population Criteria.')
             })
         })
     })
 
     it('Successful Measure Versioning', () => {
         
-        let currentUser = Cypress.env('selectedUser')
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'd')
         TestData.saveMeasureCql(`${measureCQL}\n`).then((response) => {
             TestData.expectSavedMeasureCql(response)
         })
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                    expect(response.body.version).to.eql('1.0.000')
-                })
-            })
+        TestData.versionMeasure().then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body.version).to.eql('1.0.000')
         })
     })
 })
@@ -163,23 +142,13 @@ describe('Measure Version : Non Measure owner validation', () => {
 
     it('Non Measure owner unable to version Measure', () => {
 
-        const currentUser = Cypress.env('selectedUser')
         harpUser = OktaLogin.getUser(false)
         harpUserALT = OktaLogin.setupUserSession(true)
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                    expect(response.body.message).to.eql('User ' + harpUserALT + ' is not authorized for Measure with ID ' + measureId)
-                })
+        TestData.readMeasureId().then((measureId) => {
+            TestData.versionMeasure('major', 0, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(403)
+                expect(response.body.message).to.eql('User ' + harpUserALT + ' is not authorized for Measure with ID ' + measureId)
             })
         })
     })
@@ -210,20 +179,10 @@ describe('Version Measure without CQL', () => {
     })
 
     it('User can not version Measure if there is no CQL', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has no CQL.')
-                })
+        TestData.readMeasureId().then((measureId) => {
+            TestData.versionMeasure('major', 0, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has no CQL.')
             })
         })
     })
@@ -260,22 +219,11 @@ describe('Version Measure with invalid CQL', () => {
     })
 
     it('User can not version Measure if the CQL has errors', () => {
-        let currentUser = Cypress.env('selectedUser')
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((measureId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/measures/' + measureId + '/version?versionType=major',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(400)
-                    expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has CQL errors.')
-                })
+        TestData.readMeasureId().then((measureId) => {
+            TestData.versionMeasure('major', 0, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.message).to.eql('User ' + harpUser + ' cannot version Measure with ID ' + measureId + '. Measure has CQL errors.')
             })
         })
     })
 })
-

--- a/cypress/e2e/WebInterface/Measure/Locking/MeasureLockBlocksAssociation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Locking/MeasureLockBlocksAssociation.cy.ts
@@ -1,13 +1,20 @@
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { CreateMeasurePage, CreateMeasureOptions, SupportedModels } from "../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { MadieObject, PermissionActions, Utilities } from "../../../../Shared/Utilities"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { CVGroups, MeasureGroupPage, MeasureGroups, MeasureScoring, MeasureType, PopulationBasis } from "../../../../Shared/MeasureGroupPage"
-import { Header } from "../../../../Shared/Header"
-import { QdmCql } from "../../../../Shared/QDMMeasuresCQL"
-import { QiCore6Cql } from "../../../../Shared/FHIRMeasuresCQL"
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { CreateMeasurePage, CreateMeasureOptions, SupportedModels } from '../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { MadieObject, PermissionActions, Utilities } from '../../../../Shared/Utilities'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import {
+    CVGroups,
+    MeasureGroupPage,
+    MeasureGroups,
+    MeasureScoring,
+    MeasureType,
+    PopulationBasis
+} from '../../../../Shared/MeasureGroupPage'
+import { Header } from '../../../../Shared/Header'
+import { QdmCql } from '../../../../Shared/QDMMeasuresCQL'
+import { QiCore6Cql } from '../../../../Shared/FHIRMeasuresCQL'
 
 const now = Date.now()
 const qdmMeasureName = 'LockBlockQDM' + now
@@ -25,20 +32,29 @@ const cvPops: CVGroups = {
     initialPopulation: 'Initial Population',
     measurePopulation: 'Measure Population',
     observation: {
-        aggregateMethod: "Median",
-        definition: "Measure Observation"
+        aggregateMethod: 'Median',
+        definition: 'Measure Observation'
     }
 }
 
 describe('Measure Association is not allowed when QiCore measure is locked', () => {
-
     beforeEach('Create measures', () => {
-
         harpUserALT = OktaLogin.getUser(true)
 
         // need QiCore measure in measureId
-        CreateMeasurePage.CreateMeasureAPI(qicoreMeasureName, qicoreMeasureName, SupportedModels.qiCore6, { measureCql: qiCoreCql })
-        MeasureGroupPage.CreateMeasureGroupAPI(MeasureType.process, PopulationBasis.encounter, MeasureScoring.ContinousVariable, pops, false, undefined, undefined, cvPops)
+        CreateMeasurePage.CreateMeasureAPI(qicoreMeasureName, qicoreMeasureName, SupportedModels.qiCore6, {
+            measureCql: qiCoreCql
+        })
+        MeasureGroupPage.CreateMeasureGroupAPI(
+            MeasureType.process,
+            PopulationBasis.encounter,
+            MeasureScoring.ContinousVariable,
+            pops,
+            false,
+            undefined,
+            undefined,
+            cvPops
+        )
 
         const qdmMeasure: CreateMeasureOptions = {
             ecqmTitle: qdmMeasureName,
@@ -52,8 +68,16 @@ describe('Measure Association is not allowed when QiCore measure is locked', () 
         }
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(qdmMeasure)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(2, false, 'Initial Population', '', 'Denominator Exceptions',
-            'Numerator', '', 'Denominator')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            2,
+            false,
+            'Initial Population',
+            '',
+            'Denominator Exceptions',
+            'Numerator',
+            '',
+            'Denominator'
+        )
 
         // shares QiCore measure to harpUserALT - need this user to lock the measure later
         Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
@@ -84,13 +108,11 @@ describe('Measure Association is not allowed when QiCore measure is locked', () 
     })
 
     afterEach('Clean up', () => {
-
         Utilities.deleteMeasure()
         Utilities.deleteMeasure(undefined, undefined, true, false, 2)
     })
 
     it('When QiCore measure is locked & lock is visible, the action center button is disabled with message tooltip', () => {
-
         // sets lock on QiCore measure by altUser
         Utilities.lockControl(MadieObject.Measure, true, true)
 
@@ -101,7 +123,11 @@ describe('Measure Association is not allowed when QiCore measure is locked', () 
         MeasuresPage.selectMeasure(2)
 
         cy.get('[data-testid="associate-cms-id-action-btn"]').should('be.disabled')
-        cy.get('[data-testid="associate-cms-id-tooltip"]').should('have.attr', 'aria-label', 'Unable to associate measures. Locked while being edited by ' + harpUserALT)
+        cy.get('[data-testid="associate-cms-id-tooltip"]').should(
+            'have.attr',
+            'aria-label',
+            'Unable to associate measures. Locked while being edited by ' + harpUserALT
+        )
 
         //Delete Measure Locks
         Utilities.verifyAllLocksDeleted(MadieObject.Measure, true)
@@ -109,7 +135,6 @@ describe('Measure Association is not allowed when QiCore measure is locked', () 
 
     // we can't do this scenario right now - we'd need a big refactor or enhancement for handling access tokens
     it.skip('When QiCore measure is locked & lock is NOT visible, the Associate Measure modal fails with error message', () => {
-
         // sets lock on QiCore measure by altUser
         Utilities.lockControl(MadieObject.Measure, true, true)
 

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/CQLEditor.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/CQLEditor.cy.ts
@@ -286,6 +286,7 @@ describe('Measure: CQL Editor', () => {
 
         //Validate the lack of error(s) in CQL Editor
         cy.get(CQLEditorPage.errorInCQLEditorWindow).should('not.exist')
+        CQLEditorPage.collapseEditor()
 
         //Navigate away from the page
         cy.get(EditMeasurePage.measureDetailsTab).click()

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Quality Architecture Backlog
 
-Last updated: 2026-07-06
+Last updated: 2026-07-08
 
 ## Stewardship Guidelines
 
@@ -39,69 +39,50 @@ The suite is moving toward a layered test architecture:
 
 ## Current State
 
-The saved-CQL service boundary is mostly established.
+The service-test boundary is now materially stronger and more consistent.
 
-- `TestData.saveMeasureCql` now supports QI-Core, QDM, owner, and alternate-owner valid-CQL setup.
-- `TestData.expectSavedMeasureCql` centralizes the saved-CQL response assertion.
-- Service/admin specs no longer open the CQL editor just to create valid saved CQL, except for intentional negative-state coverage.
-- `ViewHumanReadable.cy.ts` proved we can replace UI version/draft setup with API version/draft calls when the endpoint under test is service-level output.
-- `Measure.cy.ts` proved the payoff: removing UI CQL-save setup reduced runtime from about 17 minutes to under 2 minutes.
+- `TestData.saveMeasureCql` supports QI-Core, QDM, owner, and alternate-owner valid-CQL setup.
+- `TestData.expectSavedMeasureCql` centralizes saved-CQL response assertions.
+- `TestData.readCurrentMeasureContext`, `updateCurrentMeasure`, `requestMeasureById`, `requestMeasureBundle`, `requestMeasureExport`, `requestMeasureDraft`, `requestDraftStatus`, `requestMeasureTestCase`, `requestMeasureTestCaseList`, `requestAdminMeasureDelete`, and `requestMeasureGroupById` now cover the main service-boundary actions the suite was hand-rolling before.
+- `CreateMeasurePage.ts` now writes fixtures through `TestData.writeFixture` and routes measure create/clone requests through `TestData.requestWithAccessToken`.
+
+Recently proven service slices:
+
+- `Measure.cy.ts`
+- `MeasureBundle.cy.ts`
+- `MeasureExport.cy.ts`
+- `DraftMeasure.cy.ts`
+- `MeasureVersion.cy.ts`
+- `QI Core Test-Cases.cy.ts`
+- `QDM Test-Cases.cy.ts`
+- `QDM Measure.cy.ts`
+- `QDMMeasureVersion.cy.ts`
+
+These slices removed repeated token reads, fixture-path plumbing, and inline request setup while keeping negative-state assertions explicit and focused runs green.
 
 Intentional exceptions:
 
 - `QDMMeasureVersion.cy.ts` keeps the invalid-CQL UI save path because that scenario validates CQL error persistence.
 - `DeleteCMSID.cy.ts` uses edit mode for CMS ID generation; it is not leftover saved-CQL setup.
 
-Latest infrastructure batch:
-
-- `CreateMeasurePage.ts` now writes measure fixtures through `TestData.writeFixture` instead of hand-built fixture paths.
-- `CreateMeasurePage.ts` now sends measure create/clone requests through `TestData.requestWithAccessToken`.
-- Fixture-path smell count dropped by 49 in the latest infrastructure slice.
-- Access-token smell count dropped by 7 in the latest infrastructure slice.
-- This backlog cleanup now keeps only decisions, current state, validation guidance, and done signals.
-
-Latest service-spec batch:
-
-- `TestData.readCurrentMeasureContext` centralizes the current measure/version fixture lookup.
-- `TestData.updateCurrentMeasure` centralizes current-measure `PUT` requests and bearer-token handling.
-- `TestData.requestMeasureTestCase` now centralizes current-measure test-case requests while still allowing owner-scoped fixture reads and current-session authorization.
-- `EditMeasure.cy.ts` now has a local updated-measure body builder for repeated metadata update payloads.
-- The base edit behavior group now uses the helper instead of repeating token, measure-id, version-id, request, and payload plumbing.
-- The non-owner RA scenario now uses the same helper with `failOnStatusCode: false`, proving the helper supports expected negative service responses.
-- Edit and measurement-period validation groups now express only the invalid input and expected response while `TestData` owns request setup.
-- `EditMeasure.cy.ts` no longer appears in the audit's top manual fixture-path or access-token plumbing lists.
-- `EditMeasure.cy.ts` passed focused sanity after completing the validation groups: 25 passing, 0 failing.
-- `QI Core Test-Cases.cy.ts` now uses `TestData.requestMeasureTestCase` and `TestData.requestMeasureTestCaseList` for test-case service endpoints, negative authorization flows, validation cases, JSON validation, and duplicate title/group checks.
-- Repeated QI-Core measure-group setup in `QI Core Test-Cases.cy.ts` now uses a local group body builder plus `TestData.requestMeasureGroup`, removing direct token, env-user, and fixture-path plumbing from the spec.
-- `QI Core Test-Cases.cy.ts` dropped from about 1,351 lines before the service-test cleanup to 748 lines after the full-file pass.
-- Focused `QI Core Test-Cases.cy.ts` passed after the full-file pass: 20 passing, 0 failing, 1 minute 24 seconds.
-- `Measure.cy.ts` first refactor slice moved create-measure validation groups through `TestData.requestMeasure`, removed a hidden global `model` mutation, and added a working non-parallel single-spec script shape.
-- Focused `Measure.cy.ts` passed after this slice: 36 passing, 0 failing, 1 minute 36 seconds.
-- `Measure.cy.ts` update/delete slice added reusable measure-by-id and admin-delete request helpers, removed another layer of token/fixture plumbing, and kept the negative authorization checks explicit.
-- Focused `Measure.cy.ts` after the update/delete slice: 35 passing, 1 failing, 1 minute 54 seconds. The migrated update/delete and admin-delete behaviors passed; the lone failure was `Validation Error: CQL library Name contains special characters`, which returned a service `500` instead of the expected `400`. The prior focused run at `14:14:55` had 36 passing, including this same validation, so this is tracked as a likely underlying service/environment response rather than a refactor regression.
-- `Measure.cy.ts` admin-delete cleanup migrated versioning, admin delete, owner-read verification, and non-owner delete-action checks through `TestData`; direct cookie/fixture auth plumbing in the file is now zero.
-- Focused `Measure.cy.ts` after the completed admin-delete cleanup: 35 passing, 1 failing, 1 minute 40 seconds. All refactored update/delete and admin-delete checks passed; the repeated failure remains the special-character CQL library validation returning service `500` instead of expected `400`.
-- `MeasureBundle.cy.ts` first slice added `TestData.requestMeasureBundle`, reused `TestData.requestMeasure` for direct create setup, and started moving group setup through `TestData.requestMeasureGroup`.
-- `MeasureBundle.cy.ts` cleanup completed the remaining raw bundle/group/update request migration; focused run passed: 12 passing, 0 failing, 1 minute 14 seconds.
-
 ## Quality Baseline
 
-Latest `npm run quality:no-focused-tests` signal:
+Latest `node scripts/quality-audit.js` signal:
 
-- 256 specs, about 67.0k spec lines.
+- 256 specs, about 66.1k spec lines.
 - 11 skipped tests.
-- 369 manual fixture-path plumbing hits.
-- 197 manual access-token plumbing hits.
-- 95 fixed waits.
+- 293 manual fixture-path plumbing hits.
+- 150 manual access-token plumbing hits.
+- 101 fixed waits.
 - 195 forced interactions.
 - 1 global uncaught exception suppression.
 
 Largest current risk areas:
 
-- `CreateMeasurePage.ts`, `MeasureGroupPage.ts`, and `TestCasesPage.ts`: shared setup/page-object infrastructure still carries fixture path and interaction mechanics.
-- `DraftMeasure.cy.ts`, `MeasureExport.cy.ts`, QDM service specs, and CQL library service specs still show token/fixture plumbing and are good follow-on candidates.
-- `Measure.cy.ts` and `MeasureBundle.cy.ts` are now proof points rather than top plumbing risks.
-- UI reliability debt: fixed waits, forced interactions, skipped tests, and global exception suppression.
+- Shared helpers and page-object infrastructure: `TestCasesPage.ts`, `MeasureGroupPage.ts`, `CreateMeasurePage.ts`, and `Utilities.ts`.
+- CQL library service specs still lead the remaining service-side token plumbing.
+- Admin cleanup and a few measure/test-case service leftovers still carry manual fixture reads.
+- UI reliability debt now outweighs most service setup debt: fixed waits, forced interactions, skipped tests, and global exception suppression.
 
 ## Replan Rules
 
@@ -116,197 +97,85 @@ After each meaningful slice:
 
 ## Action Plan
 
-### Completed Foundation
+### Completed Proof Points
 
 - Saved-CQL API setup is established through `TestData.saveMeasureCql`.
 - Current-measure updates are established through `TestData.updateCurrentMeasure`.
 - Test-case service requests are established through `TestData.requestMeasureTestCase` and `TestData.requestMeasureTestCaseList`.
-- Measure-group API setup is usable through `TestData.requestMeasureGroup`.
-- `EditMeasure.cy.ts`, `QI Core Test-Cases.cy.ts`, and the first `Measure.cy.ts` slice are proof points that service specs can be made smaller, faster, and easier to diagnose without changing coverage intent.
+- Measure-group API setup is established through `TestData.requestMeasureGroup`.
+- Version, draft, export, bundle, admin-delete, and measure-by-id helper paths have all been proven by focused service-spec runs.
 
-### Priority 1: Probe And Refactor `Measure.cy.ts`
-
-Impact hypothesis:
-
-- `Measure.cy.ts` is now 798 lines after the validation, update/delete, and admin-delete cleanup slices.
-- Direct access-token reads dropped from 34 to 0 and direct fixture path hits dropped from 21 to 0.
-- It has now proven reusable `TestData` helpers for create, read, update-by-id, version, test-case, saved-CQL, admin-delete, and delete-action flows.
-
-First moves:
-
-- Done: migrated create-measure validation groups, measurement period validations, eCQM title validations, duplicate CQL-library-name validation, and bad-token setup.
-- Done: removed hidden shared-state coupling where the invalid-model test mutated the global `model` value and caused downstream update/delete failures.
-- Done: migrated update/delete status checks through `TestData.readMeasure`, `TestData.requestMeasureById`, `TestData.readCurrentMeasureContext`, and `TestData.requestMeasureTestCase`.
-- Done: added `TestData.requestAdminMeasureDelete` as the next shared helper for admin-delete cleanup.
-- Done: migrated remaining admin-delete manual version/delete/read calls through `TestData.versionMeasure`, `TestData.requestAdminMeasureDelete`, `TestData.readMeasure`, and `TestData.requestMeasureDeleteAction`.
-- Next: leave `Measure.cy.ts` unless the focused run exposes a refactor-specific regression; move the next high-impact service cleanup to `MeasureBundle.cy.ts`.
-- Guardrail: keep the special-character CQL library validation failure visible as an API `500` investigation; do not weaken the expected `400` assertion just to make the pipeline green.
-
-Validation:
-
-- `npm run compile`
-- `npm run quality:no-focused-tests`
-- `git diff --check`
-- Focused `Measure.cy.ts`
-
-### Priority 2: Refactor `MeasureBundle.cy.ts`
-
-Impact hypothesis:
-
-- `MeasureBundle.cy.ts` dropped from 1,103 to 888 lines after the completed bundle-helper slice.
-- It no longer has direct `cy.request`, direct access-token reads, or direct fixture-path reads in the spec.
-- Bundle tests are likely close to export/version setup patterns, so the helper work here should pay forward into `MeasureExport.cy.ts` and draft/version specs.
-
-First moves:
-
-- Done: add `TestData.requestMeasureBundle` and migrate repeated bundle GET assertions.
-- Done: replace direct create-measure POST setup in bundle edge cases with `TestData.requestMeasure`.
-- Done: replace remaining manual group POST setup with `TestData.requestMeasureGroup`.
-- Done: migrate metadata update through `TestData.readCurrentMeasureContext`, `TestData.readMeasureGroupId`, and `TestData.updateMeasure`.
-- Next: carry the same service-boundary helpers into `MeasureExport.cy.ts` or `DraftMeasure.cy.ts`.
-
-Validation:
-
-- `npm run compile`
-- `npm run quality:no-focused-tests`
-- `git diff --check`
-- Focused `MeasureBundle.cy.ts`
-
-### Priority 3: Service Setup Helper Hardening
-
-Impact hypothesis:
-
-- The remaining service specs keep rebuilding the same world: measure, group, CQL, version, draft, export IDs.
-- A small setup facade in `TestData` can reduce repeated setup while keeping public page-object signatures stable.
-
-Candidate helper shapes:
-
-- `TestData.createMeasureContext`
-- `TestData.createMeasureGroupContext`
-- `TestData.requestCurrentMeasure`
-- `TestData.requestMeasureExport`
-- typed response aliases for create/update/version flows
-
-Guardrails:
-
-- Do not create a broad framework before `Measure.cy.ts` and `MeasureBundle.cy.ts` prove the shape.
-- Keep negative authorization tests explicit.
-- Keep UI page objects out of service setup internals.
-
-### Priority 4: QDM Test Case Parity
-
-Impact hypothesis:
-
-- `QDM Test-Cases.cy.ts` still appears in both fixture-path and token plumbing counts.
-- The QI-Core test-case helper work should transfer cleanly, but QDM-specific body shape and measure setup need a probe first.
-
-First moves:
-
-- Compare QDM test-case endpoint bodies against the new QI-Core helper.
-- Reuse `requestMeasureTestCase` where endpoint shape matches.
-- Add QDM-specific helper only if the body/setup shape genuinely differs.
-
-### Priority 5: UI Reliability Debt
-
-Impact hypothesis:
-
-- Fixed waits and forced interactions now dominate the next quality risk once service plumbing is under control.
-- These failures are more likely to be flaky and user-visible than the remaining service setup noise.
-
-First targets:
-
-- Fixed waits: list sorting, CQL editor, export, and terminology-heavy specs.
-- Forced interactions: `TestCasesPage.ts`, import validations, measure highlighting, RTE fields, and editor validation specs.
-- Global exception suppression: replace blanket suppression with targeted known-error handling.
-- Skipped tests: add owner/ticket or remove obsolete skips.
-
-## Reprioritized Next Work
-
-### Priority 1: `MeasureExport.cy.ts`
+### Priority 1: CQL Library Service Cleanup
 
 Why this is next:
 
-- It is the cleanest continuation from `MeasureBundle.cy.ts`: export GETs are repeated current-measure service requests.
-- It still carries direct token, fixture, and raw request plumbing across export success and negative export cases.
-- It should pay forward into QI-Core export UI smoke coverage and future package/export helpers without touching UI behavior.
+- CQL library service specs now dominate the remaining manual access-token plumbing counts.
+- The service-side measure/QDM refactors have proven the helper direction, so the next best payoff is to apply the same discipline to library endpoints.
 
-First scoped moves:
+First targets:
 
-- Add `TestData.requestMeasureExport` for `GET /api/measures/{measureId}/exports`.
-- Move repeated export GET assertions through the helper, preserving `failOnStatusCode: false` for negative cases.
-- Reuse `TestData.requestMeasureGroup` for export setup groups.
-- Replace direct create-measure POST setup with `TestData.requestMeasure` where the spec bypasses `CreateMeasurePage`.
-
-Definition of done:
-
-- `MeasureExport.cy.ts` has no direct access-token reads or fixture-path reads for export/group setup.
-- Static checks pass.
-- Focused `MeasureExport.cy.ts` passes or produces a diagnosed non-refactor failure.
-
-### Priority 2: `DraftMeasure.cy.ts`
-
-Why this follows export:
-
-- It has more raw plumbing than export, but the behavior is stateful: version, draft, minor/patch version, and draft-status transitions all mutate the same measure family.
-- `TestData.versionMeasure`, `TestData.requestMeasureDraft`, and `TestData.requestDraftStatus` already exist, so the work is mostly replacing raw chains while preserving sequence.
-
-First scoped moves:
-
-- Replace direct draft-status POSTs with `TestData.requestDraftStatus`.
-- Replace direct major/minor/patch version calls with `TestData.versionMeasure`.
-- Replace repeated draft creation bodies with the existing `draftBody` helper plus `TestData.requestMeasureDraft`.
-- Keep a focused eye on fixture mutation after draft creation because some tests intentionally replace the current `measureId`.
+- `CreateCQL-Library.cy.ts`
+- `CQLLibraryDelete.cy.ts`
+- `EditCQL-Library.cy.ts`
+- `VersionAndDraftCQL-Library.cy.ts`
 
 Definition of done:
 
-- Draft status/version/draft requests no longer hand-roll token headers or fixture paths.
-- Existing draft family sequencing remains explicit.
-- Focused `DraftMeasure.cy.ts` passes or produces a diagnosed non-refactor failure.
+- Repeated token/header/request setup moves behind shared helpers.
+- Negative authorization and validation states remain explicit.
+- Focused library specs pass or produce diagnosed non-refactor failures.
 
-### Priority 3: QDM Test-Case Parity
+### Priority 2: Shared Helper and Infrastructure Hardening
 
-Why it is third:
+Why this is next:
 
-- `QDM Test-Cases.cy.ts` is still a top fixture/token offender and should benefit from the QI-Core test-case helper work.
-- It is more likely to need QDM-specific setup/body adjustments, so it should follow one more QI-Core service cleanup.
+- The remaining fixture-path smell is now concentrated more in shared support files than in the newly cleaned service specs.
+- `TestCasesPage.ts`, `MeasureGroupPage.ts`, `CreateMeasurePage.ts`, and `Utilities.ts` still carry too much user-path and request-mechanics knowledge.
 
-First scoped moves:
+First targets:
 
-- Compare QDM test-case bodies against `TestData.requestMeasureTestCase`.
-- Reuse the current helper where endpoint shape matches.
-- Add only narrow QDM-specific helper coverage if the API shape differs.
+- replace remaining hand-built fixture paths with `TestData` helpers
+- reduce duplicate owner-selection logic
+- narrow page-object responsibilities so service setup stays in service helpers
 
-### Priority 4: Shared Helper Hardening
+Definition of done:
 
-Why it waits:
+- Shared helpers own path conventions and common request setup.
+- Page objects stop teaching service setup patterns by accident.
+- No broad framework rewrite; small, proven helper moves only.
 
-- `Measure.cy.ts` and `MeasureBundle.cy.ts` proved the direction, but `MeasureExport.cy.ts` and `DraftMeasure.cy.ts` should prove the export/draft surfaces before adding a broader setup facade.
+### Priority 3: UI Reliability Debt
 
-Candidate helper shapes:
+Why it has moved up:
 
-- `TestData.createMeasureContext`
-- `TestData.createMeasureGroupContext`
-- `TestData.requestCurrentMeasure`
-- typed response aliases for export, draft, and draft-status flows
+- Service setup debt is no longer the dominant source of noise.
+- Fixed waits, forced interactions, skipped tests, and blanket exception suppression now carry more flake risk than the remaining service plumbing.
 
-### Priority 5: UI Reliability Debt
+First targets:
 
-Why it stays visible:
+- fixed waits in list sorting, export, and terminology-heavy specs
+- forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows
+- global uncaught exception suppression in `cypress/support/e2e.ts`
+- skipped tests that need owner/ticket/remove decisions
 
-- Fixed waits, forced interactions, skipped tests, and global exception suppression are still the biggest flake/diagnostic risks after service plumbing.
-- Start UI reliability once one more service tranche lands, or earlier if pipeline failures point at these categories.
+Definition of done:
 
-## Immediate Next Slice
+- waits are replaced by route aliases, visible/enabled assertions, or purposeful polling
+- forced interactions are reduced where readiness/selector fixes are possible
+- exception handling becomes targeted instead of blanket
 
-Start `MeasureExport.cy.ts` with a narrow export request helper and setup cleanup.
+### Priority 4: Remaining Service Tail Cleanup
 
-Definition of done for the next slice:
+Why it is lower now:
 
-- `TestData.requestMeasureExport` exists and is used by repeated export GET cases.
-- Export setup group creation uses `TestData.requestMeasureGroup` where endpoint shape matches.
-- Static checks pass.
-- Focused `MeasureExport.cy.ts` passes or produces a diagnosed non-refactor failure.
-- Backlog is updated with the helper decision and measured audit impact.
+- The highest-value measure/QDM service specs have already been converted.
+- Remaining service cleanup is now more incremental than transformational.
+
+Next candidates:
+
+- `DeleteTest-Case.cy.ts`
+- Admin service leftovers such as `CorrectExpectedValues.cy.ts`
+- any residual measure/test-case specs that still surface near the top of the audit after each batch
 
 ## Validation Set
 
@@ -322,9 +191,9 @@ env -u ELECTRON_RUN_AS_NODE npx cypress run --env configFile=dev --browser chrom
 Add focused specs based on the touched area:
 
 - Saved-CQL helper: `MeasureTranslatorVersion.cy.ts`, `QDM MeasureGroup.cy.ts`.
-- Measure setup helper: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`.
+- Measure setup helper: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `QDM Measure.cy.ts`.
 - Draft/version helpers: `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QDMMeasureVersion.cy.ts`.
-- Test-case helpers: `QI Core Test-Cases.cy.ts`, `QDM Test-Cases.cy.ts`, `TestCaseImport.cy.ts`.
+- Test-case helpers: `QI Core Test-Cases.cy.ts`, `QDM Test-Cases.cy.ts`, `TestCaseImport.cy.ts`, `DeleteTest-Case.cy.ts`.
 - Shared action/page-object changes: include a relevant WebInterface smoke or editor spec.
 
 ## Done Signals


### PR DESCRIPTION
## Summary
- continue the service-helper refactor across draft, export, version, and QDM measure/test-case/version specs
- extend `TestData` with the next shared helper moves and reduce repeated token/fixture/request plumbing in service tests
- refactor CQL Library service API coverage to use shared request and fixture helpers instead of repeated inline request setup
- add reusable CQL Library helper coverage for create, read, update, search, draft, version, and versioned-library fetch flows
- clean up the following CQL Library service specs while preserving current behavior:
  - `CreateCQL-Library.cy.ts`
  - `EditCQL-Library.cy.ts`
  - `VersionAndDraftCQL-Library.cy.ts`
- harden owner vs alt-user scenarios by separating authenticated user scope from fixture-owner scope where the tests exercise cross-user permissions
- refresh `docs/quality/test-refactor-backlog.md` to remove stale priorities, record completed slices, and reprioritize the remaining work
- include the current WebInterface test adjustments in locking and QI Core CQL editor coverage

## Validation
- `npm run compile`
- `git diff --check`
- focused Cypress runs:
  - `MeasureExport.cy.ts`
  - `DraftMeasure.cy.ts`
  - `MeasureVersion.cy.ts`
  - `QDM Measure.cy.ts`
  - `QDM Test-Cases.cy.ts`
  - `QDMMeasureVersion.cy.ts`
  - `CreateCQL-Library.cy.ts`
  - `EditCQL-Library.cy.ts`
  - `VersionAndDraftCQL-Library.cy.ts`