### PR TITLE
Refactor shared TestData helper paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,35 @@ Recommended Updates
 
 Only recommend updates for durable patterns.
 
+## Backlog Maintenance
+
+At the end of every completed task, evaluate whether the refactor backlog should be updated.
+
+Only recommend backlog updates when one of the following is true:
+
+- A backlog item is complete.
+- A higher-priority issue was discovered.
+- A lower-priority item is no longer needed.
+- Audit counts have materially changed.
+- A new refactor target was discovered.
+- Validation proved a previous assumption incorrect.
+
+Do not modify the backlog for partial progress.
+
+Return one of the following:
+
+Backlog Updates
+
+None
+
+or
+
+Recommended Backlog Updates
+
+- Section
+- Reason
+- Proposed text
+
 ## Pull Requests
 
 When asked to create a PR or summarize changes, follow:

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -6,6 +6,7 @@ import { TestCasesPage } from './TestCasesPage'
 import { UUIDTypes, v4 as uuidv4 } from 'uuid'
 import { Stratification } from '@madie/madie-models'
 import { OktaLogin } from './OktaLogin'
+import { FixtureOwner, MeasureGroupBody, TestData } from './TestData'
 
 export enum MeasureType {
     outcome = 'Outcome',
@@ -297,6 +298,27 @@ export class MeasureGroupPage {
     public static readonly denomIncludeInReportTypeField =
         '[data-testid="includeInReportType-container"] > :nth-child(2)'
 
+    private static fixtureOwner(altUser = false): FixtureOwner {
+        return altUser ? 'selectedAltUser' : 'selectedUser'
+    }
+
+    private static createMeasureGroupApi(
+        body: MeasureGroupBody,
+        fixtureName: string,
+        owner: FixtureOwner = 'selectedUser',
+        measureNumber = 0
+    ): string {
+        const user = TestData.setupUserScope(owner)
+
+        TestData.requestMeasureGroup('POST', body, measureNumber, {}, owner).then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.id).to.be.exist
+            TestData.writeFixture(fixtureName, response.body.id, owner)
+        })
+
+        return user
+    }
+
     public static createMeasureGroupforProportionMeasure(): void {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -462,21 +484,10 @@ export class MeasureGroupPage {
         PopDenomP?: string,
         popBasis?: string
     ): string {
-        let currentUser = ''
-
         if (altUser === undefined || altUser === null) {
             altUser = false
         }
-
-        if (altUser) {
-            currentUser = Cypress.env('selectedAltUser')
-        } else if (altUser === false) {
-            currentUser = Cypress.env('selectedUser')
-        }
-
-        let user = ''
-        let measurePath = ''
-        let measureGroupPath = 'cypress/fixtures/' + currentUser + '/measureGroupId'
+        const owner = this.fixtureOwner(altUser)
         let measureScoring = 'Proportion'
 
         if (popBasis == undefined || popBasis === null || popBasis == 'Boolean') {
@@ -492,92 +503,71 @@ export class MeasureGroupPage {
             PopDenomP = 'Surgical Absence of Cervix'
         }
 
-        user = OktaLogin.setupUserSession(altUser)
-        cy.log('Current user is: ' + user)
-
         if (measureNumber === undefined || measureNumber === null || measureNumber === 0) {
             measureNumber = 0
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId'
-        } else if (measureNumber > 0) {
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId' + measureNumber
         }
 
-        //Add Measure Group to the Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(measurePath)
-                .should('exist')
-                .then((fileContents) => {
-                    cy.request({
-                        url: '/api/measures/' + fileContents + '/groups',
-                        method: 'POST',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        body: {
-                            id: fileContents,
-                            scoring: measureScoring,
-                            populationBasis: popBasis,
-                            rateAggregation: '<p>test rA</p>',
-                            groupDescription: '<p>test gD</p>',
-                            populations: [
-                                {
-                                    description: '<p>test IP P</p>',
-                                    id: uuidv4(),
-                                    name: 'initialPopulation',
-                                    definition: PopIniPopP
-                                },
-                                {
-                                    description: '<p>test d P</p>',
-                                    id: uuidv4(),
-                                    name: 'denominator',
-                                    definition: PopDenomP
-                                },
-                                {
-                                    description: '<p>test dE P</p>',
-                                    id: uuidv4(),
-                                    name: 'denominatorExclusion',
-                                    definition: DenomExcl
-                                },
-                                {
-                                    description: '<p>test dEx P</p>',
-                                    id: uuidv4(),
-                                    name: 'denominatorException',
-                                    definition: DenomExcep
-                                },
-                                {
-                                    description: '<p>test n P</p>',
-                                    id: uuidv4(),
-                                    name: 'numerator',
-                                    definition: PopNumP
-                                },
-                                {
-                                    description: '<p>test nE P</p>',
-                                    id: uuidv4(),
-                                    name: 'numeratorExclusion',
-                                    definition: NumerExcl
-                                }
-                            ],
-                            scoringUnit: {
-                                label: 'ml milliLiters',
-                                value: {
-                                    code: 'ml',
-                                    name: 'milliLiters',
-                                    guidance: '',
-                                    system: 'https://clinicaltables.nlm.nih.gov/'
-                                }
-                            },
-                            measureGroupTypes: ['Outcome'],
-                            stratifications: [],
-                            improvementNotation: 'Increased score indicates improvement'
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        cy.writeFile(measureGroupPath, response.body.id)
-                    })
-                })
-        })
-        return user
+        return this.createMeasureGroupApi(
+            {
+                scoring: measureScoring,
+                populationBasis: popBasis,
+                rateAggregation: '<p>test rA</p>',
+                groupDescription: '<p>test gD</p>',
+                populations: [
+                    {
+                        description: '<p>test IP P</p>',
+                        id: uuidv4(),
+                        name: 'initialPopulation',
+                        definition: PopIniPopP
+                    },
+                    {
+                        description: '<p>test d P</p>',
+                        id: uuidv4(),
+                        name: 'denominator',
+                        definition: PopDenomP
+                    },
+                    {
+                        description: '<p>test dE P</p>',
+                        id: uuidv4(),
+                        name: 'denominatorExclusion',
+                        definition: DenomExcl
+                    },
+                    {
+                        description: '<p>test dEx P</p>',
+                        id: uuidv4(),
+                        name: 'denominatorException',
+                        definition: DenomExcep
+                    },
+                    {
+                        description: '<p>test n P</p>',
+                        id: uuidv4(),
+                        name: 'numerator',
+                        definition: PopNumP
+                    },
+                    {
+                        description: '<p>test nE P</p>',
+                        id: uuidv4(),
+                        name: 'numeratorExclusion',
+                        definition: NumerExcl
+                    }
+                ],
+                scoringUnit: {
+                    label: 'ml milliLiters',
+                    value: {
+                        code: 'ml',
+                        name: 'milliLiters',
+                        guidance: '',
+                        system: 'https://clinicaltables.nlm.nih.gov/'
+                    }
+                },
+                measureGroupTypes: ['Outcome'],
+                stratifications: [],
+                improvementNotation: 'Increased score indicates improvement'
+            },
+            'measureGroupId',
+            owner,
+            measureNumber
+        )
     }
 
     public static CreateRatioMeasureGroupAPI(
@@ -588,12 +578,7 @@ export class MeasureGroupPage {
         PopDenomP?: string,
         popBasis?: string
     ): string {
-        let currentUser = Cypress.env('selectedUser')
-        const currentAltUser = Cypress.env('selectedAltUser')
-
-        let user = ''
-        let measurePath = ''
-        let measureGroupPath = ''
+        const owner = this.fixtureOwner(altUser ?? false)
         let measureScoring = 'Ratio'
         if (popBasis == undefined || popBasis === null || popBasis == 'Boolean') {
             popBasis = 'boolean'
@@ -612,76 +597,45 @@ export class MeasureGroupPage {
             altUser = false
         }
 
-        user = OktaLogin.setupUserSession(altUser)
-
-        if (altUser) {
-            currentUser = Cypress.env('selectedAltUser')
-        } else {
-            currentUser = Cypress.env('selectedUser')
-        }
-        if (twoMeasureGroups === true) {
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId2'
-            measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId2'
-            //cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-        } else {
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId'
-            measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId'
-        }
-
-        //Add Measure Group to the Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(measurePath)
-                .should('exist')
-                .then((fileContents) => {
-                    cy.request({
-                        url: '/api/measures/' + fileContents + '/groups',
-                        method: 'POST',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        body: {
-                            id: fileContents,
-                            scoring: measureScoring,
-                            populationBasis: popBasis,
-                            populations: [
-                                {
-                                    id: uuidv4(),
-                                    name: 'initialPopulation',
-                                    definition: PopIniPopP
-                                },
-                                {
-                                    id: uuidv4(),
-                                    name: 'denominator',
-                                    definition: PopDenomP
-                                },
-                                {
-                                    id: uuidv4(),
-                                    name: 'denominatorExclusion',
-                                    definition: PopDenomP
-                                },
-                                {
-                                    id: uuidv4(),
-                                    name: 'numerator',
-                                    definition: PopNumP
-                                },
-                                {
-                                    id: uuidv4(),
-                                    name: 'numeratorExclusion',
-                                    definition: PopNumP
-                                }
-                            ],
-                            measureGroupTypes: ['Outcome'],
-                            stratifications: [],
-                            improvementNotation: 'Increased score indicates improvement'
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        cy.writeFile(measureGroupPath, response.body.id)
-                    })
-                })
-        })
-        return user
+        return this.createMeasureGroupApi(
+            {
+                scoring: measureScoring,
+                populationBasis: popBasis,
+                populations: [
+                    {
+                        id: uuidv4(),
+                        name: 'initialPopulation',
+                        definition: PopIniPopP
+                    },
+                    {
+                        id: uuidv4(),
+                        name: 'denominator',
+                        definition: PopDenomP
+                    },
+                    {
+                        id: uuidv4(),
+                        name: 'denominatorExclusion',
+                        definition: PopDenomP
+                    },
+                    {
+                        id: uuidv4(),
+                        name: 'numerator',
+                        definition: PopNumP
+                    },
+                    {
+                        id: uuidv4(),
+                        name: 'numeratorExclusion',
+                        definition: PopNumP
+                    }
+                ],
+                measureGroupTypes: ['Outcome'],
+                stratifications: [],
+                improvementNotation: 'Increased score indicates improvement'
+            },
+            twoMeasureGroups === true ? 'groupId2' : 'groupId',
+            owner,
+            twoMeasureGroups === true ? 2 : 0
+        )
     }
 
     public static CreateCohortMeasureGroupAPI(
@@ -691,27 +645,13 @@ export class MeasureGroupPage {
         popBasis?: string,
         measureNumber?: number
     ): string {
-        let currentUser = ''
         if (altUser === undefined || altUser === null) {
             altUser = false
         }
-        if (altUser) {
-            currentUser = Cypress.env('selectedAltUser')
-        } else {
-            currentUser = Cypress.env('selectedUser')
-        }
-
-        let user = ''
-        let measurePath = ''
-        let measureGroupPath = ''
+        const owner = this.fixtureOwner(altUser)
         let measureScoring = 'Cohort'
         if (measureNumber === undefined || measureNumber === null) {
             measureNumber = 0
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId'
-        }
-
-        if (measureNumber > 0) {
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId' + measureNumber
         }
 
         if (popBasis == undefined || popBasis === null || popBasis == 'Boolean') {
@@ -721,65 +661,42 @@ export class MeasureGroupPage {
             PopIniPopP = 'Initial PopulationOne'
         }
 
-        user = OktaLogin.setupUserSession(altUser)
-
-        if (twoMeasureGroups === true) {
-            measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId2'
-        } else {
-            measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId'
-        }
-
-        //Add Measure Group to the Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(measurePath)
-                .should('exist')
-                .then((fileContents) => {
-                    cy.request({
-                        url: '/api/measures/' + fileContents + '/groups',
-                        method: 'POST',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        body: {
-                            id: fileContents,
-                            scoring: measureScoring,
-                            populationBasis: popBasis,
-                            rateAggregation: '<p>test ra</p>',
-                            groupDescription: '<p>test gd</p>',
-                            populations: [
-                                {
-                                    description: '<p>test pd</p>',
-                                    id: uuidv4(),
-                                    name: 'initialPopulation',
-                                    definition: PopIniPopP
-                                }
-                            ],
-                            measureGroupTypes: ['Outcome'],
-                            stratifications: [
-                                {
-                                    id: uuidv4(),
-                                    description: '<p>test strat 1</p>',
-                                    cqlDefinition: PopIniPopP,
-                                    associations: ['initialPopulation']
-                                },
-                                {
-                                    id: uuidv4(),
-                                    description: '<p>test strat 2</p>',
-                                    cqlDefinition: PopIniPopP,
-                                    associations: ['denominator']
-                                }
-                            ],
-                            improvementNotation: 'Increased score indicates improvement',
-                            improvementNotationDescription: '<p>test iND</p>'
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        cy.writeFile(measureGroupPath, response.body.id)
-                    })
-                })
-        })
-        return user
+        return this.createMeasureGroupApi(
+            {
+                scoring: measureScoring,
+                populationBasis: popBasis,
+                rateAggregation: '<p>test ra</p>',
+                groupDescription: '<p>test gd</p>',
+                populations: [
+                    {
+                        description: '<p>test pd</p>',
+                        id: uuidv4(),
+                        name: 'initialPopulation',
+                        definition: PopIniPopP
+                    }
+                ],
+                measureGroupTypes: ['Outcome'],
+                stratifications: [
+                    {
+                        id: uuidv4(),
+                        description: '<p>test strat 1</p>',
+                        cqlDefinition: PopIniPopP,
+                        associations: ['initialPopulation']
+                    },
+                    {
+                        id: uuidv4(),
+                        description: '<p>test strat 2</p>',
+                        cqlDefinition: PopIniPopP,
+                        associations: ['denominator']
+                    }
+                ],
+                improvementNotation: 'Increased score indicates improvement',
+                improvementNotationDescription: '<p>test iND</p>'
+            },
+            twoMeasureGroups === true ? 'groupId2' : 'groupId',
+            owner,
+            measureNumber
+        )
     }
 
     public static CreateCohortMeasureGroupWithoutTypeAPI(
@@ -788,15 +705,10 @@ export class MeasureGroupPage {
         PopIniPopP?: string,
         popBasis?: string
     ): string {
-        let currentUser = Cypress.env('selectedUser')
-
         if (altUser === undefined || altUser === null) {
             altUser = false
         }
-
-        let user = ''
-        let measurePath = ''
-        let measureGroupPath = ''
+        const owner = this.fixtureOwner(altUser)
         let measureScoring = 'Cohort'
         if (popBasis == undefined || popBasis === null || popBasis == 'Boolean') {
             popBasis = 'boolean'
@@ -805,56 +717,25 @@ export class MeasureGroupPage {
             PopIniPopP = 'Initial PopulationOne'
         }
 
-        user = OktaLogin.setupUserSession(altUser)
-
-        if (altUser) {
-            currentUser = Cypress.env('selectedAltUser')
-        } else {
-            currentUser = Cypress.env('selectedUser')
-        }
-        if (twoMeasureGroups === true) {
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId2'
-            measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId2'
-            //cy.writeFile('cypress/fixtures/measureId2', response.body.id)
-        } else {
-            measurePath = 'cypress/fixtures/' + currentUser + '/measureId'
-            measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId'
-        }
-
-        //Add Measure Group to the Measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(measurePath)
-                .should('exist')
-                .then((fileContents) => {
-                    cy.request({
-                        url: '/api/measures/' + fileContents + '/groups',
-                        method: 'POST',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        body: {
-                            id: fileContents,
-                            scoring: measureScoring,
-                            populationBasis: popBasis,
-                            populations: [
-                                {
-                                    id: uuidv4(),
-                                    name: 'initialPopulation',
-                                    definition: PopIniPopP
-                                }
-                            ],
-                            measureGroupTypes: [],
-                            stratifications: [],
-                            improvementNotation: 'Increased score indicates improvement'
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        cy.writeFile(measureGroupPath, response.body.id)
-                    })
-                })
-        })
-        return user
+        return this.createMeasureGroupApi(
+            {
+                scoring: measureScoring,
+                populationBasis: popBasis,
+                populations: [
+                    {
+                        id: uuidv4(),
+                        name: 'initialPopulation',
+                        definition: PopIniPopP
+                    }
+                ],
+                measureGroupTypes: [],
+                stratifications: [],
+                improvementNotation: 'Increased score indicates improvement'
+            },
+            twoMeasureGroups === true ? 'groupId2' : 'groupId',
+            owner,
+            twoMeasureGroups === true ? 2 : 0
+        )
     }
 
     public static CreateMeasureGroupAPI(
@@ -867,21 +748,11 @@ export class MeasureGroupPage {
         numeratorObservation?: MeasureObservations,
         cvPopulations?: CVGroups
     ): string {
-        let currentUser = ''
-
         if (altUser === undefined || altUser === null) {
             altUser = false
         }
-
-        if (altUser) {
-            currentUser = Cypress.env('selectedAltUser')
-        } else {
-            currentUser = Cypress.env('selectedUser')
-        }
-        let user = ''
+        const owner = this.fixtureOwner(altUser)
         let observations = []
-        let measurePath = 'cypress/fixtures/' + currentUser + '/measureId'
-        let measureGroupPath = 'cypress/fixtures/' + currentUser + '/groupId'
         const numUuid = uuidv4()
         const denomUuid = uuidv4()
         if (denominatorObservation) {
@@ -972,36 +843,19 @@ export class MeasureGroupPage {
             }
         }
 
-        user = OktaLogin.setupUserSession(altUser)
-
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(measurePath)
-                .should('exist')
-                .then((fileContents) => {
-                    cy.request({
-                        url: '/api/measures/' + fileContents + '/groups',
-                        method: 'POST',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        body: {
-                            id: fileContents,
-                            scoring: scoring,
-                            populationBasis: populationBasis,
-                            populations: popsArray,
-                            measureGroupTypes: [measureType],
-                            stratifications: [],
-                            improvementNotation: 'Increased score indicates improvement',
-                            measureObservations: observations
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(201)
-                        expect(response.body.id).to.be.exist
-                        cy.writeFile(measureGroupPath, response.body.id)
-                    })
-                })
-        })
-        return user
+        return this.createMeasureGroupApi(
+            {
+                scoring: scoring,
+                populationBasis: populationBasis,
+                populations: popsArray,
+                measureGroupTypes: [measureType],
+                stratifications: [],
+                improvementNotation: 'Increased score indicates improvement',
+                measureObservations: observations
+            },
+            'groupId',
+            owner
+        )
     }
 
     public static setMeasureGroupType(type?: MeasureType): void {
@@ -1047,41 +901,25 @@ export class MeasureGroupPage {
     }
 
     public static addStratificationDataAPI(stratificationData: Array<Stratification>) {
-        const currentUser = Cypress.env('selectedUser')
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestWithAccessToken<Array<MeasureGroupBody>>({
+                url: `/api/measures/${measureId}/groups`,
+                method: 'GET'
+            }).then((response) => {
+                expect(response.status).to.eql(200)
 
-        const measurePath = 'cypress/fixtures/' + currentUser + '/measureId'
+                const groupWithAddedStrats = response.body[0]
+                groupWithAddedStrats.stratifications = stratificationData as typeof groupWithAddedStrats.stratifications
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile(measurePath)
-                .should('exist')
-                .then((fileContents) => {
-                    // get starting data for the group
-                    cy.request({
-                        url: '/api/measures/' + fileContents + '/groups',
-                        method: 'GET',
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        }
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                        // add stratifications to existing group
-                        let groupWithAddedStrats = response.body[0]
-                        groupWithAddedStrats.stratifications = stratificationData
-
-                        // send update with strats added
-                        cy.request({
-                            url: '/api/measures/' + fileContents + '/groups',
-                            method: 'POST',
-                            headers: {
-                                authorization: 'Bearer ' + accessToken?.value
-                            },
-                            body: groupWithAddedStrats
-                        }).then((response) => {
-                            cy.log('success start add')
-                            expect(response.status).to.eql(201)
-                        })
-                    })
+                TestData.requestWithAccessToken({
+                    url: `/api/measures/${measureId}/groups`,
+                    method: 'POST',
+                    body: groupWithAddedStrats
+                }).then((updateResponse) => {
+                    cy.log('success start add')
+                    expect(updateResponse.status).to.eql(201)
                 })
+            })
         })
     }
 }

--- a/cypress/Shared/TestData.ts
+++ b/cypress/Shared/TestData.ts
@@ -681,10 +681,11 @@ export class TestData {
         method: 'POST' | 'PUT',
         body: MeasureGroupBody,
         measureNumber = 0,
-        options: Partial<Cypress.RequestOptions> = {}
+        options: Partial<Cypress.RequestOptions> = {},
+        owner: FixtureOwner = 'selectedUser'
     ): Cypress.Chainable<Cypress.Response<T>> {
         return this.withAccessToken((accessToken) => {
-            return this.readMeasureId(measureNumber).then((measureId) => {
+            return this.readMeasureId(measureNumber, owner).then((measureId) => {
                 return cy.request({
                     ...options,
                     url: `/api/measures/${measureId}/groups`,

--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -460,34 +460,21 @@ export class Utilities {
         }
         const libraryPath = TestData.cqlLibraryIdPath(libraryNumber ?? 0, owner)
 
-        OktaLogin.setupUserSession(altUser)
+        TestData.setupUserScope(owner)
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            if (!accessToken?.value) {
-                cy.log('⚠️ deleteLibrary: No access token available — skipping cleanup')
+        cy.task('readFileSafe', libraryPath, { log: false }).then((id: string | null) => {
+            if (!id) {
+                cy.log(`⚠️ deleteLibrary: Fixture file ${libraryPath} is empty or missing — skipping cleanup`)
                 return
             }
-            cy.task('readFileSafe', libraryPath, { log: false }).then((id: string | null) => {
-                if (!id) {
-                    cy.log(`⚠️ deleteLibrary: Fixture file ${libraryPath} is empty or missing — skipping cleanup`)
-                    return
+            TestData.requestCqlLibraryById('DELETE', id, { failOnStatusCode: false }).then((response) => {
+                if (response.status === 200) {
+                    cy.log('Library deleted successfully')
+                } else {
+                    cy.log(
+                        `⚠️ Library cleanup returned ${response.status} — ${JSON.stringify(response.body).substring(0, 200)}`
+                    )
                 }
-                cy.request({
-                    url: '/api/cql-libraries/' + id,
-                    method: 'DELETE',
-                    headers: {
-                        Authorization: 'Bearer ' + accessToken?.value
-                    },
-                    failOnStatusCode: false
-                }).then((response) => {
-                    if (response.status === 200) {
-                        cy.log('Library deleted successfully')
-                    } else {
-                        cy.log(
-                            `⚠️ Library cleanup returned ${response.status} — ${JSON.stringify(response.body).substring(0, 200)}`
-                        )
-                    }
-                })
             })
         })
     }

--- a/cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts
@@ -2,11 +2,57 @@ import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
 import { SupportedModels } from "../../../Shared/CreateMeasurePage"
 import { MeasureCQL } from "../../../Shared/MeasureCQL"
 import { OktaLogin } from "../../../Shared/OktaLogin"
+import { CqlLibraryBody, TestData } from "../../../Shared/TestData"
 
 let CQLLibraryName = ''
 const CQLLibraryPublisher = 'SemanticBits'
 let measureCQLAlt = MeasureCQL.ICFCleanTestQICore
 const versionNumber = '1.0.000'
+
+const deleteCurrentCqlLibrary = (
+    options: Partial<Cypress.RequestOptions> = {}
+): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.readCqlLibraryId().then((libraryId) => {
+        return TestData.requestCqlLibraryById<CqlLibraryBody>('DELETE', libraryId, options)
+    })
+}
+
+const transferCurrentCqlLibrary = (
+    harpId: string
+): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.readCqlLibraryId().then((libraryId) => {
+        return TestData.requestWithAccessToken<CqlLibraryBody>({
+            url: '/api/cql-libraries/transfer?retainShareAccess=false',
+            method: 'PUT',
+            headers: {
+                harpid: harpId
+            },
+            body: [libraryId]
+        })
+    })
+}
+
+const draftCurrentCqlLibrary = (): Cypress.Chainable<Cypress.Response<CqlLibraryBody>> => {
+    return TestData.draftCqlLibrary<CqlLibraryBody>((libraryId) => ({
+        id: libraryId,
+        cqlLibraryName: CQLLibraryName,
+        model: 'QI-Core v4.1.1'
+    }))
+}
+
+const deleteAllCqlLibraryVersions = (
+    harpId: string,
+    options: Partial<Cypress.RequestOptions> = {}
+): Cypress.Chainable<Cypress.Response<string | { message: string }>> => {
+    return TestData.requestWithAccessToken<string | { message: string }>({
+        ...options,
+        url: '/api/cql-libraries/admin/' + CQLLibraryName + '/delete-all-versions',
+        method: 'DELETE',
+        headers: {
+            harpId
+        }
+    })
+}
 
 describe('Delete CQL Library', () => {
 
@@ -18,261 +64,114 @@ describe('Delete CQL Library', () => {
     })
 
     it('Delete CQL Library - Draft Library - user does not own nor has Library been shared with user', () => {
-        const currentUser = Cypress.env('selectedUser')
         // this is altUser, since we are looking for a failure
         OktaLogin.setupUserSession(true)
 
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + id,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'DELETE'
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                })
-            })
+        deleteCurrentCqlLibrary({ failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(403)
         })
     })
 
     it('Delete CQL Library - Draft Library - user is the owner of the Library', () => {
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(false)
-        //set local user that does not own the measure
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + id,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'DELETE'
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
+
+        deleteCurrentCqlLibrary().then((response) => {
+            expect(response.status).to.eql(200)
         })
     })
 
     it('Delete CQL Library - Draft Library - user has had the Library transferred to them', () => {
-        const currentUser = Cypress.env('selectedUser')
         const harpUserALT = OktaLogin.getUser(true)
 
         OktaLogin.setupUserSession(false)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/transfer?retainShareAccess=false',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value,
-                        'harpid': harpUserALT
-                    },
-                    body: [id],
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
-
+        transferCurrentCqlLibrary(harpUserALT).then((response) => {
+            expect(response.status).to.eql(200)
+        }).then(() => {
             OktaLogin.setupUserSession(true)
-            cy.getCookie('accessToken').then((accessToken) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                    cy.request({
-                        url: '/api/cql-libraries/' + id,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'DELETE'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                    })
-                })
+
+            deleteCurrentCqlLibrary().then((response) => {
+                expect(response.status).to.eql(200)
             })
         })
     })
 
     it('Delete CQL Library - Versioned Library - user does not own nor has Library been shared with user', () => {
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(false)
         CQLLibraryPage.versionLibraryAPI(versionNumber)
 
         // switch to altUser
         OktaLogin.setupUserSession(true)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + id,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'DELETE'
-                }).then((response) => {
-                    expect(response.status).to.eql(403)
-                })
-            })
+        deleteCurrentCqlLibrary({ failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(403)
         })
     })
 
     it('Delete CQL Library - Versioned Library - user is the owner of the Library', () => {
-        const currentUser = Cypress.env('selectedUser')
         OktaLogin.setupUserSession(false)
         CQLLibraryPage.versionLibraryAPI(versionNumber)
 
         OktaLogin.setupUserSession(false)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + id,
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    method: 'DELETE'
-                }).then((response) => {
-                    expect(response.status).to.eql(409)
-                })
-            })
+        deleteCurrentCqlLibrary({ failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(409)
         })
     })
 
     it('Delete CQL Library - Versioned Library - user has had the Library transferred to them', () => {
-        const currentUser = Cypress.env('selectedUser')
         const harpUserALT = OktaLogin.getUser(true)
 
         OktaLogin.setupUserSession(false)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                cy.request({
-                    url: '/api/cql-libraries/transfer?retainShareAccess=false',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value,
-                        'harpid': harpUserALT
-                    },
-                    body: [id],
-                    method: 'PUT'
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
-
+        transferCurrentCqlLibrary(harpUserALT).then((response) => {
+            expect(response.status).to.eql(200)
+        }).then(() => {
             OktaLogin.setupUserSession(true)
             CQLLibraryPage.versionLibraryAPI(versionNumber)
 
-            cy.getCookie('accessToken').then((accessToken) => {
-                cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((id) => {
-                    cy.request({
-                        failOnStatusCode: false,
-                        url: '/api/cql-libraries/' + id,
-                        headers: {
-                            authorization: 'Bearer ' + accessToken?.value
-                        },
-                        method: 'DELETE'
-                    }).then((response) => {
-                        expect(response.status).to.eql(409)
-                    })
-                })
+            deleteCurrentCqlLibrary({ failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(409)
             })
         })
     })
 
     it('Delete all Versions of the CQL Library - user is the owner of the Library', () => {
-        const currentUser = Cypress.env('selectedUser')
         const harpUser = OktaLogin.setupUserSession(false)
         CQLLibraryPage.versionLibraryAPI(versionNumber)
 
         //Draft Versioned Library
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/draft/' + cqlLibraryId,
-                    method: 'POST',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    },
-                    body: {
-                        "id": cqlLibraryId,
-                        "cqlLibraryName": CQLLibraryName,
-                        "model": 'QI-Core v4.1.1'
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(201)
-                    expect(response.body.draft).to.eql(true)
-                })
-            })
+        draftCurrentCqlLibrary().then((response) => {
+            expect(response.status).to.eql(201)
+            expect(response.body.draft).to.eql(true)
         })
 
         OktaLogin.setupAdminSession()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.request({
-                url: '/api/cql-libraries/admin/' + CQLLibraryName + '/delete-all-versions',
-                headers: {
-                    authorization: 'Bearer ' + accessToken?.value,
-                    'harpId': harpUser
-                },
-                method: 'DELETE'
-            }).then((response) => {
-                expect(response.status).to.eql(200)
-                expect(response.body).to.eql('The library and all its associated versions have been removed successfully.')
-            })
+        deleteAllCqlLibraryVersions(harpUser).then((response) => {
+            expect(response.status).to.eql(200)
+            expect(response.body).to.eql('The library and all its associated versions have been removed successfully.')
         })
 
         OktaLogin.setupUserSession(false)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(404)
-                })
-            })
+        TestData.readCqlLibrary<CqlLibraryBody>(0, { failOnStatusCode: false }).then((response) => {
+            expect(response.status).to.eql(404)
         })
     })
 
     it('Delete all Versions of the CQL Library - user does not own nor has Library been shared with user', () => {
-        const currentUser = Cypress.env('selectedUser')
         const harpUser = OktaLogin.setupUserSession(false)
         const harpUserALT = OktaLogin.getUser(true)
 
         OktaLogin.setupAdminSession()
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    failOnStatusCode: false,
-                    url: '/api/cql-libraries/admin/' + CQLLibraryName + '/delete-all-versions',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value,
-                        'harpId': harpUserALT
-                    },
-                    method: 'DELETE'
-                }).then((response) => {
-                    expect(response.status).to.eql(409)
-                    expect(response.body.message).to.eql('Response could not be completed because the HARP id of ' + harpUserALT + ' passed in does not match the owner of the library with the library id of ' + cqlLibraryId + '. The owner of the library is ' + harpUser)
-                })
+        TestData.readCqlLibraryId().then((cqlLibraryId) => {
+            deleteAllCqlLibraryVersions(harpUserALT, { failOnStatusCode: false }).then((response) => {
+                expect(response.status).to.eql(409)
+                expect(response.body).to.have.property(
+                    'message',
+                    'Response could not be completed because the HARP id of ' + harpUserALT + ' passed in does not match the owner of the library with the library id of ' + cqlLibraryId + '. The owner of the library is ' + harpUser
+                )
             })
         })
 
         OktaLogin.setupUserSession(false)
-        cy.getCookie('accessToken').then((accessToken) => {
-            cy.readFile('cypress/fixtures/' + currentUser + '/cqlLibraryId').should('exist').then((cqlLibraryId) => {
-                cy.request({
-                    url: '/api/cql-libraries/' + cqlLibraryId,
-                    method: 'GET',
-                    headers: {
-                        authorization: 'Bearer ' + accessToken?.value
-                    }
-                }).then((response) => {
-                    expect(response.status).to.eql(200)
-                })
-            })
+        TestData.readCqlLibrary<CqlLibraryBody>().then((response) => {
+            expect(response.status).to.eql(200)
         })
     })
 })

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -4,6 +4,33 @@ Last updated: 2026-07-08
 
 Stable rules live in `docs/quality/cypress-automation-guidelines.md`. Keep this backlog limited to current state, next actions, measured audit signal, and validation.
 
+# AI Backlog Workflow
+
+This backlog is the execution plan for repository improvements.
+
+After every completed refactor:
+
+1. Determine whether the completed item can be marked Done.
+2. Determine whether priorities have changed.
+3. Determine whether new work has been discovered.
+4. Recommend updates before moving to the next backlog item.
+
+Do not skip unfinished work unless a higher-priority issue is found.
+
+## AI Execution Rules
+
+Always work on only one backlog item at a time.
+
+A backlog item is complete when:
+
+- The targeted duplication has been removed.
+- Existing helpers have been reused where appropriate.
+- Behavior is unchanged.
+- Validation passes.
+- Documentation has been evaluated for updates.
+
+Do not begin the next backlog item until the current one is complete.
+
 ## Current Direction
 
 - Keep service setup and request mechanics behind `TestData` and domain helpers.
@@ -11,31 +38,54 @@ Stable rules live in `docs/quality/cypress-automation-guidelines.md`. Keep this 
 - Prioritize changes that reduce repeated fixture paths, token plumbing, fixed waits, forced interactions, skipped tests, or broad exception handling.
 - Update this file only when priorities, decisions, audit counts, or done signals materially change.
 
+## Starting Point
+
+Current active item:
+
+- P2 shared helper hardening, next target `cypress/Shared/TestCasesPage.ts`
+
+Why this is the best next step:
+
+- P1 CQL library service cleanup is already proven.
+- `Utilities.deleteLibrary` and the service-style API setup in `MeasureGroupPage.ts` are already moved behind `TestData`.
+- `TestCasesPage.ts` is still the largest remaining shared helper concentration for fixture-path plumbing and forced interactions.
+
+Work boundary for the next slice:
+
+- Stay inside `TestCasesPage.ts` unless a small supporting `TestData` change is required.
+- Prefer moving service-style setup and path conventions behind existing helpers before touching UI interaction patterns.
+- Keep negative assertions explicit and avoid combining helper hardening with wait/force cleanups unless the same code path requires it.
+
 ## Current State
 
 Recently proven service/helper slices:
 
 - Measure service: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QI Core Test-Cases.cy.ts`.
 - QDM service: `QDM Test-Cases.cy.ts`, `QDM Measure.cy.ts`, `QDMMeasureVersion.cy.ts`.
-- CQL library service: `CreateCQL-Library.cy.ts`, `EditCQL-Library.cy.ts`, `VersionAndDraftCQL-Library.cy.ts`.
+- CQL library service: `CreateCQL-Library.cy.ts`, `EditCQL-Library.cy.ts`, `VersionAndDraftCQL-Library.cy.ts`, `CQLLibraryDelete.cy.ts`.
 - Shared create/fixture path: `CreateMeasurePage.ts` now routes fixture writes and measure create/clone requests through `TestData` helpers.
+- Shared cleanup/request helpers: `Utilities.deleteLibrary` and the API create/update setup in `MeasureGroupPage.ts` now route fixture reads and authenticated requests through `TestData`.
+
+Recently diagnosed non-refactor failures:
+
+- `CQLLibraryDelete.cy.ts` still fails on current `master` because transfer cases return inactive-user `400` responses and admin delete-all cases return `403 insufficient_scope`. Treat that as environment or account-state drift, not as the next refactor target.
 
 ## Latest Audit Signal
 
-Command: `npm run quality:audit`
+Command: `npm run quality:no-focused-tests`
 
-- Inventory: 256 specs / 65737 spec lines; 29 shared files / 18839 shared lines; 3 support files / 637 support lines; 8 scripts / 1296 script lines.
+- Inventory: 256 specs / 65636 spec lines; 29 shared files / 18665 shared lines; 3 support files / 637 support lines; 8 scripts / 1296 script lines.
 - Skipped tests: 11.
-- Manual fixture path plumbing: 270.
-- Manual access token plumbing: 117.
+- Manual fixture path plumbing: 238.
+- Manual access token plumbing: 97.
 - Fixed waits: 101.
 - Forced interactions: 195.
 - Global uncaught exception suppression: 1.
 
 Largest risk concentrations:
 
-- `CQLLibraryDelete.cy.ts`: top remaining CQL library token-plumbing target.
-- `TestCasesPage.ts`, `MeasureGroupPage.ts`, `CreateMeasurePage.ts`, `Utilities.ts`: shared helper and page-object infrastructure debt.
+- `TestCasesPage.ts`: top remaining shared helper target for fixture-path plumbing, service-style setup, and forced interactions.
+- `CreateMeasurePage.ts`, `Utilities.ts`, and remaining service-style helpers inside shared page objects: shared helper and page-object infrastructure debt after `TestCasesPage.ts`.
 - `CorrectExpectedValues.cy.ts`, `DeleteTest-Case.cy.ts`, and selected admin/measure/test-case service specs: remaining service-tail cleanup.
 - `MeasureListNewColumnsSort.cy.ts`, `CQLLibraryListPageColumnSort.cy.ts`, export specs, highlighting specs, and editor flows: UI reliability debt from waits and forced interactions.
 - `cypress/support/e2e.ts`: global `uncaught:exception` suppression.
@@ -44,17 +94,21 @@ Largest risk concentrations:
 
 ### P1: CQL Library Service Cleanup
 
-Next target: `cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts`
+Status: Done
 
-Done when repeated token/header/request setup moves behind shared helpers, negative states stay explicit, and focused library validation passes or exposes a diagnosed non-refactor failure.
+Completed signal:
+
+- Repeated token/header/request setup moved behind shared helpers.
+- Negative states stayed explicit.
+- Focused validation exposed preexisting non-refactor failures instead of helper regressions.
 
 ### P2: Shared Helper and Infrastructure Hardening
 
-Start with:
+Current target order:
 
-- `Utilities.deleteLibrary`
-- `MeasureGroupPage.ts`
 - `TestCasesPage.ts`
+- `CreateMeasurePage.ts`
+- remaining `Utilities.ts` and shared page-object service helpers
 
 Done when shared helpers own path conventions and common request setup, and page objects no longer spread service setup mechanics.
 
@@ -81,7 +135,7 @@ Candidates:
 
 After each meaningful slice:
 
-- Run the audit and compare the current diff.
+- Run the quality scan and compare the current diff.
 - Prefer changes that remove a class of duplication across multiple specs.
 - Record only durable decisions or changed counts.
 - Validate with static checks and at least one focused spec for the changed helper path.

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -72,7 +72,7 @@ Recently diagnosed non-refactor failures:
 
 ## Latest Audit Signal
 
-Command: `npm run quality:no-focused-tests`
+Command: `npm run quality:audit`
 
 - Inventory: 256 specs / 65636 spec lines; 29 shared files / 18665 shared lines; 3 support files / 637 support lines; 8 scripts / 1296 script lines.
 - Skipped tests: 11.
@@ -135,7 +135,7 @@ Candidates:
 
 After each meaningful slice:
 
-- Run the quality scan and compare the current diff.
+- Run `npm run quality:audit` and compare the current diff.
 - Prefer changes that remove a class of duplication across multiple specs.
 - Record only durable decisions or changed counts.
 - Validate with static checks and at least one focused spec for the changed helper path.


### PR DESCRIPTION
## Summary

Refactors shared Cypress helper paths to reuse `TestData` for request setup, fixture reads, and owner-aware measure-group requests, while also tightening the backlog so the next refactor target is clearer.

## Changes

- refactored `CQLLibraryDelete.cy.ts` to reuse shared `TestData` CQL library request helpers instead of inline token/header/request setup
- refactored `Utilities.deleteLibrary` to use `TestData` helper paths for authenticated CQL library cleanup
- refactored service-style API setup in `MeasureGroupPage.ts` to route measure-group create and stratification setup through shared `TestData` helpers
- extended `TestData.requestMeasureGroup` with owner-aware measure ID lookup so shared helpers can support alt-user fixture paths
- updated `AGENTS.md` backlog-maintenance guidance
- reworked `docs/quality/test-refactor-backlog.md` so it reflects completed P1 work, current audit signal, diagnosed non-refactor failures, and a clearer next starting point

## Technical Notes

- kept negative assertions explicit in the CQL library delete spec
- preserved existing fixture names such as `measureGroupId`, `groupId`, and `groupId2` to avoid behavior changes in downstream specs
- focused `MeasureGroupPage.ts` on helper reuse rather than mixing in UI reliability cleanup
- validated that the CQL library delete failures reproduced on clean `master`, indicating environment/account drift rather than a regression from this branch

## Testing

- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`
- `env -u ELECTRON_RUN_AS_NODE npx cypress run --env configFile=dev --browser chrome --spec "cypress/e2e/Services/CQL Library Service/CQLLibraryDelete.cy.ts"`
- `env -u ELECTRON_RUN_AS_NODE npx cypress run --env configFile=dev --browser chrome --spec "cypress/e2e/WebInterface/Smoke Tests/CreateCQLLibrary.cy.ts"`
- `env -u ELECTRON_RUN_AS_NODE npx cypress run --env configFile=dev --browser chrome --spec "cypress/e2e/Services/Measure Service/ViewHumanReadable.cy.ts"`
- `env -u ELECTRON_RUN_AS_NODE npx cypress run --env configFile=dev --browser chrome --spec "cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts"`

## Risk

- `CQLLibraryDelete.cy.ts` still exposes preexisting environment/account issues in dev:
  - transfer cases return inactive-user `400`
  - admin delete-all cases return `403 insufficient_scope`
- `TestCasesPage.ts` remains the next high-value shared-helper target and still carries fixture-path plumbing and forced-interaction debt

## Documentation

- updated `docs/quality/test-refactor-backlog.md`
- updated `AGENTS.md`