### PR TITLE
Add AI and Cypress quality docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ cypress/fixtures/cmsId4QDM
 cypress/fixtures/cmsId4QiCore
 cypress/fixtures/referenceId
 
+docs/bugs/*
 
 # Created by https://www.toptal.com/developers/gitignore/api/node
 # Edit at https://www.toptal.com/developers/gitignore?templates=node

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# MADiE AI Coding Rules
+
+## Role
+
+Act as a Staff SDET / Quality Architect working in a Cypress + TypeScript test automation repo.
+
+## Main Goal
+
+Improve reliability, reuse, isolation, diagnosability, and CI signal without changing test behavior.
+
+## Reference Docs
+
+Before significant work, read the relevant docs:
+
+- General Cypress rules: `docs/quality/cypress-automation-guidelines.md`
+- Current refactor priorities: `docs/quality/test-refactor-backlog.md`
+- Architecture guidance: `docs/ai/architecture.md`
+- Debugging guidance: `docs/ai/debugging.md`
+- Refactoring guidance: `docs/ai/refactoring.md`
+
+## Priority Order
+
+1. Reliability
+2. Test isolation
+3. Helper reuse
+4. Readability
+5. Speed
+6. Minimal code change
+
+Do not sacrifice a higher priority for a lower one.
+
+## Before Editing
+
+- Search the repo for existing helpers first.
+- Reuse `TestData` helpers before creating new request, fixture, or token logic.
+- Reuse existing page-object and domain-helper patterns.
+- Do not invent new abstractions unless they remove real duplication.
+
+## Cypress Rules
+
+- Prefer `data-testid` selectors.
+- Do not add fixed waits.
+- Replace waits with route aliases, visible/enabled assertions, or polling helpers.
+- Avoid `{ force: true }` unless the test is intentionally validating hidden/native controls.
+- Do not add broad `uncaught:exception` suppression.
+- Do not commit focused tests.
+
+## Service vs UI Boundaries
+
+- Service specs should set up and verify service behavior through APIs.
+- UI specs should use the browser only for UI behavior, rendering, editor behavior, permissions, navigation, and interaction.
+- Page objects should not own service setup mechanics.
+
+## Refactor Rules
+
+- Keep changes small.
+- Preserve behavior.
+- Move repeated mechanics behind named helpers.
+- Keep negative assertions explicit.
+- Stop once duplication is reduced and validation passes.
+- Do not continue polishing style-only changes.
+
+## Validation
+
+For most changes, run:
+
+```bash
+npm run compile
+npm run quality:no-focused-tests
+git diff --check
+```
+
+## Keeping AI Docs Updated
+
+When a refactor proves a new reusable pattern, update the AI docs in the same PR.
+
+Update docs only when the change is durable and useful for future work.
+
+Do not update docs for:
+
+- one-off fixes
+- temporary workarounds
+- speculative ideas
+- run-specific notes
+- changing audit counts
+
+Use this rule:
+
+- Stable rule → `docs/quality/cypress-automation-guidelines.md`
+- Current priority / audit count / next target → `docs/quality/test-refactor-backlog.md`
+- AI workflow / prompt behavior → relevant file under `docs/ai/`
+- Architecture decision → `docs/ai/architecture.md`
+- Debugging lesson → `docs/ai/debugging.md`
+
+## Documentation Maintenance
+
+At the end of every completed task evaluate whether any documentation should be updated.
+
+Return:
+
+Documentation Updates
+
+None
+
+or
+
+Recommended Updates
+
+- file
+- section
+- reason
+- proposed text
+
+Only recommend updates for durable patterns.
+
+## Pull Requests
+
+When asked to create a PR or summarize changes, follow:
+
+docs/ai/pull-request.md

--- a/docs/ai/architecture.md
+++ b/docs/ai/architecture.md
@@ -1,0 +1,69 @@
+# Architecture Guidance
+
+Use this file when asking AI to review or change the Cypress test architecture.
+
+## Role
+
+Act as a Staff SDET / Quality Architect.
+
+Focus on reliability, isolation, helper reuse, diagnosability, maintainability, and CI signal.
+
+## Architecture Priorities
+
+1. Preserve existing behavior.
+2. Keep service setup behind `TestData` and domain helpers.
+3. Keep UI specs focused on browser-visible behavior.
+4. Keep page objects focused on UI interaction, not service setup.
+5. Prefer small helper improvements over broad framework rewrites.
+6. Reuse existing patterns before creating new abstractions.
+7. Validate every shared-path change.
+
+## Service vs UI Boundary
+
+Service specs should use APIs for setup and verification.
+
+UI specs should use the browser for:
+
+- navigation
+- rendering
+- editor behavior
+- permissions
+- visible user interactions
+
+Page objects should not own token handling, fixture-path construction, or service request mechanics.
+
+## Helper Rules
+
+Before creating a new helper:
+
+1. Search for an existing helper.
+2. Check `TestData`.
+3. Check existing domain request helpers.
+4. Check page objects and utilities.
+5. Reuse the existing pattern when possible.
+
+Only create a new helper when it removes repeated mechanics or clarifies domain behavior.
+
+## Refactor Expectations
+
+A good architecture change should improve at least one of these:
+
+- reliability
+- isolation
+- reuse
+- diagnosability
+- speed
+- pipeline signal
+
+Avoid changes that only make code look cleaner.
+
+## Output Format
+
+When giving architecture advice, return:
+
+1. Current issue
+2. Existing pattern found
+3. Recommended architecture
+4. Smallest safe change
+5. Risk
+6. Validation plan

--- a/docs/ai/debugging.md
+++ b/docs/ai/debugging.md
@@ -1,0 +1,70 @@
+# Debugging Guidance
+
+Use this file when asking AI to debug Cypress failures, flaky tests, selector issues, timeout problems, or CI failures.
+
+## Role
+
+Act as a senior Cypress debugging partner.
+
+Find the cause before changing code.
+
+## Debugging Priorities
+
+1. Identify the exact failing command.
+2. Identify whether the failure is setup, data, selector, timing, permission, API, or app behavior.
+3. Inspect the existing helper path before editing.
+4. Prefer targeted fixes over broad retries or waits.
+5. Preserve the original test intent.
+
+## Do Not Do
+
+- Do not add fixed waits as the first fix.
+- Do not add `{ force: true }` unless the element is intentionally hidden or native.
+- Do not suppress global exceptions.
+- Do not rewrite the whole spec.
+- Do not invent a new helper before checking existing ones.
+
+## Timeout Debugging
+
+For timeouts, check:
+
+1. Is the selector correct?
+2. Is the data created?
+3. Is the user on the correct page?
+4. Did the API request finish?
+5. Is the app still loading?
+6. Is there a permission or role issue?
+7. Is the element hidden behind a menu, tooltip, drawer, or modal?
+
+## Selector Debugging
+
+Prefer this order:
+
+1. `data-testid`
+2. accessible role/name
+3. stable text
+4. stable container + child selector
+5. class selectors only as a last resort
+
+## API/Data Debugging
+
+Check:
+
+1. selected user
+2. selected alt user
+3. fixture path
+4. saved IDs
+5. access token handling
+6. request helper used
+7. cleanup path
+
+## Output Format
+
+When debugging, return:
+
+1. Exact failure point
+2. Most likely cause
+3. Evidence
+4. Smallest safe fix
+5. What not to change
+6. Validation command

--- a/docs/ai/maintenance.md
+++ b/docs/ai/maintenance.md
@@ -1,0 +1,61 @@
+# AI Documentation Maintenance
+
+## Purpose
+
+Keep project documentation synchronized with proven engineering decisions.
+
+## Update Rules
+
+Update documentation only when a change is durable.
+
+Do NOT update documentation for:
+
+- temporary fixes
+- one-off workarounds
+- experimental code
+- audit counts
+- TODO items
+
+## Documentation Ownership
+
+### AGENTS.md
+
+Update when:
+
+- AI workflow changes
+- coding standards change
+- review expectations change
+
+### docs/quality/cypress-automation-guidelines.md
+
+Update when:
+
+- a new engineering rule becomes standard
+- helper usage changes
+- testing standards change
+
+### docs/quality/test-refactor-backlog.md
+
+Update when:
+
+- priorities change
+- audit numbers change
+- work is completed
+
+### architecture.md
+
+Update when:
+
+- a reusable architecture pattern is established
+
+### debugging.md
+
+Update when:
+
+- a debugging technique repeatedly solves problems
+
+### examples.md
+
+Update when:
+
+- a better implementation becomes the preferred pattern

--- a/docs/ai/pull-requests.md
+++ b/docs/ai/pull-requests.md
@@ -1,0 +1,54 @@
+# Pull Request Guidance
+
+## Goal
+
+Create pull requests that clearly communicate the purpose, impact, risks, and validation of the change.
+
+## Before Creating a PR
+
+Verify:
+
+- Code compiles
+- No focused tests
+- Validation completed
+- No unnecessary refactoring
+- Documentation updated if needed
+
+## PR Structure
+
+### Summary
+
+Describe what changed and why.
+
+### Changes
+
+List the major implementation changes.
+
+### Technical Notes
+
+Explain architectural decisions or helper reuse.
+
+### Testing
+
+List the commands and focused specs executed.
+
+### Risk
+
+Describe any known risks or areas requiring attention.
+
+### Documentation
+
+State whether documentation was updated.
+
+If not:
+
+Documentation Updates:
+None
+
+## Keep PRs
+
+- Small
+- Focused
+- Easy to review
+
+Avoid mixing unrelated changes.

--- a/docs/ai/refactoring.md
+++ b/docs/ai/refactoring.md
@@ -1,0 +1,31 @@
+# Refactor Prompt
+
+You are refactoring Cypress TypeScript tests.
+
+Goal:
+Reduce duplication and improve reliability without changing behavior.
+
+Before coding:
+
+1. Identify the existing pattern.
+2. Search for reusable helpers.
+3. Explain the smallest safe change.
+4. Do not edit yet unless asked.
+
+Rules:
+
+- Prefer existing `TestData` helpers.
+- Do not create new helpers if one already exists.
+- Do not add fixed waits.
+- Do not add `{ force: true }` unless clearly justified.
+- Keep negative/error assertions explicit.
+- Preserve test intent.
+- Keep the change small.
+
+Output:
+
+1. Files inspected
+2. Existing pattern found
+3. Proposed change
+4. Risk
+5. Validation command

--- a/docs/quality/cypress-automation-guidelines.md
+++ b/docs/quality/cypress-automation-guidelines.md
@@ -1,0 +1,71 @@
+# MADiE Cypress Automation Guidelines
+
+Last updated: 2026-07-08
+
+This guide captures stable test-architecture rules used in this repo. Keep tactical plans and changing counts in `docs/quality/test-refactor-backlog.md`.
+
+## Source of Truth
+
+- Do not add guidance here from memory. Add only rules proven by committed code, audit output, focused runs, or team decision.
+- Keep this file stable and short. Move run-by-run notes, temporary targets, and changing counts to the backlog.
+- Preserve intentional exceptions with the reason and owning scenario.
+- During PR review, link changes to quality outcomes: speed, isolation, reuse, diagnosability, reliability, or pipeline signal.
+
+## Test Boundaries
+
+- Service specs under `cypress/e2e/Services/` should set up and verify service behavior through APIs.
+- UI specs under `cypress/e2e/WebInterface/` should use the browser for UI behavior: navigation, rendering, editor behavior, permissions, and user interaction.
+- Page objects should not own service setup mechanics.
+- Split large specs by behavior only after shared setup and data helpers are stable.
+
+## Shared Test Data Rules
+
+- Use `TestData` as the service-test contract for domain actions, fixture paths, selected users, access tokens, IDs, and common requests.
+- Prefer `TestData.fixturePath`, `readFixture`, `writeFixture`, `readMeasureId`, `readCqlLibraryId`, `readTestCaseId`, and related ID helpers over hand-built `cypress/fixtures/...` paths.
+- Prefer `TestData.withAccessToken`, `requestWithAccessToken`, and domain request helpers over inline `cy.getCookie('accessToken')` request setup.
+- Keep negative authorization, validation, and error-state assertions explicit even when setup moves behind helpers.
+- Use owner-aware helpers for `selectedUser` and `selectedAltUser` so parallel user allocation stays centralized.
+
+## Established Helper Paths
+
+These helper paths are already established and should be reused before adding new request plumbing:
+
+- Measure setup and reads: `requestMeasure`, `readMeasure`, `requestMeasureById`, `updateMeasure`, `updateCurrentMeasure`.
+- CQL save and translation: `saveMeasureCql`, `expectSavedMeasureCql`, `translateFhirCql`, `translateQdmCql`.
+- Measure lifecycle: `requestMeasureBundle`, `requestMeasureExport`, `requestMeasureDraft`, `requestDraftStatus`, `versionMeasure`, `requestAdminMeasureDelete`, `requestMeasureDeleteAction`.
+- Measure groups and test cases: `requestMeasureGroup`, `requestMeasureGroupById`, `requestMeasureGroupStratification`, `requestMeasureTestCase`, `requestMeasureTestCaseList`, `requestTestCaseImports`.
+- CQL library service work: `requestCqlLibrary`, `readCqlLibrary`, `requestCqlLibraryById`, `updateCqlLibrary`, `updateCurrentCqlLibrary`, `searchCqlLibraries`, `versionCqlLibrary`, `draftCqlLibrary`, `requestVersionedCqlLibrary`.
+
+## Reliability Rules
+
+- Do not commit focused tests. `npm run quality:no-focused-tests` is the guardrail.
+- Skipped tests need an owner, ticket, or removal decision.
+- Replace fixed numeric waits with route aliases, visible/enabled assertions, or purposeful polling helpers.
+- Use `{ force: true }` only when validating intentionally hidden or native controls; otherwise fix readiness or selector strategy.
+- Avoid global exception suppression. If an exception must be tolerated, make the handling targeted and explain the scope.
+- Prefer stable `data-testid` selectors when available.
+
+## Refactor Rules
+
+- Prefer small helper moves that remove repeated mechanics across multiple specs.
+- Do not broaden framework abstractions unless they remove real duplication or align with an established local pattern.
+- Keep setup helpers named around domain behavior, not implementation steps.
+- Avoid changes that only make code prettier without improving speed, isolation, reuse, diagnosability, or reliability.
+- When a helper changes a shared path, validate with static checks and at least one focused spec that exercises that path.
+
+## Validation Commands
+
+Run these for most helper or service-boundary work:
+
+```bash
+npm run compile
+npm run quality:no-focused-tests
+git diff --check
+```
+
+Add focused Cypress specs based on the touched area. Use the backlog for the current recommended validation set.
+
+## Intentional Exceptions
+
+- `QDMMeasureVersion.cy.ts` keeps the invalid-CQL UI save path because that scenario validates CQL error persistence.
+- `DeleteCMSID.cy.ts` uses edit mode for CMS ID generation; it is not leftover saved-CQL setup.

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -2,207 +2,121 @@
 
 Last updated: 2026-07-08
 
-## Stewardship Guidelines
+Stable rules live in `docs/quality/cypress-automation-guidelines.md`. Keep this backlog limited to current state, next actions, measured audit signal, and validation.
 
-This document is a repo-owned quality architecture artifact, not a scratchpad.
-It exists to help the team make visible, repeatable decisions about test architecture,
-pipeline confidence, refactor sequencing, and reliability risk.
+## Current Direction
 
-Keep it curated:
-
-- Track priorities, decisions, validation rules, and done signals.
-- Keep run-by-run noise out unless a result changes the plan or exposes a durable risk.
-- Link work back to quality outcomes: speed, isolation, reuse, diagnosability, reliability, or pipeline signal.
-- Prefer small, proven helper moves over broad framework rewrites.
-- Reprioritize after meaningful slices; do not let stale plans become invisible policy.
-- Preserve intentional exceptions with a reason, so future cleanup does not erase useful coverage.
-- Keep negative-state tests explicit, even when request setup moves behind helpers.
-- Treat this backlog as shared SDET architecture guidance during PR review and planning.
-
-Suggested maintenance rhythm:
-
-- Update after each committed refactor slice.
-- Refresh quality-audit counts when they materially change.
-- Move completed proof points into Current State and remove low-value historical detail.
-- Open a follow-up ticket or issue when a risk needs product or pipeline ownership outside this repo.
-
-## Executive Direction
-
-The suite is moving toward a layered test architecture:
-
-- Service specs set up and verify service behavior through APIs.
-- UI specs use the browser only for UI behavior: navigation, rendering, editor behavior, permissions, and user interaction.
-- `TestData` is the service-test contract for domain actions, fixture paths, access tokens, IDs, and common requests.
-- Page objects should not own service setup mechanics.
-- Large specs should be split by behavior only after shared setup/data helpers are stable.
-- Quality gates should make risk visible: focused tests, skipped tests, fixture plumbing, token plumbing, fixed waits, forced interactions, and global exception suppression.
+- Keep service setup and request mechanics behind `TestData` and domain helpers.
+- Keep UI specs focused on browser-visible behavior.
+- Prioritize changes that reduce repeated fixture paths, token plumbing, fixed waits, forced interactions, skipped tests, or broad exception handling.
+- Update this file only when priorities, decisions, audit counts, or done signals materially change.
 
 ## Current State
 
-The service-test boundary is now materially stronger and more consistent.
+Recently proven service/helper slices:
 
-- `TestData.saveMeasureCql` supports QI-Core, QDM, owner, and alternate-owner valid-CQL setup.
-- `TestData.expectSavedMeasureCql` centralizes saved-CQL response assertions.
-- `TestData.readCurrentMeasureContext`, `updateCurrentMeasure`, `requestMeasureById`, `requestMeasureBundle`, `requestMeasureExport`, `requestMeasureDraft`, `requestDraftStatus`, `requestMeasureTestCase`, `requestMeasureTestCaseList`, `requestAdminMeasureDelete`, and `requestMeasureGroupById` now cover the main service-boundary actions the suite was hand-rolling before.
-- `CreateMeasurePage.ts` now writes fixtures through `TestData.writeFixture` and routes measure create/clone requests through `TestData.requestWithAccessToken`.
+- Measure service: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QI Core Test-Cases.cy.ts`.
+- QDM service: `QDM Test-Cases.cy.ts`, `QDM Measure.cy.ts`, `QDMMeasureVersion.cy.ts`.
+- CQL library service: `CreateCQL-Library.cy.ts`, `EditCQL-Library.cy.ts`, `VersionAndDraftCQL-Library.cy.ts`.
+- Shared create/fixture path: `CreateMeasurePage.ts` now routes fixture writes and measure create/clone requests through `TestData` helpers.
 
-Recently proven service slices:
+## Latest Audit Signal
 
-- `Measure.cy.ts`
-- `MeasureBundle.cy.ts`
-- `MeasureExport.cy.ts`
-- `DraftMeasure.cy.ts`
-- `MeasureVersion.cy.ts`
-- `QI Core Test-Cases.cy.ts`
-- `QDM Test-Cases.cy.ts`
-- `QDM Measure.cy.ts`
-- `QDMMeasureVersion.cy.ts`
+Command: `npm run quality:audit`
 
-These slices removed repeated token reads, fixture-path plumbing, and inline request setup while keeping negative-state assertions explicit and focused runs green.
+- Inventory: 256 specs / 65737 spec lines; 29 shared files / 18839 shared lines; 3 support files / 637 support lines; 8 scripts / 1296 script lines.
+- Skipped tests: 11.
+- Manual fixture path plumbing: 270.
+- Manual access token plumbing: 117.
+- Fixed waits: 101.
+- Forced interactions: 195.
+- Global uncaught exception suppression: 1.
 
-Intentional exceptions:
+Largest risk concentrations:
 
-- `QDMMeasureVersion.cy.ts` keeps the invalid-CQL UI save path because that scenario validates CQL error persistence.
-- `DeleteCMSID.cy.ts` uses edit mode for CMS ID generation; it is not leftover saved-CQL setup.
+- `CQLLibraryDelete.cy.ts`: top remaining CQL library token-plumbing target.
+- `TestCasesPage.ts`, `MeasureGroupPage.ts`, `CreateMeasurePage.ts`, `Utilities.ts`: shared helper and page-object infrastructure debt.
+- `CorrectExpectedValues.cy.ts`, `DeleteTest-Case.cy.ts`, and selected admin/measure/test-case service specs: remaining service-tail cleanup.
+- `MeasureListNewColumnsSort.cy.ts`, `CQLLibraryListPageColumnSort.cy.ts`, export specs, highlighting specs, and editor flows: UI reliability debt from waits and forced interactions.
+- `cypress/support/e2e.ts`: global `uncaught:exception` suppression.
 
-## Quality Baseline
+## Priorities
 
-Latest `node scripts/quality-audit.js` signal:
+### P1: CQL Library Service Cleanup
 
-- 256 specs, about 66.1k spec lines.
-- 11 skipped tests.
-- 293 manual fixture-path plumbing hits.
-- 150 manual access-token plumbing hits.
-- 101 fixed waits.
-- 195 forced interactions.
-- 1 global uncaught exception suppression.
+Next target: `cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts`
 
-Largest current risk areas:
+Done when repeated token/header/request setup moves behind shared helpers, negative states stay explicit, and focused library validation passes or exposes a diagnosed non-refactor failure.
 
-- Shared helpers and page-object infrastructure: `TestCasesPage.ts`, `MeasureGroupPage.ts`, `CreateMeasurePage.ts`, and `Utilities.ts`.
-- CQL library service specs still lead the remaining service-side token plumbing.
-- Admin cleanup and a few measure/test-case service leftovers still carry manual fixture reads.
-- UI reliability debt now outweighs most service setup debt: fixed waits, forced interactions, skipped tests, and global exception suppression.
+### P2: Shared Helper and Infrastructure Hardening
+
+Start with:
+
+- `Utilities.deleteLibrary`
+- `MeasureGroupPage.ts`
+- `TestCasesPage.ts`
+
+Done when shared helpers own path conventions and common request setup, and page objects no longer spread service setup mechanics.
+
+### P3: UI Reliability Debt
+
+Start with:
+
+- fixed waits in list sorting, export, and terminology-heavy specs
+- forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows
+- global exception suppression in `cypress/support/e2e.ts`
+- skipped tests needing owner/ticket/remove decisions
+
+Done when waits are replaced by route aliases, visible/enabled assertions, or polling helpers; forced interactions are justified or removed; exception handling is targeted.
+
+### P4: Remaining Service Tail Cleanup
+
+Candidates:
+
+- `DeleteTest-Case.cy.ts`
+- `CorrectExpectedValues.cy.ts`
+- remaining admin/measure/test-case specs surfaced near the top of the audit after each batch
 
 ## Replan Rules
 
 After each meaningful slice:
 
-- Re-check the quality audit, current diff, and recent failures.
-- Prefer changes that remove a class of duplication across many specs.
-- Record the impact hypothesis before editing.
-- Validate with static checks and at least one focused spec that exercises the changed path.
+- Run the audit and compare the current diff.
+- Prefer changes that remove a class of duplication across multiple specs.
+- Record only durable decisions or changed counts.
+- Validate with static checks and at least one focused spec for the changed helper path.
 - Commit once a boundary is proven so the next experiment starts clean.
-- Deprioritize changes that only make code prettier without improving speed, isolation, reuse, or diagnosability.
-
-## Action Plan
-
-### Completed Proof Points
-
-- Saved-CQL API setup is established through `TestData.saveMeasureCql`.
-- Current-measure updates are established through `TestData.updateCurrentMeasure`.
-- Test-case service requests are established through `TestData.requestMeasureTestCase` and `TestData.requestMeasureTestCaseList`.
-- Measure-group API setup is established through `TestData.requestMeasureGroup`.
-- Version, draft, export, bundle, admin-delete, and measure-by-id helper paths have all been proven by focused service-spec runs.
-
-### Priority 1: CQL Library Service Cleanup
-
-Why this is next:
-
-- CQL library service specs now dominate the remaining manual access-token plumbing counts.
-- The service-side measure/QDM refactors have proven the helper direction, so the next best payoff is to apply the same discipline to library endpoints.
-
-First targets:
-
-- `CreateCQL-Library.cy.ts`
-- `CQLLibraryDelete.cy.ts`
-- `EditCQL-Library.cy.ts`
-- `VersionAndDraftCQL-Library.cy.ts`
-
-Definition of done:
-
-- Repeated token/header/request setup moves behind shared helpers.
-- Negative authorization and validation states remain explicit.
-- Focused library specs pass or produce diagnosed non-refactor failures.
-
-### Priority 2: Shared Helper and Infrastructure Hardening
-
-Why this is next:
-
-- The remaining fixture-path smell is now concentrated more in shared support files than in the newly cleaned service specs.
-- `TestCasesPage.ts`, `MeasureGroupPage.ts`, `CreateMeasurePage.ts`, and `Utilities.ts` still carry too much user-path and request-mechanics knowledge.
-
-First targets:
-
-- replace remaining hand-built fixture paths with `TestData` helpers
-- reduce duplicate owner-selection logic
-- narrow page-object responsibilities so service setup stays in service helpers
-
-Definition of done:
-
-- Shared helpers own path conventions and common request setup.
-- Page objects stop teaching service setup patterns by accident.
-- No broad framework rewrite; small, proven helper moves only.
-
-### Priority 3: UI Reliability Debt
-
-Why it has moved up:
-
-- Service setup debt is no longer the dominant source of noise.
-- Fixed waits, forced interactions, skipped tests, and blanket exception suppression now carry more flake risk than the remaining service plumbing.
-
-First targets:
-
-- fixed waits in list sorting, export, and terminology-heavy specs
-- forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows
-- global uncaught exception suppression in `cypress/support/e2e.ts`
-- skipped tests that need owner/ticket/remove decisions
-
-Definition of done:
-
-- waits are replaced by route aliases, visible/enabled assertions, or purposeful polling
-- forced interactions are reduced where readiness/selector fixes are possible
-- exception handling becomes targeted instead of blanket
-
-### Priority 4: Remaining Service Tail Cleanup
-
-Why it is lower now:
-
-- The highest-value measure/QDM service specs have already been converted.
-- Remaining service cleanup is now more incremental than transformational.
-
-Next candidates:
-
-- `DeleteTest-Case.cy.ts`
-- Admin service leftovers such as `CorrectExpectedValues.cy.ts`
-- any residual measure/test-case specs that still surface near the top of the audit after each batch
 
 ## Validation Set
 
-Run these for helper/service-boundary work:
+Baseline:
 
 ```bash
 npm run compile
 npm run quality:no-focused-tests
 git diff --check
+```
+
+Focused service-boundary example:
+
+```bash
 env -u ELECTRON_RUN_AS_NODE npx cypress run --env configFile=dev --browser chrome --spec "cypress/e2e/Services/Measure Service/ViewHumanReadable.cy.ts"
 ```
 
-Add focused specs based on the touched area:
+Add touched-area specs:
 
-- Saved-CQL helper: `MeasureTranslatorVersion.cy.ts`, `QDM MeasureGroup.cy.ts`.
-- Measure setup helper: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `QDM Measure.cy.ts`.
-- Draft/version helpers: `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QDMMeasureVersion.cy.ts`.
-- Test-case helpers: `QI Core Test-Cases.cy.ts`, `QDM Test-Cases.cy.ts`, `TestCaseImport.cy.ts`, `DeleteTest-Case.cy.ts`.
-- Shared action/page-object changes: include a relevant WebInterface smoke or editor spec.
+- Saved CQL: `MeasureTranslatorVersion.cy.ts`, `QDM MeasureGroup.cy.ts`.
+- Measure setup: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `QDM Measure.cy.ts`.
+- Draft/version: `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QDMMeasureVersion.cy.ts`.
+- Test cases: `QI Core Test-Cases.cy.ts`, `QDM Test-Cases.cy.ts`, `TestCaseImport.cy.ts`, `DeleteTest-Case.cy.ts`.
+- CQL library: `CreateCQL-Library.cy.ts`, `EditCQL-Library.cy.ts`, `VersionAndDraftCQL-Library.cy.ts`, `CQLLibraryDelete.cy.ts`.
+- Shared UI/page-object changes: include a relevant WebInterface smoke or editor spec.
 
 ## Done Signals
 
-A refactor slice is done when:
-
-- The spec intent is clearer than before.
+- Spec intent is clearer than before.
 - Repeated fixture/token/request mechanics moved behind a named helper.
-- Negative states are still explicit.
+- Negative states remain explicit.
 - Static checks pass.
 - A focused spec covering the changed helper path passes.
-- The backlog is updated only with new decisions, not run-by-run noise.
+- This backlog contains only new decisions, changed counts, or current priorities.


### PR DESCRIPTION
## Summary
Adds repo-owned AI and Cypress quality documentation to reduce repeated guidance and keep future automation work consistent.

## Changes
- Added AGENTS.md with MADiE Cypress AI coding rules.
- Added docs/ai/* workflow docs for architecture, debugging, maintenance, refactoring, and pull requests.
- Added docs/quality/cypress-automation-guidelines.md for stable Cypress automation rules.
- Optimized docs/quality/test-refactor-backlog.md into a shorter current-state backlog.
- Updated .gitignore to ignore docs/bugs/*.

## Testing
```npm run compile
npm run quality:no-focused-tests
git diff --check
git diff --cached --check
```
## Risk
Low. Documentation-only change plus one .gitignore entry.