### PR TITLE
Fix Cypress worker launch wrapper

### DIFF
--- a/scripts/run-with-timeout.js
+++ b/scripts/run-with-timeout.js
@@ -5,23 +5,75 @@ const { spawn } = require('child_process')
 const timeoutSeconds = Number(process.argv[2])
 const command = process.argv[3]
 const args = process.argv.slice(4)
+const heartbeatSeconds = Number(process.env.CYPRESS_WORKER_HEARTBEAT_SECONDS || 300)
 
 if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0 || !command) {
   console.error('Usage: node scripts/run-with-timeout.js <seconds> <command> [args...]')
   process.exit(1)
 }
 
-const child = spawn(command, args, {
-  stdio: 'inherit',
+function quoteArg(arg) {
+  if (process.platform === 'win32') {
+    return `"${String(arg).replace(/"/g, '\\"')}"`
+  }
+
+  return `'${String(arg).replace(/'/g, `'\\''`)}'`
+}
+
+function formatElapsed(seconds) {
+  const hrs = Math.floor(seconds / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  const secs = seconds % 60
+
+  return [hrs, mins, secs]
+    .map((value) => String(value).padStart(2, '0'))
+    .join(':')
+}
+
+const shellCommand = [command, ...args].map(quoteArg).join(' ')
+
+console.error(`Starting command with timeout ${timeoutSeconds}s: ${shellCommand}`)
+
+const child = spawn(shellCommand, {
+  stdio: ['ignore', 'pipe', 'pipe'],
   env: process.env,
-  detached: process.platform !== 'win32'
+  detached: process.platform !== 'win32',
+  shell: true
+})
+
+const startedAt = Date.now()
+let lastOutputAt = startedAt
+
+child.stdout.on('data', (chunk) => {
+  lastOutputAt = Date.now()
+  process.stdout.write(chunk)
+})
+
+child.stderr.on('data', (chunk) => {
+  lastOutputAt = Date.now()
+  process.stderr.write(chunk)
+})
+
+child.on('error', (err) => {
+  console.error(`Failed to start command: ${err.message}`)
 })
 
 let timedOut = false
+const heartbeatTimer = Number.isFinite(heartbeatSeconds) && heartbeatSeconds > 0
+  ? setInterval(() => {
+      const elapsedSeconds = Math.floor((Date.now() - startedAt) / 1000)
+      const silentSeconds = Math.floor((Date.now() - lastOutputAt) / 1000)
+      console.error(
+        `Command heartbeat after ${formatElapsed(elapsedSeconds)}; last output ${formatElapsed(silentSeconds)} ago`
+      )
+    }, heartbeatSeconds * 1000)
+  : null
+
+heartbeatTimer?.unref()
 
 const timer = setTimeout(() => {
   timedOut = true
-  console.error(`Command exceeded ${timeoutSeconds}s timeout: ${command} ${args.join(' ')}`)
+  console.error(`Command exceeded ${timeoutSeconds}s timeout: ${shellCommand}`)
 
   try {
     if (process.platform === 'win32') {
@@ -48,13 +100,14 @@ const timer = setTimeout(() => {
 
 child.on('exit', (code, signal) => {
   clearTimeout(timer)
+  heartbeatTimer && clearInterval(heartbeatTimer)
 
   if (timedOut) {
     process.exit(124)
   }
 
   if (signal) {
-    console.error(`Command exited from signal ${signal}: ${command}`)
+    console.error(`Command exited from signal ${signal}: ${shellCommand}`)
     process.exit(128)
   }
 


### PR DESCRIPTION
## Summary
Update the Cypress worker timeout wrapper so parallel workers launch through the shell and emit heartbeat logs while running. This aligns the worker launch path with the repo's existing Cypress 15 shell-launch workaround and gives CI better signal when a worker goes silent.

## Changes
- Launch wrapped Cypress commands with `shell: true` instead of direct `spawn()`
- Log the full wrapped command at startup
- Pipe stdout/stderr manually so output timestamps can be tracked
- Add configurable heartbeat logging with `CYPRESS_WORKER_HEARTBEAT_SECONDS`
- Keep existing timeout and process-group termination behavior

## Technical Notes
The pipeline freeze investigated from build 254 stopped after `cypress-parallel` handed control to `cy:run:test:headed`, before any normal Cypress startup banner appeared. This change keeps the fix scoped to the runner wrapper rather than broadening test logic or Cypress config.

## Testing
- `node -c scripts/run-with-timeout.js`
- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`

## Risk
Low. The change is isolated to the CI/local wrapper used to launch Cypress workers. Main watch item is shell quoting behavior, which is why the wrapper now quotes each argument explicitly.

## Documentation
Documentation Updates:
None