### PR TITLE
Improve Cypress shared helpers and Expected/Actual reliability

### DIFF
--- a/cypress/Shared/CQLEditorPage.ts
+++ b/cypress/Shared/CQLEditorPage.ts
@@ -242,6 +242,29 @@ export class CQLEditorPage {
         }
     }
 
+    public static minimizeAlerts(hiddenAlertSelector: string): void {
+        cy.get(CQLEditorPage.minimizeButton).click()
+        cy.get(hiddenAlertSelector).should('not.exist')
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
+    }
+
+    public static reopenMinimizedAlerts(options: {
+        visibleAlertSelector?: string
+        hiddenAlertSelector?: string
+    } = {}): void {
+        cy.get(CQLEditorPage.minimizedAlertsTab).click()
+
+        if (options.visibleAlertSelector) {
+            cy.get(options.visibleAlertSelector).should('be.visible')
+        }
+
+        if (options.hiddenAlertSelector) {
+            cy.get(options.hiddenAlertSelector).should('not.exist')
+        }
+
+        cy.get(CQLEditorPage.minimizedAlertsTab).should('not.exist')
+    }
+
     public static applyDefinition(): void {
 
         cy.get('[data-testid="definition-apply-btn"]').click()
@@ -253,8 +276,11 @@ export class CQLEditorPage {
     public static replaceCqlDocument(filePath: string) {
 
         Utilities.waitForElementWriteEnabled(EditMeasurePage.cqlEditorTextBox, 8500)
-        cy.wait(2000)
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{selectall}{backspace}{selectall}{backspace}')
+        cy.get(EditMeasurePage.cqlEditorTextBox)
+            .should('be.visible')
+            .click()
+            .focused()
+            .type('{selectall}{backspace}{selectall}{backspace}', { force: true })
 
         Utilities.typeFileContents(filePath, EditMeasurePage.cqlEditorTextBox)
     }
@@ -268,6 +294,7 @@ export class CQLEditorPage {
         const maxRetries = 5
 
         const attemptExpand = (attempt: number): void => {
+            cy.document().its('readyState').should('eq', 'complete')
             cy.get('body').then(($body) => {
                 // The collapse button is only rendered when the panel is truly open
                 const panelOpen = $body.find(CQLEditorPage.collapseCQLBuilder).length > 0
@@ -281,16 +308,14 @@ export class CQLEditorPage {
                 if ($body.find(CQLEditorPage.expandCQLBuilder).length > 0) {
                     cy.log(`Expanding CQL Builder panel (attempt ${attempt + 1}/${maxRetries})`)
                     cy.get(CQLEditorPage.expandCQLBuilder).first().scrollIntoView().click({ force: true })
-                    // Wait for any navigation / page reload to settle
-                    cy.wait(4000)
-                    // Recurse if we haven't exceeded retries
+                    cy.document().its('readyState').should('eq', 'complete')
+
                     if (attempt + 1 < maxRetries) {
                         attemptExpand(attempt + 1)
                     }
                 } else {
-                    // Neither expand nor collapse button found — page may still be loading
-                    cy.log(`Neither expand nor collapse button found (attempt ${attempt + 1}/${maxRetries}), waiting...`)
-                    cy.wait(3000)
+                    cy.log(`Neither expand nor collapse button found (attempt ${attempt + 1}/${maxRetries}), retrying...`)
+
                     if (attempt + 1 < maxRetries) {
                         attemptExpand(attempt + 1)
                     }

--- a/cypress/Shared/CQLLibrariesPage.ts
+++ b/cypress/Shared/CQLLibrariesPage.ts
@@ -5,6 +5,7 @@ import { FixtureOwner, TestData } from './TestData'
 
 export class CQLLibrariesPage {
     public static readonly librariesList = '[data-testid="library-list-tbl"]'
+    public static readonly libraryListRows = '.table-body tr'
 
     //Version and Draft CQL Library
     public static readonly versionLibraryRadioButton = '[name="type"]'
@@ -81,6 +82,24 @@ export class CQLLibrariesPage {
             cy.wait('@cqlLibrary', { timeout: 10000 }).then(({ response }) => {
                 expect(response?.statusCode).to.eq(200)
             })
+        })
+    }
+
+    public static waitForLibraryListRefresh(alias: `@${string}`): Cypress.Chainable<any> {
+        return cy.wait(alias).then((interception) => {
+            expect(interception.response?.statusCode).to.eq(200)
+            return cy
+                .get(this.librariesList, { timeout: 30000 })
+                .should('be.visible')
+                .then(() => {
+                    return cy.get(this.libraryListRows, { timeout: 30000 }).should(($rows) => {
+                        expect($rows.length, 'library list rows').to.be.greaterThan(0)
+                    })
+                })
+                .then(() => {
+                    return cy.get(this.libraryListRows).first().find('td').eq(1).should('be.visible')
+                })
+                .then(() => interception)
         })
     }
 

--- a/cypress/Shared/CQLLibraryPage.ts
+++ b/cypress/Shared/CQLLibraryPage.ts
@@ -158,7 +158,7 @@ export class CQLLibraryPage {
         //saving measureID to file to use later
         cy.wait(libraryAlias).then(({ response }) => {
             expect(response?.statusCode).to.eq(201)
-            TestData.writeFixture('cqlLibraryId', response?.body.id)
+            TestData.writeCqlLibraryId(response?.body.id)
         })
     }
 
@@ -171,7 +171,6 @@ export class CQLLibraryPage {
     ): string {
         const owner = this.fixtureOwner(altUser)
         const user = TestData.setupUserScope(owner)
-        const fixtureName = twoLibraries === true ? 'cqlLibraryId2' : 'cqlLibraryId'
 
         TestData.requestCqlLibrary({
             cqlLibraryName: CqlLibraryName,
@@ -184,7 +183,7 @@ export class CQLLibraryPage {
             expect(response.status).to.eql(201)
             expect(response.body.id).to.be.exist
             expect(response.body.cqlLibraryName).to.eql(CqlLibraryName)
-            TestData.writeFixture(fixtureName, response.body.id, owner)
+            TestData.writeCqlLibraryId(response.body.id, twoLibraries === true ? 2 : 0, owner)
         })
 
         return user
@@ -205,8 +204,7 @@ export class CQLLibraryPage {
     }
 
     public static actionCenter(action: EditLibraryActions): void {
-        cy.get(this.actionCenterButton).click()
-        cy.wait(250)
+        cy.get(this.actionCenterButton).should('be.visible').click()
 
         switch (action) {
             case EditLibraryActions.delete: {
@@ -274,7 +272,6 @@ export class CQLLibraryPage {
     public static createLibraryAPI(libraryName: string, model: SupportedModels, options?: CreateLibraryOptions) {
         const owner = this.fixtureOwner(options?.altUser)
         const user = TestData.setupUserScope(owner)
-        const fixtureName = options?.libraryNumber ? `cqlLibraryId${options.libraryNumber}` : 'cqlLibraryId'
 
         TestData.requestCqlLibrary({
             cqlLibraryName: libraryName,
@@ -288,16 +285,20 @@ export class CQLLibraryPage {
             expect(response.status).to.eql(201)
             expect(response.body.id).to.be.exist
             expect(response.body.cqlLibraryName).to.eql(libraryName)
-            TestData.writeFixture(fixtureName, response.body.id, owner)
+            TestData.writeCqlLibraryId(response.body.id, options?.libraryNumber ?? 0, owner)
         })
 
         return user
     }
 
     public static checkFirstRow(expectedData: MeasureRow) {
-        cy.wait(1100)
-
-        cy.get('.table-body tr')
+        cy.get(this.cqlLibSearchResultsTable, { timeout: 30000 }).should('be.visible')
+        cy.get(CQLLibrariesPage.libraryListRows, { timeout: 30000 })
+            .first()
+            .find('td')
+            .eq(1)
+            .should('be.visible')
+        cy.get(CQLLibrariesPage.libraryListRows)
             .first()
             .then((firstRow) => {
                 if (expectedData.name) {

--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -3,7 +3,6 @@ import { MeasuresPage } from "./MeasuresPage"
 import { v4 as uuidv4 } from 'uuid'
 import { Utilities } from "./Utilities"
 import { Measure } from "@madie/madie-models"
-import { OktaLogin } from "./OktaLogin"
 import { FixtureOwner, TestData } from "./TestData"
 import { step } from "../utils/step"
 const now = require('dayjs')
@@ -69,18 +68,6 @@ export class CreateMeasurePage {
         return altUser ? 'selectedAltUser' : 'selectedUser'
     }
 
-    private static writeMeasureFixtures(
-        responseBody: any,
-        measureNumber = 0,
-        owner: FixtureOwner = 'selectedUser'
-    ): void {
-        const suffix = measureNumber > 0 ? measureNumber : ''
-
-        TestData.writeFixture(`measureId${suffix}`, responseBody.id, owner)
-        TestData.writeFixture(`versionId${suffix}`, responseBody.versionId, owner)
-        TestData.writeFixture(`measureSetId${suffix}`, responseBody.measureSetId, owner)
-    }
-
     public static clickCreateMeasureButton(): void {
 
         let alias = 'measure' + (Date.now() + 1).toString()
@@ -94,7 +81,7 @@ export class CreateMeasurePage {
         //saving measureID to file to use later
         cy.wait(waitAlias).then(({ response }) => {
             expect(response?.statusCode).to.eq(201)
-            this.writeMeasureFixtures(response?.body)
+            TestData.writeMeasureContext(response?.body)
         })
     }
 
@@ -112,7 +99,11 @@ export class CreateMeasurePage {
             //saving measureID to file to use later
             cy.wait(waitAlias).then(({ response }) => {
                 expect(response?.statusCode).to.eq(201)
-                TestData.writeFixture('measureId', response?.body.id)
+                TestData.writeMeasureContext({
+                    id: response?.body.id,
+                    versionId: response?.body.versionId ?? '',
+                    measureSetId: response?.body.measureSetId ?? ''
+                })
             })
         })
     }
@@ -223,15 +214,11 @@ export class CreateMeasurePage {
             measureNumber = 0
         }
 
-        user = OktaLogin.setupUserSession(altUser)
+        user = TestData.setupUserScope(this.fixtureOwner(altUser))
         cy.log('Current user is: ' + user)
 
         //Create New Measure
-        TestData.requestWithAccessToken<any>({
-                failOnStatusCode: false,
-                url: '/api/measure?addDefaultCQL=false',
-                method: 'POST',
-                body: {
+        TestData.requestMeasureCreate<any>({
                     'measureName': measureName,
                     'cqlLibraryName': CqlLibraryName,
                     'model': 'QI-Core v4.1.1',
@@ -298,22 +285,15 @@ export class CreateMeasurePage {
                         "display": "MIPS",
                         "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
                     }
-                }
-        }).then((response) => {
+                },
+                { failOnStatusCode: false }
+        ).then((response) => {
 
                 expect(response?.status).to.eql(201)
                 expect(response?.body.id).to.be.exist
 
-                let currentUser = ''
-                if (altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                else {
-                    currentUser = Cypress.env('selectedUser')
-                }
-
-                this.writeMeasureFixtures(response?.body, measureNumber, this.fixtureOwner(altUser))
-                cy.log(currentUser + ' MeasureSetId is ' + response?.body.measureSetId)
+                TestData.writeMeasureContext(response?.body, measureNumber, this.fixtureOwner(altUser))
+                cy.log('MeasureSetId is ' + response?.body.measureSetId)
         })
         return user
     }
@@ -343,14 +323,10 @@ export class CreateMeasurePage {
             measureNumber = 0
         }
 
-        user = OktaLogin.setupUserSession(altUser)
+        user = TestData.setupUserScope(this.fixtureOwner(altUser))
 
         //Create New Measure
-        TestData.requestWithAccessToken<any>({
-                failOnStatusCode: false,
-                url: '/api/measure?addDefaultCQL=false',
-                method: 'POST',
-                body: {
+        TestData.requestMeasureCreate<any>({
                     'measureName': measureName,
                     'cqlLibraryName': CqlLibraryName,
                     'model': 'QI-Core v4.1.1',
@@ -416,21 +392,14 @@ export class CreateMeasurePage {
                         "display": "MIPS",
                         "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
                     }
-                }
-        }).then((response) => {
+                },
+                { failOnStatusCode: false }
+        ).then((response) => {
 
                 expect(response?.status).to.eql(201)
                 expect(response?.body.id).to.be.exist
 
-                let currentUser = ''
-                if (altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                else {
-                    currentUser = Cypress.env('selectedUser')
-                }
-
-                this.writeMeasureFixtures(response?.body, measureNumber, this.fixtureOwner(altUser))
+                TestData.writeMeasureContext(response?.body, measureNumber, this.fixtureOwner(altUser))
                 cy.log('MeasureSetId is ' + response?.body.measureSetId)
         })
         return user
@@ -461,14 +430,10 @@ export class CreateMeasurePage {
             measureNumber = 0
         }
 
-        user = OktaLogin.setupUserSession(altUser)
+        user = TestData.setupUserScope(this.fixtureOwner(altUser))
 
         //Create New Measure
-        TestData.requestWithAccessToken<any>({
-                failOnStatusCode: false,
-                url: '/api/measure?addDefaultCQL=false',
-                method: 'POST',
-                body: {
+        TestData.requestMeasureCreate<any>({
                     'measureName': measureName,
                     'cqlLibraryName': CqlLibraryName,
                     'model': 'QI-Core v4.1.1',
@@ -533,21 +498,14 @@ export class CreateMeasurePage {
                         "display": "MIPS",
                         "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
                     }
-                }
-        }).then((response) => {
+                },
+                { failOnStatusCode: false }
+        ).then((response) => {
 
                 expect(response?.status).to.eql(201)
                 expect(response?.body.id).to.be.exist
 
-                let currentUser = ''
-                if (altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                else {
-                    currentUser = Cypress.env('selectedUser')
-                }
-
-                this.writeMeasureFixtures(response?.body, measureNumber, this.fixtureOwner(altUser))
+                TestData.writeMeasureContext(response?.body, measureNumber, this.fixtureOwner(altUser))
                 cy.log('MeasureSetId is ' + response?.body.measureSetId)
         })
         return user
@@ -581,13 +539,10 @@ export class CreateMeasurePage {
             altUser = true
         }
 
-        user = OktaLogin.setupUserSession(altUser)
+        user = TestData.setupUserScope(this.fixtureOwner(altUser))
 
         //Create New Measure
-        TestData.requestWithAccessToken<any>({
-                url: '/api/measure?addDefaultCQL=false',
-                method: 'POST',
-                body: {
+        TestData.requestMeasureCreate<any>({
                     'measureName': measureName,
                     'cqlLibraryName': CqlLibraryName,
                     'model': 'QDM v5.6',
@@ -627,24 +582,16 @@ export class CreateMeasurePage {
                         "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
                     }
                 }
-        }).then((response) => {
+        ).then((response) => {
 
                 expect(response?.status).to.eql(201)
                 expect(response?.body.id).to.be.exist
 
-                let currentUser = ''
-                if (altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                else {
-                    currentUser = Cypress.env('selectedUser')
-                }
-
                 if ((twoMeasures === true) && (measureNumber === 0)) {
-                    this.writeMeasureFixtures(response?.body, 2, this.fixtureOwner(altUser))
+                    TestData.writeMeasureContext(response?.body, 2, this.fixtureOwner(altUser))
                 }
                 else {
-                    this.writeMeasureFixtures(response?.body, measureNumber, this.fixtureOwner(altUser))
+                    TestData.writeMeasureContext(response?.body, measureNumber, this.fixtureOwner(altUser))
                 }
         })
         cy.log(user)
@@ -677,15 +624,11 @@ export class CreateMeasurePage {
             CreateMeasureOptions.description = '<p>SemanticBits</p>'
         }
 
-        user = OktaLogin.setupUserSession(altUser)
+        user = TestData.setupUserScope(this.fixtureOwner(altUser))
         cy.log('Current user is: ' + user)
 
         //Create New Measure
-        TestData.requestWithAccessToken<any>({
-                failOnStatusCode: false,
-                url: '/api/measure?addDefaultCQL=false',
-                method: 'POST',
-                body: {
+        TestData.requestMeasureCreate<any>({
                     'measureName': CreateMeasureOptions.ecqmTitle,
                     'cqlLibraryName': CreateMeasureOptions.cqlLibraryName,
                     'model': 'QDM v5.6',
@@ -723,21 +666,14 @@ export class CreateMeasurePage {
                         "display": "MIPS",
                         "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
                     }
-                }
-        }).then((response) => {
+                },
+                { failOnStatusCode: false }
+        ).then((response) => {
 
                 expect(response?.status).to.eql(201)
                 expect(response?.body.id).to.be.exist
 
-                let currentUser = ''
-                if (CreateMeasureOptions.altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                else {
-                    currentUser = Cypress.env('selectedUser')
-                }
-
-                this.writeMeasureFixtures(
+                TestData.writeMeasureContext(
                     response?.body,
                     CreateMeasureOptions.measureNumber,
                     this.fixtureOwner(CreateMeasureOptions.altUser)
@@ -832,13 +768,10 @@ export class CreateMeasurePage {
             altUser = true
         }
 
-        user = OktaLogin.setupUserSession(altUser)
+        user = TestData.setupUserScope(this.fixtureOwner(altUser))
 
         //Create New Measure
-        TestData.requestWithAccessToken<any>({
-                url: '/api/measure?addDefaultCQL=false',
-                method: 'POST',
-                body: {
+        TestData.requestMeasureCreate<any>({
                     'measureName': measureName,
                     'cqlLibraryName': cqlLibraryName,
                     'model': model,
@@ -863,19 +796,12 @@ export class CreateMeasurePage {
                         "codeSystem": "http://hl7.org/fhir/us/cqfmeasures/CodeSystem/quality-programs"
                     }
                 }
-        }).then((response) => {
+        ).then((response) => {
 
                 expect(response?.status).to.eql(201)
                 expect(response?.body.id).to.be.exist
 
-                if (altUser) {
-                    currentUser = Cypress.env('selectedAltUser')
-                }
-                else {
-                    currentUser = Cypress.env('selectedUser')
-                }
-
-                this.writeMeasureFixtures(response?.body, measureNumber, this.fixtureOwner(altUser))
+                TestData.writeMeasureContext(response?.body, measureNumber, this.fixtureOwner(altUser))
         })
         cy.log(user)
         return user
@@ -887,7 +813,7 @@ export class CreateMeasurePage {
         if (overrideOptions && overrideOptions.altUser) {
             useAltUser = true
         }
-        OktaLogin.setupUserSession(useAltUser)
+        TestData.setupUserScope(this.fixtureOwner(useAltUser))
 
         // example of configuring options
         if (overrideOptions && overrideOptions.measureNumber) {
@@ -895,10 +821,7 @@ export class CreateMeasurePage {
         }
 
         // query existing measure for all data
-        TestData.requestWithAccessToken<Partial<Measure>>({
-                url: '/api/measures/' + existingId,
-                method: 'GET'
-        }).then((response) => {
+        TestData.requestMeasureById<Partial<Measure>>('GET', existingId).then((response) => {
                 const clonedMeasure = response?.body as Partial<Measure>
 
                 // clear out data required to be fresh
@@ -917,15 +840,11 @@ export class CreateMeasurePage {
                     clonedMeasure.ecqmTitle = overrideOptions.ecqmTitle
                 }
 
-                TestData.requestWithAccessToken<any>({
-                    url: '/api/measure?addDefaultCQL=false',
-                    method: 'POST',
-                    body: clonedMeasure
-                }).then((response) => {
+                TestData.requestMeasureCreate<any>(clonedMeasure as any).then((response) => {
                     expect(response?.status).to.eql(201)
                     expect(response?.body.id).to.be.exist
 
-                    this.writeMeasureFixtures(response?.body, measureNumber)
+                    TestData.writeMeasureContext(response?.body, measureNumber)
                 })
         })
     }

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -53,6 +53,8 @@ export type MeasureObservations = {
 }
 
 export class MeasureGroupPage {
+    private static readonly testCaseExecutionCqlFixture = 'cypress/fixtures/CQLForTestCaseExecution.txt'
+
     public static readonly popBasisField = '[id="populationBasis"]'
     public static readonly pcErrorAlertToast = '[data-testid="population-criteria-error"]'
 
@@ -304,16 +306,22 @@ export class MeasureGroupPage {
 
     private static createMeasureGroupApi(
         body: MeasureGroupBody,
-        fixtureName: string,
         owner: FixtureOwner = 'selectedUser',
-        measureNumber = 0
+        groupNumber = 0,
+        measureNumber = 0,
+        fixtureName?: string
     ): string {
         const user = TestData.setupUserScope(owner)
 
         TestData.requestMeasureGroup('POST', body, measureNumber, {}, owner).then((response) => {
             expect(response.status).to.eql(201)
             expect(response.body.id).to.be.exist
-            TestData.writeFixture(fixtureName, response.body.id, owner)
+            if (fixtureName) {
+                TestData.writeFixture(fixtureName, response.body.id, owner)
+                return
+            }
+
+            TestData.writeMeasureGroupId(response.body.id, groupNumber, owner)
         })
 
         return user
@@ -323,36 +331,8 @@ export class MeasureGroupPage {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        //Add CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
-            .should('exist')
-            .then((fileContents) => {
-                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-            })
-
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
-        //Create Measure Group
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
-        cy.get(MeasureGroupPage.measureGroupTypeCheckbox).each(($ele) => {
-            if ($ele.text() == 'Text') {
-                cy.wrap($ele).should('exist')
-                cy.wrap($ele).focus()
-                cy.wrap($ele).click()
-            }
-        })
-        cy.get(MeasureGroupPage.measureGroupTypeSelect)
-            .find('input')
-            .type('Process')
-            .type('{downArrow}')
-            .type('{enter}')
+        MeasureGroupPage.loadTestCaseExecutionCql()
+        MeasureGroupPage.setMeasureGroupType()
         // this clears the previous step's dropdown
         cy.get(this.QDMPopCriteria1Desc).click()
 
@@ -382,23 +362,8 @@ export class MeasureGroupPage {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        //Add CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
-            .should('exist')
-            .then((fileContents) => {
-                cy.wait(3000)
-                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-            })
-
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
-        //Create Measure Group
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.loadTestCaseExecutionCql()
+        MeasureGroupPage.setMeasureGroupType()
 
         cy.get(MeasureGroupPage.popBasisField).focus()
 
@@ -428,23 +393,8 @@ export class MeasureGroupPage {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        //Add CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
-            .should('exist')
-            .then((fileContents) => {
-                cy.wait(3000)
-                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-            })
-
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-
-        //Create Measure Group
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-
-        Utilities.setMeasureGroupType()
+        MeasureGroupPage.loadTestCaseExecutionCql()
+        MeasureGroupPage.setMeasureGroupType()
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCV)
 
         Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
@@ -564,9 +514,10 @@ export class MeasureGroupPage {
                 stratifications: [],
                 improvementNotation: 'Increased score indicates improvement'
             },
-            'measureGroupId',
             owner,
-            measureNumber
+            0,
+            measureNumber,
+            'measureGroupId'
         )
     }
 
@@ -632,8 +583,8 @@ export class MeasureGroupPage {
                 stratifications: [],
                 improvementNotation: 'Increased score indicates improvement'
             },
-            twoMeasureGroups === true ? 'groupId2' : 'groupId',
             owner,
+            twoMeasureGroups === true ? 2 : 0,
             twoMeasureGroups === true ? 2 : 0
         )
     }
@@ -693,8 +644,8 @@ export class MeasureGroupPage {
                 improvementNotation: 'Increased score indicates improvement',
                 improvementNotationDescription: '<p>test iND</p>'
             },
-            twoMeasureGroups === true ? 'groupId2' : 'groupId',
             owner,
+            twoMeasureGroups === true ? 2 : 0,
             measureNumber
         )
     }
@@ -732,8 +683,8 @@ export class MeasureGroupPage {
                 stratifications: [],
                 improvementNotation: 'Increased score indicates improvement'
             },
-            twoMeasureGroups === true ? 'groupId2' : 'groupId',
             owner,
+            twoMeasureGroups === true ? 2 : 0,
             twoMeasureGroups === true ? 2 : 0
         )
     }
@@ -853,7 +804,6 @@ export class MeasureGroupPage {
                 improvementNotation: 'Increased score indicates improvement',
                 measureObservations: observations
             },
-            'groupId',
             owner
         )
     }
@@ -863,7 +813,7 @@ export class MeasureGroupPage {
             type = MeasureType.process
         }
 
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).wait(1000).should('exist')
+        cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
         cy.get(MeasureGroupPage.measureGroupTypeCheckbox).should('exist')
@@ -877,8 +827,33 @@ export class MeasureGroupPage {
         })
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('exist')
         cy.get(MeasureGroupPage.measureGroupTypeSelect).should('be.visible')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).find('input').type(type).type('{downArrow}').type('{enter}')
-        cy.get(MeasureGroupPage.measureGroupTypeSelect).click()
+        cy.get(MeasureGroupPage.measureGroupTypeSelect)
+            .find('input')
+            .should('be.visible')
+            .type(type)
+            .type('{downArrow}')
+            .type('{enter}')
+        cy.get(MeasureGroupPage.popBasisField).should('be.visible').click()
+    }
+
+    private static loadTestCaseExecutionCql(): void {
+        cy.get(EditMeasurePage.cqlEditorTab).click()
+        Utilities.waitForElementWriteEnabled(EditMeasurePage.cqlEditorTextBox, 8500)
+        cy.readFile(MeasureGroupPage.testCaseExecutionCqlFixture)
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
+        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
+        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get('body').then(($body) => {
+            if ($body.find(EditMeasurePage.cqlEditorExpandCollapseBtn).length > 0) {
+                CQLEditorPage.collapseEditor()
+            }
+        })
+        cy.get(EditMeasurePage.measureGroupsTab).click()
+        cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
+        cy.get(EditMeasurePage.measureGroupsTab).click()
     }
 
     public static includeSdeData(): void {
@@ -901,24 +876,15 @@ export class MeasureGroupPage {
     }
 
     public static addStratificationDataAPI(stratificationData: Array<Stratification>) {
-        TestData.readMeasureId().then((measureId) => {
-            TestData.requestWithAccessToken<Array<MeasureGroupBody>>({
-                url: `/api/measures/${measureId}/groups`,
-                method: 'GET'
-            }).then((response) => {
-                expect(response.status).to.eql(200)
+        TestData.requestMeasureGroup<Array<MeasureGroupBody>>('GET').then((response) => {
+            expect(response.status).to.eql(200)
 
-                const groupWithAddedStrats = response.body[0]
-                groupWithAddedStrats.stratifications = stratificationData as typeof groupWithAddedStrats.stratifications
+            const groupWithAddedStrats = response.body[0]
+            groupWithAddedStrats.stratifications = stratificationData as typeof groupWithAddedStrats.stratifications
 
-                TestData.requestWithAccessToken({
-                    url: `/api/measures/${measureId}/groups`,
-                    method: 'POST',
-                    body: groupWithAddedStrats
-                }).then((updateResponse) => {
-                    cy.log('success start add')
-                    expect(updateResponse.status).to.eql(201)
-                })
+            TestData.requestMeasureGroup('POST', groupWithAddedStrats).then((updateResponse) => {
+                cy.log('success start add')
+                expect(updateResponse.status).to.eql(201)
             })
         })
     }

--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -25,6 +25,7 @@ export type MeasureRow = {
 
 export class MeasuresPage {
     public static readonly measureListTitles = '[data-testid="measure-list-tbl"]'
+    public static readonly measureListRows = '.measures-list tr'
     public static readonly ownedMeasures = '[data-testid="owned-measures-tab"]'
     public static readonly sharedMeasures = '[data-testid="shared-measures-tab"]'
     public static readonly allMeasuresTab = '[data-testid="all-measures-tab"]'
@@ -111,10 +112,26 @@ export class MeasuresPage {
         cy.get(actionSelector).scrollIntoView().should('be.enabled').click()
     }
 
-    public static checkFirstRow(expectedData: MeasureRow) {
-        cy.wait(1100)
+    public static waitForMeasureListRefresh(alias: `@${string}`): Cypress.Chainable<any> {
+        return cy.wait(alias).then((interception) => {
+            expect(interception.response?.statusCode).to.eq(200)
+            return cy
+                .get(this.measureListTitles, { timeout: 30000 })
+                .should('be.visible')
+                .then(() => {
+                    return cy.get(this.measureListRows, { timeout: 30000 }).should(($rows) => {
+                        expect($rows.length, 'measure list rows').to.be.greaterThan(0)
+                    })
+                })
+                .then(() => {
+                    return cy.get(this.measureListRows).first().find('td').eq(1).should('be.visible')
+                })
+                .then(() => interception)
+        })
+    }
 
-        cy.get('.measures-list tr')
+    public static checkFirstRow(expectedData: MeasureRow) {
+        cy.get(this.measureListRows, { timeout: 30000 })
             .first()
             .then((firstRow) => {
                 if (expectedData.name) {

--- a/cypress/Shared/TestCaseBuilder.ts
+++ b/cypress/Shared/TestCaseBuilder.ts
@@ -67,11 +67,9 @@ export class TestCaseBuilder {
 
     public static addEditNewResource(addition: Profile, resourceNumber?: number) {
         let bundleIndex = 0
-        let resourceFixtureName = 'builderResourceId'
         let resourceId = ''
         if (resourceNumber) {
             bundleIndex = resourceNumber
-            resourceFixtureName = `builderResourceId${resourceNumber}`
         }
 
         cy.get('[data-testid="add-element-' + addition + '"]').click().wait(500)
@@ -82,7 +80,7 @@ export class TestCaseBuilder {
 
             resourceId = store.bundle.entry[bundleIndex].resource.id
 
-            TestData.writeFixture(resourceFixtureName, resourceId)
+            TestData.writeBuilderResourceId(resourceId, resourceNumber)
 
             const actionCenterButton = '[data-testid="action-center-button-' + resourceId + '"]'
             const editAction = '[data-testid="action-center-' + resourceId + '_Edit"]'

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -488,7 +488,7 @@ export class TestCasesPage {
         console.log('The element id value is ' + elementId[2])
         cy.log(elementId[2])
         elemid = elementId[2].toString().valueOf()
-        TestData.writeFixture('elementId', elemid)
+        TestData.writeElementId(elemid)
       })
   }
 
@@ -510,7 +510,7 @@ export class TestCasesPage {
         cy.log('The data-testid value is ' + attrData)
         cy.log('The element id value is ' + elemid)
 
-        TestData.writeFixture('elementId', elemid)
+        TestData.writeElementId(elemid)
       })
   }
 
@@ -529,7 +529,7 @@ export class TestCasesPage {
       .invoke('attr', 'data-testid')
       .then((idValue) => {
         testCaseId = idValue!.split('-')[5].toString().valueOf()
-        TestData.writeFixture('testCaseId', testCaseId)
+        TestData.writeTestCaseId(testCaseId)
       })
   }
 
@@ -548,7 +548,7 @@ export class TestCasesPage {
         //saving testCaseId to file to use later
         cy.wait('@testcase', { timeout: 60000 }).then(({ response }) => {
           expect(response?.statusCode).to.eq(201)
-          TestData.writeFixture('testCaseId', response?.body.id)
+          TestData.writeTestCaseId(response?.body.id)
           cy.log(response?.body.message)
         })
       })
@@ -585,7 +585,7 @@ export class TestCasesPage {
   //indicates one of the available actions that can be done on an element(ie: Edit, Clone, Delete)
   //**NOTE**: Before this function can be called, the grabElementId(eleTableEntry) function must be called, first.
   public static qdmTestCaseElementAction(action: string): void {
-    TestData.readFixture('elementId')
+    TestData.readElementId()
       .then((fileContents) => {
         cy.get('[data-testid="action-center-' + fileContents + '"]').scrollIntoView()
         cy.scrollTo(0, 500)
@@ -643,7 +643,7 @@ export class TestCasesPage {
   }
 
   public static compositeTestCaseAddedAction(action: string): void {
-    TestData.readFixture('elementId')
+    TestData.readElementId()
       .then((fileContents) => {
         // Click tooltip first
         cy.get('[data-testid="action-center-tooltip-' + fileContents + '"]')
@@ -762,15 +762,19 @@ export class TestCasesPage {
       cy.get(TestCasesPage.jsonTab).click()
     }
 
+    this.waitForJsonEditorReady()
+    cy.get(TestCasesPage.aceEditorJsonInput)
+      .click({ force: true })
+      .clear({ force: true })
+      .type(testCaseJson, { parseSpecialCharSequences: false, force: true })
+  }
+
+  public static waitForJsonEditorReady(): void {
     Utilities.waitForElementVisible(TestCasesPage.aceEditor, 37700)
     Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
     cy.get(TestCasesPage.aceEditor).should('exist')
     cy.get(TestCasesPage.aceEditor).should('be.visible')
-    cy.get(TestCasesPage.aceEditorJsonInput)
-      .should('exist')
-      .click({ force: true })
-      .clear({ force: true })
-      .type(testCaseJson, { parseSpecialCharSequences: false, force: true })
+    cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
   }
 
   public static updateTestCase(
@@ -838,8 +842,7 @@ export class TestCasesPage {
   ): void {
     const { populationIndex = 0, waitForRunButtonEnabledMs, waitForRunCompletionMs } = options
 
-    Utilities.waitForElementVisible(this.tctExpectedActualSubTab, 35000)
-    cy.get(this.tctExpectedActualSubTab).scrollIntoView().click({ force: true })
+    this.openExpectedActualTab({ checkboxSelector: this.testCaseIPPExpected })
 
     Utilities.waitForElementVisible(this.testCaseIPPExpected, 35000)
     cy.get(this.testCaseIPPExpected).eq(populationIndex).scrollIntoView().check({ force: true })
@@ -873,6 +876,75 @@ export class TestCasesPage {
     cy.get(this.tcHighlightingTab).should('exist')
     cy.get(this.tcHighlightingTab).should('be.visible')
     cy.get(this.tcHighlightingTab).click()
+  }
+
+  public static openExpectedActualTab(options: {
+    checkboxSelector?: string
+  } = {}): void {
+    const { checkboxSelector } = options
+
+    Utilities.waitForElementVisible(this.tctExpectedActualSubTab, 35000)
+    cy.get(this.tctExpectedActualSubTab).should('be.visible').click()
+
+    this.normalizeExpectedActualPopulationPanel()
+
+    if (checkboxSelector) {
+      cy.get(checkboxSelector).should('exist')
+    }
+  }
+
+  public static checkExpectedActualCheckbox(
+    checkboxSelector: string,
+    options: {
+      index?: number
+    } = {},
+  ): void {
+    const { index } = options
+
+    this.normalizeExpectedActualPopulationPanel()
+    const checkbox = cy.get(checkboxSelector)
+
+    if (typeof index === 'number') {
+      checkbox.eq(index).should('exist').check({ scrollBehavior: 'center' })
+      return
+    }
+
+    checkbox.should('exist').check({ scrollBehavior: 'center' })
+  }
+
+  public static uncheckExpectedActualCheckbox(
+    checkboxSelector: string,
+    options: {
+      index?: number
+    } = {},
+  ): void {
+    const { index } = options
+
+    this.normalizeExpectedActualPopulationPanel()
+    const checkbox = cy.get(checkboxSelector)
+
+    if (typeof index === 'number') {
+      checkbox.eq(index).should('exist').uncheck({ scrollBehavior: 'center' })
+      return
+    }
+
+    checkbox.should('exist').uncheck({ scrollBehavior: 'center' })
+  }
+
+  private static normalizeExpectedActualPopulationPanel(): void {
+    Utilities.waitForElementVisible(this.testCasePopulationList, 35000)
+    cy.get(this.testCasePopulationList).should('be.visible')
+
+    cy.get(this.testCasePopulationList).then(($panel) => {
+      const scrollContainers = [
+        $panel[0] as HTMLElement,
+        ...$panel.parents().toArray().map((element) => element as HTMLElement),
+      ].filter((element) => element.scrollWidth > element.clientWidth)
+
+      scrollContainers.forEach((element) => {
+        element.scrollLeft = 0
+      })
+    })
   }
 
   // -----------------------------
@@ -964,7 +1036,7 @@ export class TestCasesPage {
       .click()
       .should('have.attr', 'aria-selected', 'true')
 
-    TestData.readFixture(this.testCaseIdFixtureName(secondTestCase))
+    TestData.readTestCaseId(secondTestCase ? 2 : 0)
       .then((tcId) => {
         const buttonSelector = `[data-testid=view-edit-test-case-button-${tcId}]`
 
@@ -999,35 +1071,34 @@ export class TestCasesPage {
     const user = TestData.setupUserScope(owner)
     cy.log('Current user is: ' + user)
     const resolvedMeasureNumber = this.measureNumber(secondMeasure, measureNumber ?? 0)
-    const testCaseFixtureName = this.testCaseIdFixtureName(twoTestCases)
-    const testCasePatientFixtureName = this.testCasePatientIdFixtureName(twoTestCases)
 
     //Add Test Case to the Measure
-    TestData.readMeasureId(resolvedMeasureNumber, owner).then((id) => {
-      TestData.requestWithAccessToken<any>({
-        url: '/api/measures/' + id + '/test-cases',
-        method: 'POST',
-        body: {
-          name: 'TEST',
-          series: series,
-          title: title,
-          description: description,
-          json: jsonValue,
-          hapiOperationOutcome: {
-            code: 201,
-            message: null,
-            outcomeResponse: null,
-          },
+    TestData.requestMeasureTestCase<any>(
+      'POST',
+      {
+        name: 'TEST',
+        series: series,
+        title: title,
+        description: description,
+        json: jsonValue,
+        hapiOperationOutcome: {
+          code: 201,
+          message: null,
+          outcomeResponse: null,
         },
-      }).then((response) => {
-        expect(response.status).to.eql(201)
-        expect(response.body.id).to.be.exist
-        expect(response.body.series).to.eql(series)
-        expect(response.body.title).to.eql(title)
-        expect(response.body.description).to.eql(description)
-        TestData.writeFixture(testCaseFixtureName, response.body.id, owner)
-        TestData.writeFixture(testCasePatientFixtureName, response.body.patientId, owner)
-      })
+      } as any,
+      {},
+      owner,
+      null,
+      resolvedMeasureNumber
+    ).then((response) => {
+      expect(response.status).to.eql(201)
+      expect(response.body.id).to.be.exist
+      expect(response.body.series).to.eql(series)
+      expect(response.body.title).to.eql(title)
+      expect(response.body.description).to.eql(description)
+      TestData.writeTestCaseId(response.body.id, twoTestCases ? 2 : 0, owner)
+      TestData.writeTestCasePatientId(response.body.patientId, twoTestCases ? 2 : 0, owner)
     })
     return user
   }
@@ -1043,29 +1114,29 @@ export class TestCasesPage {
   ): string {
     const owner = this.fixtureOwner(altUser)
     const user = TestData.setupUserScope(owner)
-    const testCaseFixtureName = this.testCaseIdFixtureName(twoTestCases)
 
     //Add Test Case to the Measure
-    TestData.readMeasureId(measureNumber ?? 0, owner).then((id) => {
-      TestData.requestWithAccessToken<any>({
-        url: '/api/measures/' + id + '/test-cases',
-        method: 'POST',
-        body: {
-          name: 'TEST',
-          series: series,
-          title: title,
-          description: description,
-          json: jsonValue,
-        },
-      }).then((response) => {
-        expect(response.status).to.eql(201)
-        expect(response.body.id).to.be.exist
-        expect(response.body.series).to.eql(series)
-        //expect(response.body.json).to.eql(jsonValue)
-        expect(response.body.title).to.eql(title)
-        expect(response.body.description).to.eql(description)
-        TestData.writeFixture(testCaseFixtureName, response.body.id, owner)
-      })
+    TestData.requestMeasureTestCase<any>(
+      'POST',
+      {
+        name: 'TEST',
+        series: series,
+        title: title,
+        description: description,
+        json: jsonValue,
+      },
+      {},
+      owner,
+      null,
+      measureNumber ?? 0
+    ).then((response) => {
+      expect(response.status).to.eql(201)
+      expect(response.body.id).to.be.exist
+      expect(response.body.series).to.eql(series)
+      //expect(response.body.json).to.eql(jsonValue)
+      expect(response.body.title).to.eql(title)
+      expect(response.body.description).to.eql(description)
+      TestData.writeTestCaseId(response.body.id, twoTestCases ? 2 : 0, owner)
     })
     return user
   }

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -883,14 +883,15 @@ export class TestCasesPage {
   } = {}): void {
     const { checkboxSelector } = options
 
-    Utilities.waitForElementVisible(this.tctExpectedActualSubTab, 35000)
-    cy.get(this.tctExpectedActualSubTab).should('be.visible').click()
-
-    this.normalizeExpectedActualPopulationPanel()
+    cy.get(this.tctExpectedActualSubTab, { timeout: 35000 }).should('exist').scrollIntoView().should('be.visible').click()
 
     if (checkboxSelector) {
       cy.get(checkboxSelector).should('exist')
     }
+
+    this.normalizeExpectedActualPopulationPanel({
+      requirePanel: !checkboxSelector,
+    })
   }
 
   public static checkExpectedActualCheckbox(
@@ -912,6 +913,25 @@ export class TestCasesPage {
     checkbox.should('exist').check({ scrollBehavior: 'center' })
   }
 
+  public static clickExpectedActualCheckbox(
+    checkboxSelector: string,
+    options: {
+      index?: number
+    } = {},
+  ): void {
+    const { index } = options
+
+    this.normalizeExpectedActualPopulationPanel()
+    const checkbox = cy.get(checkboxSelector)
+
+    if (typeof index === 'number') {
+      checkbox.eq(index).should('exist').should('be.visible').click({ scrollBehavior: 'center' })
+      return
+    }
+
+    checkbox.should('exist').should('be.visible').click({ scrollBehavior: 'center' })
+  }
+
   public static uncheckExpectedActualCheckbox(
     checkboxSelector: string,
     options: {
@@ -931,11 +951,23 @@ export class TestCasesPage {
     checkbox.should('exist').uncheck({ scrollBehavior: 'center' })
   }
 
-  private static normalizeExpectedActualPopulationPanel(): void {
-    Utilities.waitForElementVisible(this.testCasePopulationList, 35000)
-    cy.get(this.testCasePopulationList).should('be.visible')
+  private static normalizeExpectedActualPopulationPanel(options: {
+    requirePanel?: boolean
+  } = {}): void {
+    const { requirePanel = false } = options
 
-    cy.get(this.testCasePopulationList).then(($panel) => {
+    if (requirePanel) {
+      Utilities.waitForElementVisible(this.testCasePopulationList, 35000)
+    }
+
+    cy.get('body').then(($body) => {
+      const panel = $body.find(this.testCasePopulationList)
+
+      if (!panel.length) {
+        return
+      }
+
+      cy.get(this.testCasePopulationList).should('be.visible').then(($panel) => {
       const scrollContainers = [
         $panel[0] as HTMLElement,
         ...$panel.parents().toArray().map((element) => element as HTMLElement),
@@ -943,6 +975,7 @@ export class TestCasesPage {
 
       scrollContainers.forEach((element) => {
         element.scrollLeft = 0
+      })
       })
     })
   }

--- a/cypress/Shared/TestData.ts
+++ b/cypress/Shared/TestData.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { OktaLogin } from './OktaLogin'
+import { Environment } from './Environment'
 
 export type FixtureOwner = 'selectedUser' | 'selectedAltUser'
 export type TestUserScope = FixtureOwner
@@ -94,6 +95,8 @@ export type TestCaseImportResponse = {
         message?: string
     }>
 }
+
+export type ShareableMadieObject = 'measure' | 'library'
 
 export type MeasureDraftBody = {
     measureSetId?: string
@@ -200,6 +203,14 @@ export class TestData {
         return cy.writeFile(this.fixturePath(name, owner), value)
     }
 
+    public static readElementId(owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<string> {
+        return this.readFixture('elementId', owner)
+    }
+
+    public static writeElementId(value: string, owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<null> {
+        return this.writeFixture('elementId', value, owner)
+    }
+
     public static measureIdPath(measureNumber = 0, owner: FixtureOwner = 'selectedUser'): string {
         const suffix = measureNumber > 0 ? measureNumber : ''
         return this.fixturePath(`measureId${suffix}`, owner)
@@ -218,17 +229,61 @@ export class TestData {
         return cy.readFile(this.cqlLibraryIdPath(libraryNumber, owner)).should('exist')
     }
 
+    public static writeCqlLibraryId(
+        value: string,
+        libraryNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<null> {
+        return this.writeFixture(`cqlLibraryId${libraryNumber > 0 ? libraryNumber : ''}`, value, owner)
+    }
+
     public static testCaseIdPath(testCaseNumber = 0, owner: FixtureOwner = 'selectedUser'): string {
         const suffix = testCaseNumber > 0 ? testCaseNumber : ''
         return this.fixturePath(`testCaseId${suffix}`, owner)
+    }
+
+    public static builderResourceIdFixtureName(resourceNumber = 0): string {
+        const suffix = resourceNumber > 0 ? resourceNumber : ''
+        return `builderResourceId${suffix}`
     }
 
     public static readTestCaseId(testCaseNumber = 0, owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<string> {
         return cy.readFile(this.testCaseIdPath(testCaseNumber, owner)).should('exist')
     }
 
+    public static writeTestCaseId(
+        value: string,
+        testCaseNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<null> {
+        return this.writeFixture(`testCaseId${testCaseNumber > 0 ? testCaseNumber : ''}`, value, owner)
+    }
+
+    public static readBuilderResourceId(
+        resourceNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<string> {
+        return this.readFixture(this.builderResourceIdFixtureName(resourceNumber), owner)
+    }
+
+    public static writeBuilderResourceId(
+        value: string,
+        resourceNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<null> {
+        return this.writeFixture(this.builderResourceIdFixtureName(resourceNumber), value, owner)
+    }
+
     public static readTestCasePatientId(owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<string> {
         return this.readFixture('testCasePId', owner)
+    }
+
+    public static writeTestCasePatientId(
+        value: string,
+        testCaseNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<null> {
+        return this.writeFixture(`testCasePId${testCaseNumber > 0 ? testCaseNumber : ''}`, value, owner)
     }
 
     public static readMeasureSetId(owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<string> {
@@ -248,8 +303,21 @@ export class TestData {
         })
     }
 
+    public static measureGroupIdPath(groupNumber = 0, owner: FixtureOwner = 'selectedUser'): string {
+        const suffix = groupNumber > 0 ? groupNumber : ''
+        return this.fixturePath(`groupId${suffix}`, owner)
+    }
+
     public static readMeasureGroupId(owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<string> {
         return this.readFixture('groupId', owner)
+    }
+
+    public static writeMeasureGroupId(
+        value: string,
+        groupNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<null> {
+        return this.writeFixture(`groupId${groupNumber > 0 ? groupNumber : ''}`, value, owner)
     }
 
     public static readStratificationId(owner: FixtureOwner = 'selectedUser'): Cypress.Chainable<string> {
@@ -307,6 +375,18 @@ export class TestData {
         } as MeasureBody
     }
 
+    public static writeMeasureContext(
+        measure: Pick<MeasureBody, 'id' | 'versionId' | 'measureSetId'>,
+        measureNumber = 0,
+        owner: FixtureOwner = 'selectedUser'
+    ): void {
+        const suffix = measureNumber > 0 ? measureNumber : ''
+
+        this.writeFixture(`measureId${suffix}`, measure.id ?? '', owner)
+        this.writeFixture(`versionId${suffix}`, measure.versionId ?? '', owner)
+        this.writeFixture(`measureSetId${suffix}`, measure.measureSetId ?? '', owner)
+    }
+
     public static cqlLibraryBody(body: Partial<CqlLibraryBody>): CqlLibraryBody {
         return {
             librarySetId: uuidv4(),
@@ -322,6 +402,18 @@ export class TestData {
         return this.requestWithAccessToken<T>({
             ...options,
             url: '/api/measure',
+            method: 'POST',
+            body: this.measureBody(body)
+        })
+    }
+
+    public static requestMeasureCreate<T = any>(
+        body: Partial<MeasureBody>,
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<T>> {
+        return this.requestWithAccessToken<T>({
+            ...options,
+            url: '/api/measure?addDefaultCQL=false',
             method: 'POST',
             body: this.measureBody(body)
         })
@@ -693,24 +785,18 @@ export class TestData {
     }
 
     public static requestMeasureGroup<T = MeasureGroupBody>(
-        method: 'POST' | 'PUT',
-        body: MeasureGroupBody,
+        method: 'GET' | 'POST' | 'PUT',
+        body?: MeasureGroupBody,
         measureNumber = 0,
         options: Partial<Cypress.RequestOptions> = {},
         owner: FixtureOwner = 'selectedUser'
     ): Cypress.Chainable<Cypress.Response<T>> {
-        return this.withAccessToken((accessToken) => {
-            return this.readMeasureId(measureNumber, owner).then((measureId) => {
-                return cy.request({
-                    ...options,
-                    url: `/api/measures/${measureId}/groups`,
-                    method,
-                    headers: {
-                        ...options.headers,
-                        authorization: `Bearer ${accessToken}`
-                    },
-                    body: this.measureGroupBody(measureId, body)
-                })
+        return this.readMeasureId(measureNumber, owner).then((measureId) => {
+            return this.requestWithAccessToken<T>({
+                ...options,
+                url: `/api/measures/${measureId}/groups`,
+                method,
+                ...(body ? { body: this.measureGroupBody(measureId, body) } : {})
             })
         }) as Cypress.Chainable<Cypress.Response<T>>
     }
@@ -827,14 +913,88 @@ export class TestData {
         })
     }
 
+    public static requestTestCaseLock(
+        lockObject: boolean,
+        options: Partial<Cypress.RequestOptions> = {},
+        owner: FixtureOwner = 'selectedUser',
+        measureNumber = 0,
+        testCaseNumber = 0
+    ): Cypress.Chainable<Cypress.Response<any>> {
+        return this.readMeasureId(measureNumber, owner).then((measureId) => {
+            return this.readTestCaseId(testCaseNumber, owner).then((testCaseId) => {
+                const url = lockObject
+                    ? `/api/measures/${measureId}/test-cases/${testCaseId}/lock`
+                    : `/api/test-cases/${testCaseId}/unlock`
+
+                return this.requestWithAccessToken<any>({
+                    ...options,
+                    url,
+                    method: 'POST'
+                })
+            })
+        })
+    }
+
+    public static requestCqlLibraryLock(
+        method: 'PUT' | 'DELETE',
+        libraryNumber = 0,
+        options: Partial<Cypress.RequestOptions> = {},
+        owner: FixtureOwner = 'selectedUser'
+    ): Cypress.Chainable<Cypress.Response<any>> {
+        return this.readCqlLibraryId(libraryNumber, owner).then((libraryId) => {
+            return this.requestWithAccessToken<any>({
+                ...options,
+                url: `/api/cql-libraries/${libraryId}/lock`,
+                method
+            })
+        })
+    }
+
+    public static requestUnlockAll(
+        type: 'measures' | 'cql-libraries',
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<any>> {
+        return this.requestWithAccessToken<any>({
+            ...options,
+            url: `/api/${type}/unlock`,
+            method: 'DELETE'
+        })
+    }
+
+    public static requestSharePermissions(
+        objectType: ShareableMadieObject,
+        action: 'GRANT' | 'REVOKE',
+        madieId: string,
+        user: string,
+        options: Partial<Cypress.RequestOptions> = {}
+    ): Cypress.Chainable<Cypress.Response<any>> {
+        const url =
+            objectType === 'library'
+                ? `/api/cql-libraries/${action === 'GRANT' ? 'share' : 'unshare'}`
+                : `/api/measures/${action === 'GRANT' ? 'shared' : 'unshared'}`
+
+        return this.requestWithAccessToken<any>({
+            failOnStatusCode: false,
+            ...options,
+            url,
+            method: 'PUT',
+            headers: {
+                'api-key': Environment.credentials().adminApiKey,
+                ...options.headers
+            },
+            body: { [madieId]: [user] }
+        })
+    }
+
     public static requestMeasureTestCase<T = TestCaseBody>(
         method: 'POST' | 'GET' | 'PUT' | 'DELETE',
         body?: TestCaseBody | ((context: TestCaseRequestContext) => TestCaseBody),
         options: Partial<Cypress.RequestOptions> = {},
         owner: FixtureOwner = 'selectedUser',
-        testCaseNumber: number | null = 0
+        testCaseNumber: number | null = 0,
+        measureNumber = 0
     ): Cypress.Chainable<Cypress.Response<T>> {
-        return this.readMeasureId(0, owner).then((measureId) => {
+        return this.readMeasureId(measureNumber, owner).then((measureId) => {
             const requestTestCase = (testCaseId?: string) => {
                 const requestBody =
                     typeof body === 'function' ? body({ measureId, testCaseId }) : body

--- a/cypress/Shared/Utilities.ts
+++ b/cypress/Shared/Utilities.ts
@@ -388,17 +388,12 @@ export class Utilities {
         }
 
         readId().then((madieId) => {
-            TestData.requestWithAccessToken({
-                failOnStatusCode: false,
-                url: '/api/' + urlPath,
-                headers: {
-                    'api-key': adminApiKey
-                },
-                method: 'PUT',
-                body: { [madieId]: [user] }
-                // Note: these brackets don't make this an array.
-                // This syntax is needed for keys of an object to force it to honor the value
-            }).then((response) => {
+            TestData.requestSharePermissions(
+                objectType === MadieObject.Library ? 'library' : 'measure',
+                action,
+                madieId,
+                user
+            ).then((response) => {
                 console.log(response)
                 expect(response.status).to.eql(200)
                 if (action === PermissionActions.GRANT) {
@@ -449,15 +444,13 @@ export class Utilities {
     }
 
     public static lockControl(type: MadieObject, lockObject: boolean, altUser?: boolean) {
-        let action = 'PUT'
-        if (!lockObject) {
-            action = 'DELETE'
-        }
-
         if (altUser === undefined || altUser === null) {
             altUser = false
         }
-        OktaLogin.setupUserSession(altUser)
+        const owner: FixtureOwner = altUser ? 'selectedAltUser' : 'selectedUser'
+        const action = lockObject ? 'PUT' : 'DELETE'
+
+        TestData.setupUserScope(owner)
 
         switch (type) {
             case MadieObject.Measure:
@@ -467,30 +460,14 @@ export class Utilities {
                 break
 
             case MadieObject.TestCase:
-                TestData.readMeasureId().then((measureId) => {
-                    TestData.readTestCaseId().then((tcId) => {
-                        const lockUrl = lockObject
-                            ? `/api/measures/${measureId}/test-cases/${tcId}/lock`
-                            : `/api/test-cases/${tcId}/unlock`
-
-                        TestData.requestWithAccessToken({
-                            url: lockUrl,
-                            method: 'POST'
-                        }).then((response) => {
-                            expect(response.status).to.eql(200)
-                        })
-                    })
+                TestData.requestTestCaseLock(lockObject, {}, owner).then((response) => {
+                    expect(response.status).to.eql(200)
                 })
                 break
 
             case MadieObject.Library:
-                TestData.readCqlLibraryId().then((id) => {
-                    TestData.requestWithAccessToken({
-                        url: '/api/cql-libraries/' + id + '/lock',
-                        method: action as 'PUT' | 'DELETE'
-                    }).then((response) => {
-                        expect(response.status).to.eql(200)
-                    })
+                TestData.requestCqlLibraryLock(action as 'PUT' | 'DELETE', 0, {}, owner).then((response) => {
+                    expect(response.status).to.eql(200)
                 })
                 break
 
@@ -504,7 +481,7 @@ export class Utilities {
             altUser = false
         }
 
-        OktaLogin.setupUserSession(altUser)
+        TestData.setupUserScope(altUser ? 'selectedAltUser' : 'selectedUser')
 
         harpUser = OktaLogin.getUser(false)
         harpUserALT = OktaLogin.getUser(true)
@@ -512,10 +489,7 @@ export class Utilities {
         switch (type) {
             case MadieObject.Measure:
                 TestData.readMeasureId().then((measureId) => {
-                    TestData.requestWithAccessToken({
-                        url: '/api/measures/unlock',
-                        method: 'DELETE'
-                    }).then((response) => {
+                    TestData.requestUnlockAll('measures').then((response) => {
                         expect(response.status).to.eql(200)
                         if (altUser) {
                             expect(response.body[0]).to.include(
@@ -552,10 +526,7 @@ export class Utilities {
 
             case MadieObject.Library:
                 TestData.readCqlLibraryId().then((id) => {
-                    TestData.requestWithAccessToken({
-                        url: '/api/cql-libraries/unlock',
-                        method: 'DELETE'
-                    }).then((response) => {
+                    TestData.requestUnlockAll('cql-libraries').then((response) => {
                         expect(response.status).to.eql(200)
                         if (altUser) {
                             expect(response.body[0]).to.include(

--- a/cypress/e2e/Services/Measure Service/Measure.cy.ts
+++ b/cypress/e2e/Services/Measure Service/Measure.cy.ts
@@ -24,6 +24,10 @@ const mpEndDate = now().format('YYYY-MM-DD')
 const measureCQL = MeasureCQL.SBTEST_CQL
 const eCQMTitle = 'eCQMTitle'
 const randValue = Math.floor(Math.random() * 1000 + 1)
+const cqlLibraryNameValidationError =
+    'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+const rejectedMeasureNameInputs = ['Test<abc>', 'Test{abc}', '%7Bbase%7D*1', '%7Bbase%7D-0']
+const rejectedCqlLibraryNameInputs = ['Test<abc>', 'Test{abc}', 'Test!@#%$^&', '%7Bbase%7D*1', '%7Bbase%7D-0']
 const measureValidationBody = (overrides: Partial<MeasureBody> = {}): Partial<MeasureBody> => ({
     measureName: 'TestMeasure' + Date.now() + randValue,
     cqlLibraryName: 'TestCql' + Date.now() + randValue,
@@ -247,6 +251,29 @@ describe('Measure Service: Error validations', () => {
         })
     })
 
+    rejectedMeasureNameInputs.forEach((invalidMeasureName) => {
+        it(`Validation Error: Measure Name rejects ${invalidMeasureName}`, () => {
+            CQLLibraryName = 'TestCql' + Date.now()
+
+            TestData.requestMeasure(
+                {
+                    measureName: invalidMeasureName,
+                    cqlLibraryName: CQLLibraryName,
+                    model,
+                    ecqmTitle: eCQMTitle,
+                    measurementPeriodStart: mpStartDate,
+                    measurementPeriodEnd: mpEndDate
+                },
+                { failOnStatusCode: false }
+            ).then((response) => {
+                expect(response.status).to.eql(400)
+                expect(response.body.id).to.not.exist
+                expect(response.body.validationErrors).to.exist
+                expect(response.body.validationErrors.measureName ?? response.body.validationErrors.measure).to.exist
+            })
+        })
+    })
+
     it('Validation Error: Measure Name contains more than 500 characters', () => {
         measureName =
             'qwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwertyqwerty' +
@@ -328,7 +355,7 @@ describe('Measure Service: CQL Library name validations', () => {
             expect(response.status).to.eql(400)
             console.log('validations errors were:\n' + response.body.validationErrors.measure.toString())
             expect(response.body.validationErrors.measure).to.eql(
-                'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+                cqlLibraryNameValidationError
             )
         })
     })
@@ -341,7 +368,7 @@ describe('Measure Service: CQL Library name validations', () => {
             expect(response.status).to.eql(400)
             console.log('validations errors were:\n' + response.body.validationErrors.measure.toString())
             expect(response.body.validationErrors.measure).to.eql(
-                'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+                cqlLibraryNameValidationError
             )
         })
     })
@@ -354,10 +381,25 @@ describe('Measure Service: CQL Library name validations', () => {
             expect(response.status).to.eql(400)
             console.log('validations errors were:\n' + response.body.validationErrors.measure.toString())
             expect(response.body.validationErrors.measure).to.eql(
-                'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+                cqlLibraryNameValidationError
             )
         })
     })
+
+    rejectedCqlLibraryNameInputs
+        .filter((invalidCqlLibraryName) => invalidCqlLibraryName !== 'Test!@#%$^&')
+        .forEach((invalidCqlLibraryName) => {
+            it(`Validation Error: CQL library Name rejects ${invalidCqlLibraryName}`, () => {
+                TestData.requestMeasure(measureValidationBody({
+                    measureName: 'test',
+                    cqlLibraryName: invalidCqlLibraryName
+                }), { failOnStatusCode: false }).then((response) => {
+                    expect(response.status).to.eql(400)
+                    expect(response.body.id).to.not.exist
+                    expect(response.body.validationErrors.measure).to.eql(cqlLibraryNameValidationError)
+                })
+            })
+        })
 
     it('Validation Error: CQL library Name empty', () => {
         TestData.requestMeasure(measureValidationBody({
@@ -377,7 +419,7 @@ describe('Measure Service: CQL Library name validations', () => {
             expect(response.status).to.eql(400)
             console.log('validations errors were:\n' + response.body.validationErrors.measure.toString())
             expect(response.body.validationErrors.measure).to.eql(
-                'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+                cqlLibraryNameValidationError
             )
         })
     })
@@ -390,7 +432,7 @@ describe('Measure Service: CQL Library name validations', () => {
             expect(response.status).to.eql(400)
             console.log('validations errors were:\n' + response.body.validationErrors.measure.toString())
             expect(response.body.validationErrors.measure).to.eql(
-                'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+                cqlLibraryNameValidationError
             )
         })
     })
@@ -403,7 +445,7 @@ describe('Measure Service: CQL Library name validations', () => {
             expect(response.status).to.eql(400)
             console.log('validations errors were:\n' + response.body.validationErrors.measure.toString())
             expect(response.body.validationErrors.measure).to.eql(
-                'Library name must start with an upper case letter, followed by alpha-numeric character(s) and must not contain spaces or other special characters except of underscore for QDM.'
+                cqlLibraryNameValidationError
             )
         })
     })

--- a/cypress/e2e/WebInterface/CQL Library/CQLLibraryListPageColumnSort.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CQLLibraryListPageColumnSort.cy.ts
@@ -50,13 +50,11 @@ describe('CQL Library List Page Sort by Columns', () => {
 
         // sort by Library ASC
         cy.get(CQLLibrariesPage.hdrLibrary).click()
-        cy.wait('@sort')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort')
             cy.get('.table-body tr').first().find('td').eq(1).invoke('text').then(ascName => {
             // sort by Library DESC
             cy.get(CQLLibrariesPage.hdrLibrary).click()
-            cy.wait('@sort2')
-            cy.wait(1100)
+            CQLLibrariesPage.waitForLibraryListRefresh('@sort2')
             cy.get('.table-body tr').first().find('td').eq(1).invoke('text').then(descName => {
                 // ASC first name should come before DESC first name alphabetically
                 expect(ascName.toLowerCase().localeCompare(descName.toLowerCase())).to.be.lessThan(0)
@@ -65,13 +63,11 @@ describe('CQL Library List Page Sort by Columns', () => {
 
         // sort by Version ASC
         cy.get(CQLLibrariesPage.hdrVersion).click()
-        cy.wait('@sort3')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort3')
         cy.get('.table-body tr').first().find('td').eq(2).invoke('text').then(ascVersion => {
             // sort by Version DESC
             cy.get(CQLLibrariesPage.hdrVersion).click()
-            cy.wait('@sort4')
-            cy.wait(1100)
+            CQLLibrariesPage.waitForLibraryListRefresh('@sort4')
             cy.get('.table-body tr').first().find('td').eq(2).invoke('text').then(descVersion => {
                 // ASC and DESC should produce different first versions
                 expect(ascVersion).to.not.equal(descVersion)
@@ -80,29 +76,39 @@ describe('CQL Library List Page Sort by Columns', () => {
 
         // sort by Status ASC
         cy.get(CQLLibrariesPage.hdrStatus).click()
-        cy.wait('@sort5')
-        cy.wait(1100)
-        cy.get('.table-body tr').first().find('td').eq(3).invoke('text').then(ascStatus => {
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort5').then(({ response }) => {
+            const ascExpectedDraft = Boolean(response?.body?.content?.[0]?.draft)
+
+            cy.get('.table-body tr').first().find('td').eq(3).invoke('text').then(ascStatus => {
+                if (ascExpectedDraft) {
+                    expect(ascStatus.trim()).to.include('Draft')
+                } else {
+                    expect(ascStatus.trim()).to.eq('')
+                }
+
             // sort by Status DESC
-            cy.get(CQLLibrariesPage.hdrStatus).click()
-            cy.wait('@sort6')
-            cy.wait(1100)
-            cy.get('.table-body tr').first().find('td').eq(3).invoke('text').then(descStatus => {
-                // At least one of the two should show 'Draft'
-                const hasDraft = ascStatus === 'Draft' || descStatus === 'Draft'
-                expect(hasDraft).to.be.true
+                cy.get(CQLLibrariesPage.hdrStatus).click()
+                CQLLibrariesPage.waitForLibraryListRefresh('@sort6').then(({ response: descResponse }) => {
+                    const descExpectedDraft = Boolean(descResponse?.body?.content?.[0]?.draft)
+
+                    cy.get('.table-body tr').first().find('td').eq(3).invoke('text').then(descStatus => {
+                        if (descExpectedDraft) {
+                            expect(descStatus.trim()).to.include('Draft')
+                        } else {
+                            expect(descStatus.trim()).to.eq('')
+                        }
+                    })
+                })
             })
         })
 
         // sort by Model ASC
         cy.get(CQLLibrariesPage.hdrModel).click()
-        cy.wait('@sort7')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort7')
         cy.get('.table-body tr').first().find('td').eq(4).invoke('text').then(ascModel => {
             // sort by Model DESC
             cy.get(CQLLibrariesPage.hdrModel).click()
-            cy.wait('@sort8')
-            cy.wait(1100)
+            CQLLibrariesPage.waitForLibraryListRefresh('@sort8')
             cy.get('.table-body tr').first().find('td').eq(4).invoke('text').then(descModel => {
                 // ASC and DESC should produce different first models
                 expect(ascModel).to.not.equal(descModel)
@@ -113,23 +119,19 @@ describe('CQL Library List Page Sort by Columns', () => {
 
         // sort by Shared ASC
         cy.get(CQLLibrariesPage.hdrShared).click()
-        cy.wait('@sort9')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort9')
         // sort by Shared DESC - verify the shared icon appears on the first row
         cy.get(CQLLibrariesPage.hdrShared).click()
-        cy.wait('@sort10')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort10')
         cy.get('.table-body tr').first().find('td').eq(5).find('[data-testid="CheckCircleOutlineIcon"]').should('exist')
 
         // sort by Updated ASC - oldest first
         cy.get(CQLLibrariesPage.hdrUpdated).click()
-        cy.wait('@sort11')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort11')
         cy.get('.table-body tr').first().find('td').eq(7).invoke('text').then(ascDate => {
             // sort by Updated DESC - newest first
             cy.get(CQLLibrariesPage.hdrUpdated).click()
-            cy.wait('@sort12')
-            cy.wait(1100)
+            CQLLibrariesPage.waitForLibraryListRefresh('@sort12')
             cy.get('.table-body tr').first().find('td').eq(7).invoke('text').then(descDate => {
                 // Verify sorting changed the order
                 const ascParsed = dayjs(ascDate, 'M/D/YYYY')
@@ -162,8 +164,7 @@ describe('CQL Library List Page Sort by Columns', () => {
 
         // sort by model ASC
         cy.get(CQLLibrariesPage.hdrModel).click()
-        cy.wait('@sort')
-        cy.wait(1100)
+        CQLLibrariesPage.waitForLibraryListRefresh('@sort')
         cy.get('.table-body tr').first().find('td').eq(4).invoke('text').then(ascModel => {
 
             // verify page 1
@@ -181,8 +182,7 @@ describe('CQL Library List Page Sort by Columns', () => {
 
             // sort by model DESC to reset
             cy.get(CQLLibrariesPage.hdrModel).click()
-            cy.wait('@sort2')
-            cy.wait(1100)
+            CQLLibrariesPage.waitForLibraryListRefresh('@sort2')
             cy.get('.table-body tr').first().find('td').eq(4).invoke('text').then(descModel => {
                 // ASC and DESC should produce different first models
                 expect(ascModel).to.not.equal(descModel)

--- a/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measure Group/MeasureObservations.cy.ts
@@ -561,6 +561,7 @@ describe('Measure Observation - Expected Values', () => {
         //wait for alert / successful save message to appear
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 20700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.collapseEditor()
 
         //Click on the measure group tab
         Utilities.waitForElementVisible(EditMeasurePage.measureGroupsTab, 11700)
@@ -611,10 +612,9 @@ describe('Measure Observation - Expected Values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check()
+
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Verify Measure Observation row is added
@@ -623,15 +623,15 @@ describe('Measure Observation - Expected Values', () => {
         //Check Measure Population Exclusion and verify Observation row goes away
         cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLEXExpected)
+        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('be.checked')
         cy.get(TestCasesPage.measureObservationRow).should('not.exist')
 
         //Uncheck Measure Population Exclusion and verify Observation row re appears
         cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).uncheck().should('not.be.checked')
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLEXExpected)
+        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).should('not.be.checked')
         cy.get(TestCasesPage.measureObservationRow).should('exist')
     })
 
@@ -687,12 +687,10 @@ describe('Measure Observation - Expected Values', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         //Verify Numerator and Denominator Observation rows are added
@@ -702,40 +700,44 @@ describe('Measure Observation - Expected Values', () => {
         //Check Denominator Exclusion and verify Denominator Observation row goes away
         cy.get(TestCasesPage.testCaseDENEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseDENEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENEXExpected)
+        cy.get(TestCasesPage.testCaseDENEXExpected).should('be.checked')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('not.exist')
 
         //Uncheck Denominator Exclusion and verify Denominator Observation row re appears
         cy.get(TestCasesPage.testCaseDENEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseDENEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENEXExpected).uncheck().should('not.be.checked')
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseDENEXExpected)
+        cy.get(TestCasesPage.testCaseDENEXExpected).should('not.be.checked')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
 
         //Check Numerator Exclusion and verify Numerator Observation row goes away
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
+        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.checked')
         cy.get(TestCasesPage.numeratorObservationRow).should('not.exist')
 
         //Uncheck Numerator Exclusion and verify Numerator Observation row re appears
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).uncheck().should('not.be.checked')
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
+        cy.get(TestCasesPage.testCaseNUMEXExpected).should('not.be.checked')
         cy.get(TestCasesPage.numeratorObservationRow).should('exist')
 
         //Check Numerator & Denominator Exclusion and verify Numerator & Denominator Observation rows goes away
-        cy.get(TestCasesPage.testCaseNUMEXExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
+        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENEXExpected)
+        cy.get(TestCasesPage.testCaseDENEXExpected).should('be.checked')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('not.exist')
         cy.get(TestCasesPage.numeratorObservationRow).should('not.exist')
 
         //Uncheck Numerator & Denominator Exclusion and verify Numerator & Denominator Observation rows re appear
-        cy.get(TestCasesPage.testCaseNUMEXExpected).uncheck().should('not.be.checked')
-        cy.get(TestCasesPage.testCaseDENEXExpected).uncheck().should('not.be.checked')
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
+        cy.get(TestCasesPage.testCaseNUMEXExpected).should('not.be.checked')
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseDENEXExpected)
+        cy.get(TestCasesPage.testCaseDENEXExpected).should('not.be.checked')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
         cy.get(TestCasesPage.numeratorObservationRow).should('exist')
     })

--- a/cypress/e2e/WebInterface/Measure/Measures List/MeasureListNewColumnsSort.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Measures List/MeasureListNewColumnsSort.cy.ts
@@ -50,13 +50,11 @@ describe('Measure List Page Sort by Columns', () => {
 
         //sort by measure name ASC
         cy.contains('.header-button', 'Measure').click()
-        cy.wait('@sort')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort')
         cy.get('.measures-list tr').first().find('td').eq(1).invoke('text').then(ascName => {
             // sort by measure name DESC
             cy.contains('.header-button', 'Measure').click()
-            cy.wait('@sort2')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort2')
             cy.get('.measures-list tr').first().find('td').eq(1).invoke('text').then(descName => {
                 // ASC first name should come before DESC first name alphabetically
                 expect(ascName.toLowerCase().localeCompare(descName.toLowerCase())).to.be.lessThan(0)
@@ -65,13 +63,11 @@ describe('Measure List Page Sort by Columns', () => {
 
         // sort by version ASC
         cy.contains('.header-button', 'Version').click()
-        cy.wait('@sort3')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort3')
         cy.get('.measures-list tr').first().find('td').eq(2).invoke('text').then(ascVersion => {
             // sort by version DESC
             cy.contains('.header-button', 'Version').click()
-            cy.wait('@sort4')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort4')
             cy.get('.measures-list tr').first().find('td').eq(2).invoke('text').then(descVersion => {
                 // ASC first version should differ from DESC first version
                 expect(ascVersion).to.not.equal(descVersion)
@@ -80,29 +76,39 @@ describe('Measure List Page Sort by Columns', () => {
 
         // sort by status ASC
         cy.contains('.header-button', 'Status').click()
-        cy.wait('@sort13')
-        cy.wait(1100)
-        cy.get('.measures-list tr').first().find('td').eq(3).invoke('text').then(ascStatus => {
+        MeasuresPage.waitForMeasureListRefresh('@sort13').then(({ response }) => {
+            const ascExpectedDraft = Boolean(response?.body?.content?.[0]?.measureMetaData?.draft)
+
+            cy.get('.measures-list tr').first().find('td').eq(3).invoke('text').then(ascStatus => {
+                if (ascExpectedDraft) {
+                    expect(ascStatus.trim()).to.include('Draft')
+                } else {
+                    expect(ascStatus.trim()).to.eq('')
+                }
+
             // sort by status DESC
-            cy.contains('.header-button', 'Status').click()
-            cy.wait('@sort14')
-            cy.wait(1100)
-            cy.get('.measures-list tr').first().find('td').eq(3).invoke('text').then(descStatus => {
-                // At least one of the two should show 'Draft'
-                const hasDraft = ascStatus === 'Draft' || descStatus === 'Draft'
-                expect(hasDraft).to.be.true
+                cy.contains('.header-button', 'Status').click()
+                MeasuresPage.waitForMeasureListRefresh('@sort14').then(({ response: descResponse }) => {
+                    const descExpectedDraft = Boolean(descResponse?.body?.content?.[0]?.measureMetaData?.draft)
+
+                    cy.get('.measures-list tr').first().find('td').eq(3).invoke('text').then(descStatus => {
+                        if (descExpectedDraft) {
+                            expect(descStatus.trim()).to.include('Draft')
+                        } else {
+                            expect(descStatus.trim()).to.eq('')
+                        }
+                    })
+                })
             })
         })
 
         // sort by model ASC
         cy.contains('.header-button', 'Model').click()
-        cy.wait('@sort5')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort5')
         cy.get('.measures-list tr').first().find('td').eq(4).invoke('text').then(ascModel => {
             // sort by model DESC
             cy.contains('.header-button', 'Model').click()
-            cy.wait('@sort6')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort6')
             cy.get('.measures-list tr').first().find('td').eq(4).invoke('text').then(descModel => {
                 // ASC and DESC should produce different first models
                 expect(ascModel).to.not.equal(descModel)
@@ -113,23 +119,19 @@ describe('Measure List Page Sort by Columns', () => {
 
         // sort by shared ASC
         cy.contains('.header-button', 'Shared').click()
-        cy.wait('@sort7')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort7')
         // sort by shared DESC - verify the shared icon appears on the first row
         cy.contains('.header-button', 'Shared').click()
-        cy.wait('@sort8')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort8')
         cy.get('.measures-list tr').first().find('td').eq(5).find('[data-testid="CheckCircleOutlineIcon"]').should('exist')
 
         // sort by cms id ASC - empty/null values first
         cy.contains('.header-button', 'CMS ID').click()
-        cy.wait('@sort9')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort9')
         cy.get('.measures-list tr').first().find('td').eq(6).invoke('text').then(ascCmsId => {
             // sort by cms id DESC - highest values first
             cy.contains('.header-button', 'CMS ID').click()
-            cy.wait('@sort10')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort10')
             cy.get('.measures-list tr').first().find('td').eq(6).invoke('text').then(descCmsId => {
                 // ASC should start empty or with a lower ID, DESC should have a value
                 // At minimum, the two sort orders should produce different first rows
@@ -141,13 +143,11 @@ describe('Measure List Page Sort by Columns', () => {
 
         // sort by updated ASC - oldest first
         cy.contains('.header-button', 'Updated').click()
-        cy.wait('@sort11')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort11')
         cy.get('.measures-list tr').first().find('td').eq(8).invoke('text').then(ascDate => {
             // sort by updated DESC - newest first
             cy.contains('.header-button', 'Updated').click()
-            cy.wait('@sort12')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort12')
             cy.get('.measures-list tr').first().find('td').eq(8).invoke('text').then(descDate => {
                 // The oldest date (ASC) should be before the newest date (DESC)
                 const ascParsed = dayjs(ascDate, 'M/D/YYYY')
@@ -172,8 +172,7 @@ describe('Measure List Page Sort by Columns', () => {
 
         // sort by model
         cy.contains('.header-button', 'Model').click()
-        cy.wait('@sort')
-        cy.wait(1100)
+        MeasuresPage.waitForMeasureListRefresh('@sort')
         cy.get('.measures-list tr').first().find('td').eq(4).invoke('text').then(ascModel => {
 
             // verify page 1
@@ -191,8 +190,7 @@ describe('Measure List Page Sort by Columns', () => {
 
             // sort by model again to reset
             cy.contains('.header-button', 'Model').click()
-            cy.wait('@sort2')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort2')
             cy.get('.measures-list tr').first().find('td').eq(4).invoke('text').then(descModel => {
                 // ASC and DESC should produce different first models
                 expect(ascModel).to.not.equal(descModel)
@@ -221,8 +219,7 @@ describe('Measure List Page Sort by Columns', () => {
 
             // sort 1 - by measure ASC
             cy.contains('.header-button', 'Measure').click()
-            cy.wait('@sort')
-            cy.wait(1100)
+            MeasuresPage.waitForMeasureListRefresh('@sort')
 
             cy.get('.measures-list tr').first().find('td').eq(1).invoke('text').then(secondMeasureName => {
 
@@ -231,8 +228,7 @@ describe('Measure List Page Sort by Columns', () => {
 
                     // sort 2 - by measure DESC
                     cy.contains('.header-button', 'Measure').click()
-                    cy.wait('@sort2')
-                    cy.wait(1100)
+                    MeasuresPage.waitForMeasureListRefresh('@sort2')
                     cy.get('.measures-list tr').first().then(firstRow => {
 
                         // verify that name is different from both previous measures
@@ -242,8 +238,7 @@ describe('Measure List Page Sort by Columns', () => {
 
                     // sort 3 - click again to return to default sort
                     cy.contains('.header-button', 'Measure').click()
-                    cy.wait('@sort3')
-                    cy.wait(3300)
+                    MeasuresPage.waitForMeasureListRefresh('@sort3')
                     // verify return to default sort by "last updated"
                     MeasuresPage.checkFirstRow({ name: originalMeasureName, updated: today })
             })

--- a/cypress/e2e/WebInterface/Measure/MinimizeAlerts.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MinimizeAlerts.cy.ts
@@ -4,6 +4,7 @@ import { Utilities } from "../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../Shared/EditMeasurePage"
 import { MeasuresPage } from "../../../Shared/MeasuresPage"
 import { CQLEditorPage } from "../../../Shared/CQLEditorPage"
+import { MeasureGroupPage } from "../../../Shared/MeasureGroupPage"
 import { QiCore6Cql } from "../../../Shared/FHIRMeasuresCQL"
 
 const now = Date.now()
@@ -12,9 +13,7 @@ const CqlLibraryName = 'MinimizeAlertsLib' + now
 const errorCql = QiCore6Cql.intentionalErrorCql
 
 describe('Minimize Alerts - Measure with a CQL error', () => {
-
     beforeEach('Create Measure and Login', () => {
-
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, { measureCql: errorCql })
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
@@ -22,45 +21,32 @@ describe('Minimize Alerts - Measure with a CQL error', () => {
     })
 
     afterEach('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('On CQL Editor, user can minimize and then maximize the error list', () => {
-
         // CQL save successful, orange box shows with 1 issue
         cy.get(CQLEditorPage.orangeWarningBox).should('have.length', 0)
 
-        cy.get(CQLEditorPage.minimizeButton).click()
-
-        // Orange box is gone, alerts tab shows on right side
-        cy.get(CQLEditorPage.orangeWarningBox).should('not.exist')
-        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
-
-        // Click on the Alerts tab
-        cy.get(CQLEditorPage.minimizedAlertsTab).click()
+        CQLEditorPage.minimizeAlerts(CQLEditorPage.orangeWarningBox)
 
         // Alerts tab is gone, orange box no longer shows as warnings are only in-line in the CQL Editor
-        cy.get(CQLEditorPage.minimizedAlertsTab).should('not.exist')
+        CQLEditorPage.reopenMinimizedAlerts({ hiddenAlertSelector: CQLEditorPage.orangeWarningBox })
     })
 
     it('On CQL Editor, after minimzing errors and navigating away; when user returns, the original error list shows', () => {
-
         // CQL save successful, orange box shows with 1 issue
         cy.get(CQLEditorPage.orangeWarningBox).should('have.length', 0)
 
-        cy.get(CQLEditorPage.minimizeButton).click()
-
-        // Orange box is gone, alerts tab shows on right side
-        cy.get(CQLEditorPage.orangeWarningBox).should('not.exist')
-        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
+        CQLEditorPage.minimizeAlerts(CQLEditorPage.orangeWarningBox)
 
         // nav away - go to details tab
         cy.get(EditMeasurePage.measureDetailsTab).click()
-        cy.wait(500)
+        cy.get(EditMeasurePage.measurementInformationSaveButton).should('be.visible')
 
         // come back to cql editor
         cy.get(EditMeasurePage.cqlEditorTab).click()
+        cy.get(EditMeasurePage.cqlEditorTextBox).should('be.visible')
 
         // Alerts tab is gone, main box now shows as red
         cy.get(CQLEditorPage.errorMsg).should('be.visible')
@@ -68,42 +54,29 @@ describe('Minimize Alerts - Measure with a CQL error', () => {
     })
 
     it('On Populations page, user can minimize and then maximize the error list', () => {
-
         // verify error box
         cy.get(CQLEditorPage.errorMsg).should('have.length', 1)
 
         cy.get(EditMeasurePage.measureGroupsTab).click()
+        cy.get(MeasureGroupPage.measureGroupDescriptionBox).should('be.visible')
 
-        // click minimize
-        cy.get(CQLEditorPage.minimizeButton).click()
-        cy.wait(2500) // change to wait for alert to disappear
+        CQLEditorPage.minimizeAlerts(MeasureGroupPage.CQLHasErrorMsg)
 
-        // verify box gone & label shows on right side
-        cy.get('[data-testid="error-alerts"]').should('not.exist')
-        cy.get('[data-testid="minimized-alert"]').should('be.visible')
-
-        // click label
-        cy.contains('Display Alerts').click()
-        cy.wait(2500)
-
-        // verify label gone & error box re-appears
-        cy.get('[data-testid="generic-error-text-header"]').should('be.visible')
-            .and('have.text', 'Following issues were found within the CQL')
-        cy.get('[data-testid="minimized-alert"]').should('not.exist')
-
-        cy.wait(2500)
+        // verify label gone & page-level alert re-appears
+        CQLEditorPage.reopenMinimizedAlerts({ visibleAlertSelector: MeasureGroupPage.CQLHasErrorMsg })
+        cy.get(MeasureGroupPage.CQLHasErrorMsg)
+            .should('be.visible')
+            .and('contain.text', 'Please complete the CQL Editor process before continuing')
     })
 })
 
 describe('Minimize Alerts - Non-owner can also minimize to review the measure', () => {
-
     beforeEach('Create Measure and Login', () => {
-
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, { measureCql: errorCql })
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
-        
+
         OktaLogin.AltLogin()
         cy.get(MeasuresPage.allMeasuresTab).click()
         MeasuresPage.actionCenter('edit')
@@ -111,26 +84,16 @@ describe('Minimize Alerts - Non-owner can also minimize to review the measure', 
     })
 
     afterEach('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify Non Measure owner can perform minimize action', () => {
-
         // CQL save successful, red box shows with 1 issue
         cy.get(CQLEditorPage.errorMsg).should('have.length', 1)
 
-        cy.get(CQLEditorPage.minimizeButton).click()
-
-        // Red box is gone, alerts tab shows on right side
-        cy.get(CQLEditorPage.errorMsg).should('not.exist')
-        cy.get(CQLEditorPage.minimizedAlertsTab).should('be.visible')
-
-        // Click on the Alerts tab
-        cy.get(CQLEditorPage.minimizedAlertsTab).click()
+        CQLEditorPage.minimizeAlerts(CQLEditorPage.errorMsg)
 
         // Alerts tab is gone, red box shows again
-        cy.get(CQLEditorPage.errorMsg).should('be.visible')
-        cy.get(CQLEditorPage.minimizedAlertsTab).should('not.exist')
+        CQLEditorPage.reopenMinimizedAlerts({ visibleAlertSelector: CQLEditorPage.errorMsg })
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/CQLCodeSystem.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core CQL Editor/CQLCodeSystem.cy.ts
@@ -4,12 +4,34 @@ import { MeasuresPage } from "../../../../Shared/MeasuresPage"
 import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
 import { Utilities } from "../../../../Shared/Utilities"
 import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage";
+import { CQLLibraryPage } from "../../../../Shared/CQLLibraryPage"
 import { TestCasesPage } from "../../../../Shared/TestCasesPage"
 
 const now = Date.now()
 const measureName = 'CQLCodeSystem' + now
 const CqlLibraryName = 'CQLCodeSystemLib' + now
+
+const expectSaveMessage = (expectedMessage: string) => {
+    cy.get(CQLEditorPage.saveAlertMessage)
+        .find(TestCasesPage.importTestCaseSuccessInfo)
+        .should('contain.text', expectedMessage)
+}
+
+const returnToCqlEditor = () => {
+    cy.get(EditMeasurePage.measureGroupsTab).click()
+    CQLEditorPage.clickCQLEditorTab()
+    cy.get(EditMeasurePage.cqlEditorTextBox).should('be.visible')
+}
+
+const expectEditorErrorAfterTabSwitch = (expectedError: string) => {
+    returnToCqlEditor()
+    cy.get(CQLEditorPage.errorMsg).should('contain', expectedError)
+}
+
+const expectNoEditorErrorsAfterTabSwitch = () => {
+    returnToCqlEditor()
+    cy.get(CQLEditorPage.errorInCQLEditorWindow).should('not.exist')
+}
 
 describe('Validations around code system in Measure CQL', () => {
 
@@ -40,13 +62,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(3) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 7, Col:0: VSAC: 0:110 | Unable to find a code system version')
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(3) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 7, Col:0: VSAC: 0:110 | Unable to find a code system version')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.wait(2000)
-        cy.get(CQLEditorPage.errorMsg).should('contain', "VSAC: 0:110 | Unable to find a code system version")
+        expectEditorErrorAfterTabSwitch("VSAC: 0:110 | Unable to find a code system version")
     })
 
     it('Verify proper error(s) appear in CQL Editor, when a user includes version and there is no vsac version', () => {
@@ -64,15 +83,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 7, Col:0: VSAC: 0:72 | Version not found.')
-
-        cy.get('.page-header').click()
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 7, Col:0: VSAC: 0:72 | Version not found.')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.wait(2000)
-        cy.get(CQLEditorPage.errorMsg).should('contain', "VSAC: 0:72 | Version not found.")
+        expectEditorErrorAfterTabSwitch("VSAC: 0:72 | Version not found.")
     })
 
     it('Verify proper error(s) appear in CQL Editor, when a user does not include version and there is no vsac', () => {
@@ -90,13 +104,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 10, Col:0: Code: 0:57 | Code not found.')
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 10, Col:0: Code: 0:57 | Code not found.')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.wait(2000)
-        cy.get(CQLEditorPage.errorMsg).should('contain', "Code: 0:57 | Code not found.")
+        expectEditorErrorAfterTabSwitch("Code: 0:57 | Code not found.")
     })
 
     it('Verify proper error(s) appear in CQL Editor, when a user provides no version and vsac exists', () => {
@@ -114,12 +125,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(1) Error:Row: 9, Col:0: ELM: 0:0 | Measure CQL must contain a Context.')
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(1) Error:Row: 9, Col:0: ELM: 0:0 | Measure CQL must contain a Context.')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(CQLEditorPage.errorInCQLEditorWindow).should('not.exist')
+        expectNoEditorErrorsAfterTabSwitch()
     })
 
     it('Verify proper error(s) appear in CQL Editor, when a user provides a FHIR version', () => {
@@ -137,12 +146,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(1) Error:Row: 9, Col:0: ELM: 0:0 | Measure CQL must contain a Context.')
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(1) Error:Row: 9, Col:0: ELM: 0:0 | Measure CQL must contain a Context.')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(CQLEditorPage.errorInCQLEditorWindow).should('not.exist')
+        expectNoEditorErrorsAfterTabSwitch()
     })
 
     it('Verify proper error(s) appear in CQL Editor, when user provides a FHIR version and there is no vsac version', () => {
@@ -160,23 +167,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 7, Col:0: VSAC: 0:107 | Version not found.')
-
-        cy.get('.page-header').click()
-
-        //Intercept VSAC validation and CQL translator calls so we can wait for them
-        cy.intercept('PUT', '/api/vsac/validations/codes*').as('vsacValidation')
-        cy.intercept('PUT', '/api/fhir/cql/translator/cql*').as('cqlTranslator')
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 11, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 7, Col:0: VSAC: 0:107 | Version not found.')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        //Wait for VSAC validation and CQL translator to complete before checking errors
-        cy.wait('@vsacValidation', { timeout: 60000 })
-        cy.wait('@cqlTranslator', { timeout: 60000 })
-        cy.wait(2000)
-        cy.get(CQLEditorPage.errorMsg).should('contain', "VSAC: 0:107 | Version not found.")
+        expectEditorErrorAfterTabSwitch("VSAC: 0:107 | Version not found.")
     })
 
     it('Verify proper error(s) appear in CQL Editor, when user provides invalid value set format ', () => {
@@ -194,13 +188,10 @@ describe('Validations around code system in Measure CQL', () => {
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
         //Validate message on page
-        cy.get('[id="status-handler"]').find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 10, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 8, Col:0: VSAC: 0:125 | "\'http://cts.nlm.nih.gov/INCORRECT/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\' is not a valid URL. Fhir URL should start with \'http://cts.nlm.nih.gov/fhir/ValueSet/\'"')
-
-        cy.get('.page-header').click()
+        expectSaveMessage('CQL updated successfully but the following issues were foundLibrary statement was incorrect. MADiE has overwritten it.(2) Errors:Row: 10, Col:0: ELM: 0:0 | Measure CQL must contain a Context.Row: 8, Col:0: VSAC: 0:125 | "\'http://cts.nlm.nih.gov/INCORRECT/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\' is not a valid URL. Fhir URL should start with \'http://cts.nlm.nih.gov/fhir/ValueSet/\'"')
 
         //Validate error(s) in CQL Editor window
-        cy.get(EditMeasurePage.measureGroupsTab).click()
-        cy.get(EditMeasurePage.cqlEditorTab).click()
+        returnToCqlEditor()
         cy.get(CQLLibraryPage.measureCQLGenericErrorsList).should('contain', 'Row: 8, Col:0: VSAC: 0:125 | "\'http://cts.nlm.nih.gov/INCORRECT/fhir/ValueSet/2.16.840.1.113883.3.464.1003.101.12.1016\' is not a valid URL. Fhir URL should start with \'http://cts.nlm.nih.gov/fhir/ValueSet/\'"')
     })
 })

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/QmigSTU5FileValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/QmigSTU5FileValidations.cy.ts
@@ -18,6 +18,19 @@ const downloadsFolder = Cypress.config('downloadsFolder')
 const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-folder')
 const qiCoreCommonLib = 'resources/library-QICoreCommon-2.1.000.json'
 
+const exportMeasureArchive = (fileName: string) => {
+    EditMeasurePage.actionCenter(EditMeasureActions.export)
+    cy.verifyDownload(fileName + '.zip', { timeout: 15000 })
+    cy.log('Successfully verified zip file export')
+}
+
+const unzipMeasureArchive = (fileName: string) => {
+    cy.task('unzipFile', { zipFile: fileName + '.zip', path: downloadsFolder }).then(() => {
+        cy.log('unzipFile Task finished')
+    })
+    cy.readFile(path.join(downloadsFolder, fileName + '.json'), null, { timeout: 90000 }).should('exist')
+}
+
 // ToDo: these need new CQLs & upgrades to 6.0.0
 describe('QMIG STU5 Compliance: Proportion Measure Export Validations', () => {
     const measureName = 'Stu5ProportionExport' + Date.now()
@@ -47,16 +60,8 @@ describe('QMIG STU5 Compliance: Proportion Measure Export Validations', () => {
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
 
-        EditMeasurePage.actionCenter(EditMeasureActions.export)
-
-        //verify zip file exists
-        cy.verifyDownload(fileName + '.zip', { timeout: 5500 })
-        cy.log('Successfully verified zip file export')
-
-        cy.task('unzipFile', { zipFile: fileName + '.zip', path: downloadsFolder }).then((results) => {
-            cy.log('unzipFile Task finished')
-            cy.wait(1000)
-        })
+        exportMeasureArchive(fileName)
+        unzipMeasureArchive(fileName)
     })
 
     after('Clean up', () => {
@@ -137,16 +142,8 @@ describe('QMIG STU5 Compliance: Cohort Measure Export Validations', () => {
 
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
 
-        EditMeasurePage.actionCenter(EditMeasureActions.export)
-
-        //verify zip file exists
-        cy.verifyDownload(fileName + '.zip', { timeout: 5500 })
-        cy.log('Successfully verified zip file export')
-
-        cy.task('unzipFile', { zipFile: fileName + '.zip', path: downloadsFolder }).then((results) => {
-            cy.log('unzipFile Task finished')
-            cy.wait(1000)
-        })
+        exportMeasureArchive(fileName)
+        unzipMeasureArchive(fileName)
     })
 
     after('Clean up', () => {
@@ -230,16 +227,8 @@ describe('QMIG STU5 Compliance: Continuous Variable Measure Export Validations',
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
 
-        EditMeasurePage.actionCenter(EditMeasureActions.export)
-
-        //verify zip file exists
-        cy.verifyDownload(fileName + '.zip', { timeout: 5500 })
-        cy.log('Successfully verified zip file export')
-
-        cy.task('unzipFile', { zipFile: fileName + '.zip', path: downloadsFolder }).then((results) => {
-            cy.log('unzipFile Task finished')
-            cy.wait(1000)
-        })
+        exportMeasureArchive(fileName)
+        unzipMeasureArchive(fileName)
     })
 
     after('Clean up', () => {
@@ -292,16 +281,8 @@ describe('QMIG STU5 Compliance: Ratio Measure Export Validations', () => {
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
 
-        EditMeasurePage.actionCenter(EditMeasureActions.export)
-
-        //verify zip file exists
-        cy.verifyDownload(fileName + '.zip', { timeout: 5500 })
-        cy.log('Successfully verified zip file export')
-
-        cy.task('unzipFile', { zipFile: fileName + '.zip', path: downloadsFolder }).then((results) => {
-            cy.log('unzipFile Task finished')
-            cy.wait(1000)
-        })
+        exportMeasureArchive(fileName)
+        unzipMeasureArchive(fileName)
     })
 
     after('Clean up', () => {

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/QICoreMeasureExport.cy.ts
@@ -23,6 +23,19 @@ const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-fol
 const measureCQLContent = MeasureCQL.stndBasicQICoreCQL
 const measureCQL = MeasureCQL.zipfileExportQICore
 
+const selectMajorVersionType = () => {
+    cy.get(MeasuresPage.measureVersionTypeDropdown).click()
+    cy.get(MeasuresPage.measureVersionMajor).click()
+    Utilities.waitForElementVisible(MeasuresPage.confirmMeasureVersionNumber, 7000)
+}
+
+const visitExportHtml = (fileName: string) => {
+    Cypress.config('baseUrl', null)
+    cy.readFile(path.join(downloadsFolder, fileName), { timeout: 90000 }).should('exist')
+    cy.visit(`./cypress/downloads/${fileName}`)
+    cy.document().its('readyState').should('eq', 'complete')
+}
+
 describe('QI-Core Measure Export', () => {
     deleteDownloadsFolderBeforeAll()
 
@@ -99,8 +112,7 @@ describe('QI-Core Measure Export', () => {
 
         MeasuresPage.actionCenter('version')
 
-        cy.get(MeasuresPage.measureVersionTypeDropdown).click()
-        cy.get(MeasuresPage.measureVersionMajor).click().wait(1000)
+        selectMajorVersionType()
         cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
 
         cy.get('#draggable-dialog-title').click()
@@ -217,11 +229,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, be
         cy.verifyDownload('eCQMTitle4QICore-v0.0.000-FHIR.zip', { timeout: 90000 })
 
         //remove the baseUrl so that we can visit a local file
-        Cypress.config('baseUrl', null)
-        cy.wait(1000)
-        // Load the HTML file
-        cy.visit('./cypress/downloads/eCQMTitle4QICore-v0.0.000-FHIR.html')
-        cy.wait(1000)
+        visitExportHtml('eCQMTitle4QICore-v0.0.000-FHIR.html')
 
         // Scrub the HTML and verify the data we are looking for
         cy.document().then((doc) => {
@@ -405,7 +413,6 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
 
     before('Create New Measure and Login', () => {
         Cypress.config('baseUrl', url)
-        cy.wait(1000)
 
         measureNameFC = 'HRExport2' + Date.now()
         CqlLibraryNameFC = 'HRExport2Lib' + Date.now()
@@ -457,9 +464,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
 
         //version measure
         MeasuresPage.actionCenter('version')
-        cy.get(MeasuresPage.measureVersionTypeDropdown).click()
-        cy.get(MeasuresPage.measureVersionMajor).click().wait(1000)
-        Utilities.waitForElementVisible(MeasuresPage.confirmMeasureVersionNumber, 7000)
+        selectMajorVersionType()
         cy.get(MeasuresPage.confirmMeasureVersionNumber).type('1.0.000')
 
         cy.get('#draggable-dialog-title').click()
@@ -489,11 +494,7 @@ describe('QI-Core Measure Export: Validating contents of Human Readable file, af
         cy.verifyDownload('eCQMTitle4QICore-v1.0.000-FHIR.zip', { timeout: 90000 })
 
         //remove the baseUrl so that we can visit a local file
-        Cypress.config('baseUrl', null)
-        cy.wait(1000)
-        // Load the HTML file
-        cy.visit('./cypress/downloads/eCQMTitle4QICore-v1.0.000-FHIR.html')
-        cy.wait(1000)
+        visitExportHtml('eCQMTitle4QICore-v1.0.000-FHIR.html')
         // Scrub the HTML and verify the data we are looking for
         cy.document().then((doc) => {
             const bodyText = doc.body.innerText

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
@@ -312,7 +312,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -455,7 +455,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Cohort_ListQDMPositiveEncounterPerformed.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Cohort_ListQDMPositiveEncounterPerformed.cy.ts
@@ -215,7 +215,7 @@ describe('Measure Creation: Cohort ListQDMPositiveEncounterPerformed', () => {
         QDMElements.addCode('SOP', '1')
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -296,7 +296,7 @@ describe('Measure Creation: Cohort ListQDMPositiveEncounterPerformed', () => {
         QDMElements.addCode('SOP', '1')
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/ProportionPatient.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/ProportionPatient.cy.ts
@@ -288,17 +288,12 @@ describe('Measure Creation: Proportion Patient Based', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         //Add Expected values
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENEXExpected).click()
-        cy.get(TestCasesPage.testCaseDENEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENEXExpected)
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Proportion_ListQDMPositiveProcedurePerformed.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Proportion_ListQDMPositiveProcedurePerformed.cy.ts
@@ -135,7 +135,7 @@ describe('Measure Creation: Proportion ListQDMPositiveProcedurePerformed', () =>
         QDMElements.addCode('SNOMEDCT', '111527005')
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).type('1')
         cy.get(TestCasesPage.testCaseDENOMExpected).type('1')
@@ -199,7 +199,7 @@ describe('Measure Creation: Proportion ListQDMPositiveProcedurePerformed', () =>
         cy.get('[data-testid=add-code-concept-button]').click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).type('2')
         cy.get(TestCasesPage.testCaseDENOMExpected).type('2')

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts
@@ -272,7 +272,7 @@ describe('Measure Creation: Ratio EncounterPerformed, Multiple Criterias With MO
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected values for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts
@@ -196,7 +196,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -312,7 +312,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithMO.cy.ts
@@ -106,7 +106,7 @@ describe('Measure Creation and Testing: CV Episode Measure With MO', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithStratification.cy.ts
@@ -132,7 +132,7 @@ describe('Measure Creation and Testing: CV Episode Measure With Stratification',
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
@@ -80,12 +80,10 @@ describe('Measure Creation and Testing: CV Patient With MO', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
         cy.get(TestCasesPage.measureObservationRow).type('1')
 
         cy.get(TestCasesPage.detailsTab).should('exist')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeEncounter.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortEpisodeEncounter.cy.ts
@@ -56,7 +56,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -66,7 +66,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Test case updated successfully with warnings in JSON')
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientBoolean.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientBoolean.cy.ts
@@ -49,11 +49,9 @@ describe('Measure Creation and Testing: Cohort Patient Boolean', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.detailsTab).should('exist')
         cy.get(TestCasesPage.detailsTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientWithStratification.cy.ts
@@ -91,13 +91,10 @@ describe('Measure Creation and Testing: Cohort Patient w/ Stratification', () =>
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-
-        cy.get(TestCasesPage.initialPopulationStratificationExpectedValue).should('be.enabled')
-        cy.get(TestCasesPage.initialPopulationStratificationExpectedValue).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.initialPopulationStratificationExpectedValue)
 
         cy.get(TestCasesPage.detailsTab).should('exist')
         cy.get(TestCasesPage.detailsTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeSingleIPNoMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeSingleIPNoMO.cy.ts
@@ -107,7 +107,7 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -122,7 +122,7 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
             'Test case updated successfully ' + 'with warnings in JSON',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
@@ -155,7 +155,7 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -185,7 +185,7 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
             'Test case updated successfully ' + 'with warnings in JSON',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeTwoIPsWithMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeTwoIPsWithMOs.cy.ts
@@ -97,7 +97,7 @@ describe('Measure Creation and Testing: Ratio Episode Two IPs w/ MOs', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
@@ -141,7 +141,7 @@ describe('Measure Creation and Testing: Ratio Episode Two IPs w/ MOs', () => {
             'Test case updated successfully with warnings in JSON',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOs.cy.ts
@@ -130,32 +130,28 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
+        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
+        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).click()
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.enabled')
@@ -174,7 +170,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
             'Test case updated successfully ' + 'with warnings in JSON',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
@@ -206,32 +202,28 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
+        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
+        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).click()
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.enabled')
@@ -250,7 +242,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
             'Test case updated successfully ' + 'with warnings in JSON',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts
@@ -126,32 +126,28 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs, using same
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
+        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
+        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).click()
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.enabled')
@@ -170,7 +166,7 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs, using same
             'Test case updated successfully ' + 'with warnings in JSON',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts
@@ -103,7 +103,7 @@ describe('Measure Creation and Testing: CV Patient Measure With Stratification',
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).type('1')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVPatientWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVPatientWithStratification.cy.ts
@@ -117,20 +117,16 @@ describe('Measure Creation and Testing: CV Patient Measure With Stratification',
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
         cy.get(TestCasesPage.measureObservationRow).type('1')
 
-        cy.get(TestCasesPage.initialPopulationStratificationExpectedValue).check().should('be.checked')
-        cy.get(TestCasesPage.measurePopulationStratificationExpectedValue).check().should('be.checked')
-        cy.get(TestCasesPage.initialPopulationStrata2ExpectedValue).check().should('be.checked')
-        cy.get(TestCasesPage.measurePopulationStrata2ExpectedValue).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.initialPopulationStratificationExpectedValue)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.measurePopulationStratificationExpectedValue)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.initialPopulationStrata2ExpectedValue)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.measurePopulationStrata2ExpectedValue)
 
         cy.get(TestCasesPage.detailsTab).should('exist')
         cy.get(TestCasesPage.detailsTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEncounter600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEncounter600.cy.ts
@@ -51,7 +51,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -63,7 +63,7 @@ describe('Measure Creation and Testing: Cohort Episode Encounter', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(Toasts.otherSuccessToast).should('contain.text', 'Test case updated successfully')
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CohortEpisodeWithStratification.cy.ts
@@ -61,7 +61,7 @@ describe('Measure Creation and Testing: Cohort Episode w/ Stratification', () =>
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).type('1')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/ProportionEpisode.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/ProportionEpisode.cy.ts
@@ -89,7 +89,7 @@ describe('Measure Creation and Testing: Proportion Episode Measure', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/RatioEncounterSingleIPWithMOs600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/RatioEncounterSingleIPWithMOs600.cy.ts
@@ -78,7 +78,7 @@ describe('Measure Creation and Testing: Ratio Encounter Single IP w/ MOs', () =>
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
@@ -102,7 +102,7 @@ describe('Measure Creation and Testing: Ratio Encounter Single IP w/ MOs', () =>
             'Test case updated successfully! Test case validation has started running, please continue working in MADiE.',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/RatioPatientSingleIPNoMOwithDRC.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/RatioPatientSingleIPNoMOwithDRC.cy.ts
@@ -97,21 +97,20 @@ describe('Measure Creation and Testing: Ratio Patient Single IP w/o MO w/ DRC', 
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(Toasts.otherSuccessToast).should(
             'contain.text',
             'Test case updated successfully! Test case validation has started running, please continue working in MADiE.',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
@@ -144,36 +143,33 @@ describe('Measure Creation and Testing: Ratio Patient Single IP w/o MO w/ DRC', 
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).click()
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('exist')
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).click()
-        cy.get(TestCasesPage.testCaseNUMEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
+        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.checked')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(Toasts.otherSuccessToast).should(
             'contain.text',
             'Test case updated successfully! Test case validation has started running, please continue working in MADiE.',
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
         cy.get(TestCasesPage.runTestButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -17,7 +17,6 @@ let testCaseSeries = 'SBTestSeries'
 const validTestCaseJson = TestCaseJson.QDMTestCaseJson
 const measureCQL = MeasureCQL.QDMCQL4MAT5645
 const measureData: CreateMeasureOptions = {}
-
 describe('Run / Execute Test case and verify passing percentage and coverage', () => {
 
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
@@ -318,6 +317,7 @@ describe('Run / Execute QDM Test Case button validations', () => {
         measureData.cqlLibraryName = CqlLibraryName
         measureData.measureScoring = 'Cohort'
         measureData.patientBasis = 'true'
+        measureData.measureCql = measureCQL
 
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
         OktaLogin.Login()
@@ -329,66 +329,54 @@ describe('Run / Execute QDM Test Case button validations', () => {
     })
 
     it('Run Test Case button is disabled  -- CQL Errors', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
+        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
 
-        //Add CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.readFile('cypress/fixtures/QDMMeasureCQL.txt').should('exist').then((fileContents) => {
-            cy.wait(3000)
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
-
+        cy.get(EditMeasurePage.cqlEditorTab).should('be.visible').click()
+        Utilities.waitForElementWriteEnabled(EditMeasurePage.cqlEditorTextBox, 8500)
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{home}')
         cy.get(EditMeasurePage.cqlEditorTextBox).type('adjfajsdsdjf{}')
 
-        //save CQL on measure
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
         cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
         Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 60000)
+        cy.get(EditMeasurePage.cqlEditorExpandCollapseBtn).click()
 
-        TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries)
-
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.cqlHasErrorsMsg).should('have.text', 'An error exists with the measure CQL, please review the CQL Editor tab')
+        Utilities.waitForElementVisible(TestCasesPage.testCaseSyntaxError, 105000)
+        cy.get(TestCasesPage.testCaseSyntaxError).should(
+            'contain.text',
+            'An error exists with the measure CQL, please review the CQL Editor tab.'
+        )
+        cy.get(TestCasesPage.runQDMTestCaseBtn).should('not.be.enabled')
     })
 
     it('Run / Execute Test Case button is disabled  -- Missing group / population selections', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
+        TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
 
-        //Add CQL
-        cy.get(EditMeasurePage.cqlEditorTab).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.readFile('cypress/fixtures/QDMMeasureCQL.txt').should('exist').then((fileContents) => {
-            cy.wait(3000)
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
-
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.enabled')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 60000)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         cy.get(EditMeasurePage.testCasesTab).scrollIntoView()
-        TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries)
-
+        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        Utilities.waitForElementVisible(TestCasesPage.runQDMTestCaseBtn, 37700)
-        cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.visible')
-        cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.disabled')
+        Utilities.waitForElementVisible(TestCasesPage.testCaseSyntaxError, 105000)
+        cy.get(TestCasesPage.testCaseSyntaxError).should(
+            'contain.text',
+            'No Population Criteria is associated with this measure. Please review the Population Criteria tab.'
+        )
+        cy.get(TestCasesPage.runQDMTestCaseBtn).should('not.be.enabled')
     })
 
     it('Run / Execute Test Case button is disabled -- missing TC Json', () => {
@@ -396,26 +384,13 @@ describe('Run / Execute QDM Test Case button validations', () => {
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
-        //Add CQL
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-
-        cy.readFile('cypress/fixtures/QDMMeasureCQL.txt').should('exist').then((fileContents) => {
-            cy.wait(3000)
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
-
-        //save CQL on measure
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('exist')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 60000)
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         //Click on the measure group tab
         cy.get(EditMeasurePage.measureGroupsTab).click()
         cy.get(MeasureGroupPage.QDMPopulationCriteria1).click()
 
-        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'ipp')
+        Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Patient16To23')
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
@@ -498,6 +473,11 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         Utilities.waitForElementVisible(EditMeasurePage.testCasesTab, 60000)
         cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get('body').then(($body) => {
+            if ($body.find(Utilities.discardChangesConfirmationModal).length > 0) {
+                Utilities.clickOnDiscardChanges()
+            }
+        })
         Utilities.waitForElementEnabled(TestCasesPage.executeTestCaseButton, 60000)
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Fail')
@@ -572,4 +552,3 @@ describe('Run / Execute Test Case by Non Measure Owner', () => {
         cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.enabled')
     })
 })
-

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/BooleanAndNonBooleanExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/BooleanAndNonBooleanExpectedValues.cy.ts
@@ -29,15 +29,11 @@ describe('Non Boolean Population Basis Expected values', () => {
             'Qualifying Encounters',
             '',
             'Qualifying Encounters',
-            'Encounter',
+            'Encounter'
         )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{end}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
-        cy.get(EditMeasurePage.cqlEditorExpandCollapseBtn).click()
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -54,9 +50,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
@@ -77,10 +71,10 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.errorToastMsg).should(
             'contain.text',
-            'Test case updated successfully with ' + 'errors in JSON',
+            'Test case updated successfully with ' + 'errors in JSON'
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).should('contain.value', '1')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('contain.value', '2')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('contain.value', '3')
@@ -127,7 +121,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -139,9 +133,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         //Add Expected values for Population Basis Encounter (Proportion Measure Group)
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -160,20 +152,17 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).type('3')
 
         //Add Expected values for Population Basis Boolean (Cohort Measure Group)
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
 
         //Save updated test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.errorToastMsg).should(
             'contain.text',
-            'Test case updated successfully with ' + 'errors in JSON',
+            'Test case updated successfully with ' + 'errors in JSON'
         )
 
         //Assert Expected values for Population Basis Encounter (Proportion Measure Group)
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('contain.value', '1')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('contain.value', '2')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('contain.value', '3')
@@ -192,9 +181,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
@@ -230,9 +217,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
@@ -240,7 +225,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.testCaseIPPExpected).type('abc')
         cy.get(TestCasesPage.nonBooleanExpectedValueError).should(
             'contain.text',
-            'Only positive numeric values can be entered in the expected values',
+            'Only positive numeric values can be entered in the expected values'
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
@@ -250,7 +235,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.testCaseDENOMExpected).type('$%@')
         cy.get(TestCasesPage.nonBooleanExpectedValueError).should(
             'contain.text',
-            'Only positive numeric values can be entered in the expected values',
+            'Only positive numeric values can be entered in the expected values'
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
@@ -260,7 +245,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).type('13@a')
         cy.get(TestCasesPage.nonBooleanExpectedValueError).should(
             'contain.text',
-            'Only positive numeric values can be entered in the expected values',
+            'Only positive numeric values can be entered in the expected values'
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
@@ -270,7 +255,7 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).clear().type('1.9')
         cy.get(TestCasesPage.nonBooleanExpectedValueError).should(
             'contain.text',
-            'Decimals values cannot be entered in the population expected values',
+            'Decimals values cannot be entered in the population expected values'
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
@@ -282,10 +267,10 @@ describe('Non Boolean Population Basis Expected values', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.errorToastMsg).should(
             'contain.text',
-            'Test case updated successfully with ' + 'errors in JSON',
+            'Test case updated successfully with ' + 'errors in JSON'
         )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).should('contain.value', '1')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('contain.value', '2')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('contain.value', '3')
@@ -304,14 +289,11 @@ describe('Boolean Population Basis Expected Values', () => {
             'Initial Population',
             '',
             'Initial Population',
-            'Boolean',
+            'Boolean'
         )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -359,7 +341,7 @@ describe('Boolean Population Basis Expected Values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -371,45 +353,31 @@ describe('Boolean Population Basis Expected Values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         //Add Expected values for Population Basis Encounter (Proportion Measure Group)
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
 
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
 
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         //Add Expected values for Population Basis Boolean (Cohort Measure Group)
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
 
         //Save updated test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.errorToastMsg).should(
             'contain.text',
-            'Test case updated successfully with ' + 'errors in JSON',
+            'Test case updated successfully with ' + 'errors in JSON'
         )
 
         //Assert Expected values for Population Basis Encounter (Proportion Measure Group)
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should(
             'contain.text',
-            'Measure Group 1 - Proportion | boolean',
+            'Measure Group 1 - Proportion | boolean'
         )
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.checked')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
@@ -462,7 +430,7 @@ describe('Boolean Population Basis Expected Values', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -474,31 +442,17 @@ describe('Boolean Population Basis Expected Values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         //Add Expected values for Population Basis Encounter (Proportion Measure Group)
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
 
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
 
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         //Add Expected values for Population Basis Boolean (Cohort Measure Group)
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
 
         //attempt to navigate away from the test case page
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -519,14 +473,11 @@ describe('Expected values for second initial population', () => {
             'Initial Population',
             'Initial Population',
             'Initial Population',
-            'Boolean',
+            'Boolean'
         )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -569,7 +520,7 @@ describe('Expected values for second initial population', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group updated successfully.',
+            'Population details for this group updated successfully.'
         )
 
         //Navigate to Test Cases page and add Test Case details
@@ -581,25 +532,20 @@ describe('Expected values for second initial population', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check()
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
 
         //Save updated test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.errorToastMsg).should(
             'contain.text',
-            'Test case updated successfully with ' + 'errors in JSON',
+            'Test case updated successfully with ' + 'errors in JSON'
         )
 
         //Assert Expected values for Initial population
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.checked')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.checked')
     })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecuteTestCasesByNonMeasureOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecuteTestCasesByNonMeasureOwner.cy.ts
@@ -89,21 +89,10 @@ describe('Ability to run valid test cases whether or not the user is the owner o
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
             Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
 
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseIPPExpected).click()
-
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseDENOMExpected).click()
-
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseNUMERExpected).click()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+            TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+            TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+            TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
             Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 9500)
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -163,27 +152,18 @@ describe('Ability to run valid test cases whether or not the user is the owner o
             cy.get(TestCasesPage.aceEditorJsonInput).should('exist').wait(2000)
             cy.editTestCaseJSON(validTestCaseJson)
 
+            Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 9500)
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
             cy.get('.toast').should('have.text', 'Test case updated successfully with warnings in JSON')
+            Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
 
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseIPPExpected).click()
-
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseDENOMExpected).click()
-
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseNUMERExpected).click()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+            TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+            TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+            TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -234,7 +214,7 @@ describe('Ability to run valid test cases whether or not the user is the owner o
                 'contain.text',
                 "No code provided, and a code should be provided from the value set 'US Core Encounter Type' (http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type|3.1.0)",
             )
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab()
             cy.get(TestCasesPage.measureGroup1Label).should('have.color', '#4d7e23')
             cy.get(TestCasesPage.measureActualCheckbox).should('be.checked')
         },
@@ -257,21 +237,10 @@ describe('Ability to run valid test cases whether or not the user is the owner o
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on actual / expected sub-tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 9500)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
@@ -36,10 +36,8 @@ describe('Measure Observation Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Validate measure observation expected values
@@ -73,7 +71,7 @@ describe('Measure Observation Expected values', () => {
         )
 
         //Assert saved observation values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.measureObservationRow).should('contain.value', '1.3')
     })
 
@@ -112,12 +110,10 @@ describe('Measure Observation Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).click()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         //Validate measure observation expected values
@@ -149,7 +145,7 @@ describe('Measure Observation Expected values', () => {
         //Assert saved observation values
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('contain.value', '1.3')
         cy.get(TestCasesPage.numeratorObservationRow).should('contain.value', '5')
     })
@@ -163,10 +159,8 @@ describe('Measure Observation Expected values', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Enter value in to Measure observation Expected values
@@ -246,9 +240,7 @@ describe('Measure observation expected result', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         //Enter values in to Measure population(MP) & Measure population exclusion(MPE) fields and verify MP-MPE = number of observation rows
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('5')
@@ -333,9 +325,7 @@ describe('Measure observation expected result', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         //Enter values in to Denominator & Denominator exclusion(DE) fields and verify Denominator-DE = number of Denominator observation rows
         cy.get(TestCasesPage.testCaseDENOMExpected).type('4')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExpectedValues.cy.ts
@@ -1,12 +1,12 @@
-import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
-import { CreateMeasurePage, SupportedModels } from "../../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
-import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
-import { Utilities } from "../../../../../Shared/Utilities"
-import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
-import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
+import { TestCaseJson } from '../../../../../Shared/TestCaseJson'
+import { CreateMeasurePage, SupportedModels } from '../../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../../Shared/OktaLogin'
+import { MeasuresPage } from '../../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../../Shared/EditMeasurePage'
+import { MeasureGroupPage } from '../../../../../Shared/MeasureGroupPage'
+import { Utilities } from '../../../../../Shared/Utilities'
+import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
+import { CQLEditorPage } from '../../../../../Shared/CQLEditorPage'
 
 const now = Date.now()
 const measureName = 'MeasureForTCExpectedValues' + now
@@ -17,21 +17,17 @@ const testCaseSeries = 'SBTestSeries'
 const testCaseJson = TestCaseJson.TestCaseJson_CohortPatientBoolean_PASS
 
 describe('Validate Test Case Expected value updates on Measure Group change', () => {
-
     beforeEach('Create measure, measure group, test case and login', () => {
-
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore4)
         TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, testCaseJson)
         OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify if the scoring type is changed, Test Case Expected values are cleared for that group', () => {
-
         //Create Ratio Measure group
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
 
@@ -40,20 +36,19 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         //Save edited / updated to test case
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.executionContextWarning).should('have.text', 'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.')
-       
+        cy.get(TestCasesPage.executionContextWarning).should(
+            'have.text',
+            'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.'
+        )
+
         //Navigate to Measure group page and update scoring type
         cy.get(EditMeasurePage.measureGroupsTab).click()
         Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
@@ -65,18 +60,20 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(MeasureGroupPage.updateMeasureGroupConfirmationMsg).contains('Are you sure you want to Save Changes?')
         cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //Navigate to test Cases page and verify Test Case Expected values are cleared
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.clickEditforCreatedTestCase()
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
     })
 
     it('Verify if the population basis is changed, Test Case Expected values are cleared for that group', () => {
-
         //Create Ratio Measure group
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
 
@@ -85,18 +82,17 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         //Save edited / updated to test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.executionContextWarning).should('have.text', 'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.')
+        cy.get(TestCasesPage.executionContextWarning).should(
+            'have.text',
+            'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.'
+        )
 
         //Navigate to Measure group page and update scoring type
         cy.get(EditMeasurePage.measureGroupsTab).click()
@@ -116,7 +112,10 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.enabled')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-        cy.get(MeasureGroupPage.scoreUpdateMGConfirmMsg).should('contain.text', 'Your Measure Population Basis is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure group.Are you sure you want to Save Changes?This action cannot be undone.')
+        cy.get(MeasureGroupPage.scoreUpdateMGConfirmMsg).should(
+            'contain.text',
+            'Your Measure Population Basis is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure group.Are you sure you want to Save Changes?This action cannot be undone.'
+        )
         cy.get(MeasureGroupPage.updatePopulationBasisConfirmationBtn).click()
 
         //validation message after attempting to save
@@ -128,14 +127,13 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.contain.value')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.contain.value')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('not.contain.value')
     })
 
     it('Verify if Measure group is deleted, that group no longer appears in the edit test case page', () => {
-
         //Create Ratio Measure group
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
 
@@ -144,13 +142,11 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('be.visible')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Group 1 - Ratio | boolean')
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 8500)
 
@@ -162,35 +158,41 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(MeasureGroupPage.deleteGroupbtn).click()
         cy.get(MeasureGroupPage.yesDeleteModalbtn).should('exist').should('be.visible').should('be.enabled')
         cy.get(MeasureGroupPage.yesDeleteModalbtn).click()
-        cy.get('[data-testid="save-measure-group-validation-message"]').should('contain.text', 'You must set all required Populations.')
+        cy.get('[data-testid="save-measure-group-validation-message"]').should(
+            'contain.text',
+            'You must set all required Populations.'
+        )
 
         //Navigate to Edit Test Case page and assert Measure group after deletion
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('not.exist')
-        cy.get(TestCasesPage.testCasePopulationList).should('contain.text', 'No data for current scoring. Please make sure at least one measure group has been created.')
+        cy.get(TestCasesPage.testCasePopulationList).should(
+            'contain.text',
+            'No data for current scoring. Please make sure at least one measure group has been created.'
+        )
     })
 
     it('Verify if group populations are added/deleted, test case expected values will be updated', () => {
-
         //Create Ratio Measure group
         MeasuresPage.actionCenter('edit')
 
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.wait(3000)
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.wait(3000)
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorExpandCollapseBtn).click()
 
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
@@ -208,27 +210,28 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully'
+        )
 
         //Add Expected values for Test Case
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseDENEXExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENEXExpected)
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('not.exist')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.executionContextWarning).should('have.text', 'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.')
-       
+        cy.get(TestCasesPage.executionContextWarning).should(
+            'have.text',
+            'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.'
+        )
+
         //Navigate to Measure Group page and add Numerator Exclusion & delete Denominator Exclusion
         cy.get(EditMeasurePage.measureGroupsTab).click()
         Utilities.dropdownSelect(MeasureGroupPage.numeratorExclusionSelect, 'num')
@@ -236,23 +239,23 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get('.MuiList-root > [data-value=""]').click()
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully'
+        )
 
         //Navigate to Test cases page and verify Numerator Exclusion check box exists & Denominator Exclusion check box is deleted
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseNUMEXExpected })
         cy.get(TestCasesPage.testCaseDENEXExpected).should('not.exist')
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).click()
-        cy.get(TestCasesPage.testCaseNUMEXExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
     })
 
     it('Verify if Measure Observation is added/removed from Measure group, test case Expected values will be updated', () => {
-
         //Create Ratio Measure group
         MeasureGroupPage.createMeasureGroupforRatioMeasure()
 
@@ -274,7 +277,10 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //Close the Toast message
         cy.get(TestCasesPage.clearIconBtn).click()
@@ -283,12 +289,8 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
 
         cy.get(TestCasesPage.detailsTab).click()
@@ -306,7 +308,10 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(MeasureGroupPage.denominatorAggregateFunction).should('not.exist')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //Close the Toast message
         cy.get(TestCasesPage.clearIconBtn).click()
@@ -315,19 +320,11 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).click()
-
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.checked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('not.exist')
     })
 
     it('Verify if Stratification is added to the Measure group, test case Expected values will be updated', () => {
-
         //Create CV Measure Group
         MeasureGroupPage.createMeasureGroupforContinuousVariableMeasure()
 
@@ -335,7 +332,7 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.initialPopulationStratificationExpectedValue).should('not.exist')
 
         //Add Stratification to the Measure Group
@@ -347,30 +344,35 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
         Utilities.dropdownSelect(MeasureGroupPage.stratOne, 'ipp')
         //Utilities.dropdownSelect(MeasureGroupPage.stratAssociationOne, 'initialPopulation')
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //Verify Stratification Expected values after adding stratification
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get('[data-testid="strat-row-population-id-measurePopulation"] > :nth-child(2)').should('exist')
     })
 
     it('Verify if the correct Population check boxes are checked on test case expected values for Ratio measure with two IPs', () => {
-
         //Create Ratio Measure group with 2 IP's
         MeasuresPage.actionCenter('edit')
 
         //Add CQL
         cy.get(EditMeasurePage.cqlEditorTab).click()
 
-        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/CQLForTestCaseExecution.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
 
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        cy.get(EditMeasurePage.cqlEditorExpandCollapseBtn).click()
 
         //Create Measure Group
         cy.get(EditMeasurePage.measureGroupsTab).click()
@@ -396,28 +398,33 @@ describe('Validate Test Case Expected value updates on Measure Group change', ()
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully.'
+        )
 
         //Add Expected values for Test Case
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
         Utilities.waitForElementVisible(TestCasesPage.testCaseDENOMExpected, 60000)
 
         //Check first IP Expected value and assert Denominator Expected value is checked
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         //Check second IP Expected value and assert Denominator Expected value is checked
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 1 })
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         //Save edited / updated to test case
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-        cy.get(TestCasesPage.executionContextWarning).should('have.text', 'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.')       
+        cy.get(TestCasesPage.executionContextWarning).should(
+            'have.text',
+            'Test case updated successfully! Timezone offsets have been added when hours are present, otherwise timezone offsets are removed or set to UTC for consistency.'
+        )
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
@@ -217,10 +217,7 @@ describe('JSON Resource ID tests', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Add json to the test case
-        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
-        cy.get(TestCasesPage.aceEditor).should('exist')
-        cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.wait(2000)
+        TestCasesPage.waitForJsonEditorReady()
         cy.editTestCaseJSON(emptyResourceIDTCJson)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -303,10 +300,7 @@ describe('JSON Resource ID tests', () => {
             TestCasesPage.clickEditforCreatedTestCase()
 
             //Add json to the test case
-            Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
-            cy.get(TestCasesPage.aceEditor).should('exist')
-            cy.get(TestCasesPage.aceEditor).should('be.visible')
-            cy.wait(2000)
+            TestCasesPage.waitForJsonEditorReady()
             cy.editTestCaseJSON(missingResourceIDTCJsonButHasFullUrlExt)
 
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -387,10 +381,7 @@ describe('JSON Resource ID tests', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Add json to the test case
-        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
-        cy.get(TestCasesPage.aceEditor).should('exist')
-        cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.wait(2000)
+        TestCasesPage.waitForJsonEditorReady()
         cy.editTestCaseJSON(missingResourceIDTCJson)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -462,13 +453,8 @@ describe('JSON Resource ID tests', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Add json to the test case
-        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
-        cy.get(TestCasesPage.aceEditor).should('exist')
-        cy.get(TestCasesPage.aceEditor).should('be.visible')
-        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
-        cy.get(TestCasesPage.aceEditor).click()
-        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 3500)
-        cy.get(TestCasesPage.aceEditor).wait(1500).type(dupResourceIDTCJson, { parseSpecialCharSequences: false })
+        TestCasesPage.waitForJsonEditorReady()
+        cy.editTestCaseJSON(dupResourceIDTCJson)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -520,10 +506,7 @@ describe('JSON Resource ID tests', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Add json to the test case
-        Utilities.waitForElementVisible(TestCasesPage.aceEditor, 30700)
-        cy.get(TestCasesPage.aceEditor).should('exist')
-        cy.get(TestCasesPage.aceEditor).should('be.visible')
-        cy.wait(2000)
+        TestCasesPage.waitForJsonEditorReady()
         cy.editTestCaseJSON(missingMetaProfile)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCasePopulationValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCasePopulationValues.cy.ts
@@ -1,16 +1,16 @@
-import { CreateMeasurePage } from "../../../../Shared/CreateMeasurePage"
-import { OktaLogin } from "../../../../Shared/OktaLogin"
-import { MeasuresPage } from "../../../../Shared/MeasuresPage"
-import { EditMeasurePage } from "../../../../Shared/EditMeasurePage"
-import { TestCasesPage } from "../../../../Shared/TestCasesPage"
-import { Utilities } from "../../../../Shared/Utilities"
-import { MeasureGroupPage } from "../../../../Shared/MeasureGroupPage"
-import { TestCaseJson } from "../../../../Shared/TestCaseJson"
-import { MeasureCQL } from "../../../../Shared/MeasureCQL"
-import { CQLEditorPage } from "../../../../Shared/CQLEditorPage"
-import { Header } from "../../../../Shared/Header"
+import { CreateMeasurePage } from '../../../../Shared/CreateMeasurePage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { Utilities } from '../../../../Shared/Utilities'
+import { MeasureGroupPage } from '../../../../Shared/MeasureGroupPage'
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
+import { MeasureCQL } from '../../../../Shared/MeasureCQL'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { Header } from '../../../../Shared/Header'
 
-let randValue = (Math.floor((Math.random() * 1000) + 1))
+let randValue = Math.floor(Math.random() * 1000 + 1)
 const now = Date.now()
 const measureName = 'TCPopValues' + now + randValue
 const CqlLibraryName = 'TCPopValuesLib' + now + randValue
@@ -22,31 +22,31 @@ const measureCQL = MeasureCQL.ICFCleanTest_CQL
 const proportionMeasureCQL = MeasureCQL.CQL_Multiple_Populations
 
 describe('Test Case Expected Measure Group population values based on initial measure scoring', () => {
-
     beforeEach('Create measure and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
         OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify the Test Case Populations when Measure group is not added', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //Navigate to Test Cases page
         cy.get(EditMeasurePage.testCasesTab).click()
-        cy.get(TestCasesPage.testCaseExecutionError).should('contain.text', 'No Population Criteria is associated with this measure. Please review the Population Criteria tab.')
+        cy.get(TestCasesPage.testCaseExecutionError).should(
+            'contain.text',
+            'No Population Criteria is associated with this measure. Please review the Population Criteria tab.'
+        )
     })
 
-    it('Validate Population Values check boxes are correct based on measure scoring value that is applied, ' +
-        'when the measure is initially created (default measure group)', () => {
-
+    it(
+        'Validate Population Values check boxes are correct based on measure scoring value that is applied, ' +
+            'when the measure is initially created (default measure group)',
+        () => {
             //Add Measure Group
             MeasureGroupPage.createMeasureGroupforProportionMeasure()
 
@@ -59,44 +59,38 @@ describe('Test Case Expected Measure Group population values based on initial me
             TestCasesPage.clickEditforCreatedTestCase()
 
             //click on Expected / Actual tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
             cy.get(TestCasesPage.testCasePopulationValuesTable).should('be.visible')
 
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+            TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-            cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+            TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-            cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-            cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
-    })
+            TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        }
+    )
 
-    it('Validate notification that a reset of population values, on test cases, will occur once the completed ' +
-        'save / update of the scoring value is executed', () => {
-
+    it(
+        'Validate notification that a reset of population values, on test cases, will occur once the completed ' +
+            'save / update of the scoring value is executed',
+        () => {
             //Click on Edit Measure
             MeasuresPage.actionCenter('edit')
             //navigate to CQL Editor page / tab
             cy.get(EditMeasurePage.cqlEditorTab).click()
             //read and write CQL from flat file
-            cy.readFile('cypress/fixtures/QICoreCleanCQL.txt').should('exist').then((fileContents) => {
-                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-            })
+            cy.readFile('cypress/fixtures/QICoreCleanCQL.txt')
+                .should('exist')
+                .then((fileContents) => {
+                    cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+                })
             //save CQL on measure
             cy.get(EditMeasurePage.cqlEditorSaveButton).click()
             //Click on the measure group tab
 
             cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+            CQLEditorPage.collapseEditor()
 
             cy.get(EditMeasurePage.measureGroupsTab).click()
 
@@ -108,7 +102,6 @@ describe('Test Case Expected Measure Group population values based on initial me
             cy.get(MeasureGroupPage.popBasis).type('Procedure')
             cy.get(MeasureGroupPage.popBasisOption).click()
 
-
             Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringRatio)
 
             Utilities.dropdownSelect(MeasureGroupPage.initialPopulationSelect, 'Surgical Absence of Cervix')
@@ -119,12 +112,18 @@ describe('Test Case Expected Measure Group population values based on initial me
 
             cy.get(MeasureGroupPage.reportingTab).click()
             Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
-            Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+            Utilities.dropdownSelect(
+                MeasureGroupPage.improvementNotationSelect,
+                'Increased score indicates improvement'
+            )
 
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
 
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+                'contain.text',
+                'Population details for this group saved successfully.'
+            )
 
             Utilities.dropdownSelect(MeasureGroupPage.measureScoringSelect, MeasureGroupPage.measureScoringCohort)
 
@@ -134,30 +133,39 @@ describe('Test Case Expected Measure Group population values based on initial me
 
             //validation message after attempting to save
             cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should('exist')
-            cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should('contain.text', 'Change Scoring?Your Measure Scoring is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure.Are you sure you want to Save Changes?This action cannot be undone.No, Keep WorkingYes, Save changes')
+            cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should(
+                'contain.text',
+                'Change Scoring?Your Measure Scoring is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure.Are you sure you want to Save Changes?This action cannot be undone.No, Keep WorkingYes, Save changes'
+            )
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
 
             cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should('not.exist')
-    })
+        }
+    )
 
-    it('Validate Population Values are reset on all test cases that exist under a measure group, after the score ' +
-        'unit value is saved / updated', () => {
-        let currentUser = Cypress.env('selectedUser')
+    it(
+        'Validate Population Values are reset on all test cases that exist under a measure group, after the score ' +
+            'unit value is saved / updated',
+        () => {
+            let currentUser = Cypress.env('selectedUser')
             //Click on Edit Measure
             MeasuresPage.actionCenter('edit')
             //navigate to CQL Editor page / tab
             cy.get(EditMeasurePage.cqlEditorTab).click()
             //read and write CQL from flat file
-            cy.readFile('cypress/fixtures/QICoreCleanCQL.txt').should('exist').then((fileContents) => {
-                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-            })
+            cy.readFile('cypress/fixtures/QICoreCleanCQL.txt')
+                .should('exist')
+                .then((fileContents) => {
+                    cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+                })
             //save CQL on measure
             cy.get(EditMeasurePage.cqlEditorSaveButton).click()
 
             cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+            CQLEditorPage.collapseEditor()
             //Click on the measure group tab
             cy.get(EditMeasurePage.measureGroupsTab).click()
             //log, in cypress, the measure score value
@@ -179,7 +187,10 @@ describe('Test Case Expected Measure Group population values based on initial me
 
             cy.get(MeasureGroupPage.reportingTab).click()
             Utilities.waitForElementVisible(MeasureGroupPage.improvementNotationSelect, 5000)
-            Utilities.dropdownSelect(MeasureGroupPage.improvementNotationSelect, 'Increased score indicates improvement')
+            Utilities.dropdownSelect(
+                MeasureGroupPage.improvementNotationSelect,
+                'Increased score indicates improvement'
+            )
 
             //save measure group
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible')
@@ -188,16 +199,17 @@ describe('Test Case Expected Measure Group population values based on initial me
             //validation message after attempting to save
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+                'contain.text',
+                'Population details for this group saved successfully.'
+            )
             //create test case
             TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries, validTestCaseJson)
             cy.get(EditMeasurePage.testCasesTab).click()
             TestCasesPage.clickEditforCreatedTestCase()
 
             //click on Expected / Actual tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
             cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
             cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
@@ -223,7 +235,10 @@ describe('Test Case Expected Measure Group population values based on initial me
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
             cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
-            cy.get(TestCasesPage.successMsg).should('contain.text', 'Test case updated successfully with warnings in JSON')
+            cy.get(TestCasesPage.successMsg).should(
+                'contain.text',
+                'Test case updated successfully with warnings in JSON'
+            )
 
             //navigate back to the measure group tab / page and...
             //change score unit value and save / update measure with new value
@@ -238,54 +253,61 @@ describe('Test Case Expected Measure Group population values based on initial me
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
             //validation message after attempting to save
             cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should('exist')
-            cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should('contain.text', 'Change Scoring?Your Measure Scoring is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure.Are you sure you want to Save Changes?This action cannot be undone.No, Keep WorkingYes, Save changes')
+            cy.get(MeasureGroupPage.scoreUpdateConfirmModal).should(
+                'contain.text',
+                'Change Scoring?Your Measure Scoring is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure.Are you sure you want to Save Changes?This action cannot be undone.No, Keep WorkingYes, Save changes'
+            )
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('exist')
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.visible')
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).should('be.enabled')
             cy.get(MeasureGroupPage.updateMeasureGroupConfirmationBtn).click()
 
-            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population ' +
-                'details for this group updated successfully.')
+            cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+                'contain.text',
+                'Population ' + 'details for this group updated successfully.'
+            )
 
+            cy.readFile('cypress/fixtures/' + currentUser + '/measureId')
+                .should('exist')
+                .then((fileContents) => {
+                    cy.intercept('GET', '/api/measures/' + fileContents + '/test-cases').as('testCase')
 
-            cy.readFile('cypress/fixtures/' + currentUser + '/measureId').should('exist').then((fileContents) => {
-                cy.intercept('GET', '/api/measures/' + fileContents + '/test-cases').as('testCase')
+                    //navigate back to the test case tab
+                    cy.get(EditMeasurePage.testCasesTab).click()
 
-                //navigate back to the test case tab
-                cy.get(EditMeasurePage.testCasesTab).click()
+                    cy.url({ timeout: 30000 }).should('include', '/edit/test-cases')
 
-                cy.url({ timeout: 30000 }).should('include', '/edit/test-cases')
-
-                cy.wait('@testCase').then(({ response }) => {
-                    expect(response?.statusCode).to.eq(200)
+                    cy.wait('@testCase').then(({ response }) => {
+                        expect(response?.statusCode).to.eq(200)
+                    })
                 })
-            })
             TestCasesPage.clickEditforCreatedTestCase()
 
             //click on Expected / Actual tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab()
 
             //confirm that check boxes that were checked are no longer checked
             cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
             cy.get(TestCasesPage.testCaseIPPExpected).should('be.empty')
-    })
+        }
+    )
 
     it('Test Case Population value options are limited to those that are defined from Measure Group -- required populations', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
         //navigate to CQL Editor page / tab
         cy.get(EditMeasurePage.cqlEditorTab).click()
         //read and write CQL from flat file
-        cy.readFile('cypress/fixtures/QICoreCleanCQL.txt').should('exist').then((fileContents) => {
-            cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
-        })
+        cy.readFile('cypress/fixtures/QICoreCleanCQL.txt')
+            .should('exist')
+            .then((fileContents) => {
+                cy.get(EditMeasurePage.cqlEditorTextBox).type(fileContents)
+            })
         //save CQL on measure
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.collapseEditor()
 
         //Click on the measure group tab
         cy.get(EditMeasurePage.measureGroupsTab).click()
@@ -326,7 +348,10 @@ describe('Test Case Expected Measure Group population values based on initial me
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully.'
+        )
 
         //Navigate to Test Cases page and verify Populations
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -337,12 +362,13 @@ describe('Test Case Expected Measure Group population values based on initial me
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('be.visible')
-        cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Group 1 - Proportion | Procedure')
+        cy.get(TestCasesPage.testCasePopulationValuesTable).should(
+            'contain.text',
+            'Measure Group 1 - Proportion | Procedure'
+        )
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Population')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Expected')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Actual')
@@ -356,28 +382,29 @@ describe('Test Case Expected Measure Group population values based on initial me
 })
 
 describe('Test Case Population dependencies', () => {
-
     before('Create measure and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, proportionMeasureCQL)
-        MeasureGroupPage.CreateProportionMeasureGroupAPI(0, false, 'Initial PopulationOne', '', '', 'Initial PopulationOne', '', 'Initial PopulationOne', 'Boolean')
+        MeasureGroupPage.CreateProportionMeasureGroupAPI(
+            0,
+            false,
+            'Initial PopulationOne',
+            '',
+            '',
+            'Initial PopulationOne',
+            '',
+            'Initial PopulationOne',
+            'Boolean'
+        )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
     })
 
     after('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Verify Test Case population dependencies for Proportion Measures', () => {
-
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -394,8 +421,10 @@ describe('Test Case Population dependencies', () => {
 
         //validation message after attempting to save
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('be.visible')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text',
-            'Population details for this group updated successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group updated successfully.'
+        )
 
         //create test case
         //Navigate to Test Cases page and add Test Case details
@@ -407,15 +436,10 @@ describe('Test Case Population dependencies', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         cy.log('Select DENOM and verify IPP is checked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -424,25 +448,25 @@ describe('Test Case Population dependencies', () => {
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.log('Uncheck IPP and verify DENOM is unchecked')
-        cy.get(TestCasesPage.testCaseIPPExpected).uncheck()
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.checked')
 
         //Select DENOM again
-        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.log('Uncheck DENOM and verify IPP is not unchecked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).uncheck()
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.log('Select Numerator and verify if DENOM and IPP are checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
@@ -450,27 +474,27 @@ describe('Test Case Population dependencies', () => {
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.log('Uncheck DENOM and verify if Numerator is unchecked')
-        cy.get(TestCasesPage.testCaseDENOMExpected).uncheck()
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.checked')
 
         cy.get(TestCasesPage.testCaseNUMERExpected).should('not.be.checked')
 
         //Check Numerator again
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.log('Uncheck Numerator and verify if Denom is not unchecked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).uncheck()
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('not.be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
 
         //Check Numerator again
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.log('Uncheck IPP and verify if DENOM and Numerator are unchecked')
-        cy.get(TestCasesPage.testCaseIPPExpected).uncheck()
+        TestCasesPage.uncheckExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
 
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.checked')
@@ -478,7 +502,7 @@ describe('Test Case Population dependencies', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).should('not.be.checked')
 
         cy.log('Select Numerator Exclusion and verify IPP, Numerator and Denominator are selected')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMEXExpected)
         cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.checked')
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
@@ -490,28 +514,19 @@ describe('Test Case Population dependencies', () => {
 })
 
 describe('Test Case Expected Measure Group population values based on initial measure scoring', () => {
-
     beforeEach('Create measure and login', () => {
-
         CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
         MeasureGroupPage.CreateRatioMeasureGroupAPI(false, false, undefined, undefined, undefined, 'Procedure')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        cy.get(EditMeasurePage.cqlEditorTab).click()
-        cy.get(EditMeasurePage.cqlEditorTextBox).click().type('{moveToEnd}{enter}')
-        cy.get(EditMeasurePage.cqlEditorSaveButton).click()
-        //wait for alert / successful save message to appear
-        Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 27700)
-        cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: false })
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Test Case Population value options are limited to those that are defined from Measure Group', () => {
-
         cy.get(EditMeasurePage.cqlEditorTab).click()
         cy.get(EditMeasurePage.cqlEditorTextBox).type('{moveToEnd}{enter}')
         cy.get(EditMeasurePage.cqlEditorSaveButton).click()
@@ -554,12 +569,13 @@ describe('Test Case Expected Measure Group population values based on initial me
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('be.visible')
-        cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Group 1 - Proportion | Procedure')
+        cy.get(TestCasesPage.testCasePopulationValuesTable).should(
+            'contain.text',
+            'Measure Group 1 - Proportion | Procedure'
+        )
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Population')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Expected')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Actual')
@@ -569,6 +585,5 @@ describe('Test Case Expected Measure Group population values based on initial me
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Exclusion')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Exclusion')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Exception')
-
     })
 })

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -318,12 +318,8 @@ Cypress.Commands.add('UMLSAPIKeyLogin', () => {
 })
 
 Cypress.Commands.add('editTestCaseJSON', (jsonContent: string) => {
-    Utilities.waitForElementVisible(TestCasesPage.aceEditor, 37700)
-    Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
-    cy.get(TestCasesPage.aceEditor).should('exist')
-    cy.get(TestCasesPage.aceEditor).should('be.visible')
+    TestCasesPage.waitForJsonEditorReady()
     cy.get(TestCasesPage.aceEditorJsonInput)
-        .should('exist')
         .click({ force: true })
         .clear({ force: true })
         .type(jsonContent, { parseSpecialCharSequences: false, force: true })

--- a/docs/ai/debugging.md
+++ b/docs/ai/debugging.md
@@ -36,6 +36,18 @@ For timeouts, check:
 6. Is there a permission or role issue?
 7. Is the element hidden behind a menu, tooltip, drawer, or modal?
 
+## Expected/Actual Panel Failures
+
+If a failure happens on the Test Case Expected/Actual panel and Cypress reports that an expected-value checkbox is covered, clipped, or not visible:
+
+1. Check whether the spec is using `TestCasesPage.openExpectedActualTab(...)`.
+2. Check whether boolean expected-value toggles use `checkExpectedActualCheckbox(...)` or `uncheckExpectedActualCheckbox(...)`.
+3. Treat split-panel sash overlap and clipped overflow as the first likely cause before changing selectors.
+4. Do not add `{ force: true }` for these checkbox flows unless the test is intentionally validating a hidden or native-only control.
+5. Do not keep `should('be.visible')` assertions on clipped expected-value checkboxes when the shared helper already proves readiness.
+
+Focused Cypress validation on Monday, July 20, 2026 showed this issue in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`, and the stable fix was to use the shared Expected/Actual helper path rather than raw tab clicks plus checkbox actions.
+
 ## Selector Debugging
 
 Prefer this order:

--- a/docs/quality/cypress-automation-guidelines.md
+++ b/docs/quality/cypress-automation-guidelines.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Automation Guidelines
 
-Last updated: 2026-07-15
+Last updated: 2026-07-20
 
 This guide captures stable test-architecture rules used in this repo. Keep tactical plans and changing counts in `docs/quality/test-refactor-backlog.md`.
 
@@ -45,6 +45,7 @@ These helper paths are already established and should be reused before adding ne
 - Avoid global exception suppression. If an exception must be tolerated, make the handling targeted and explain the scope.
 - Prefer stable `data-testid` selectors when available.
 - When a spec creates uniquely named rows in a list, select those rows by generated name or stored ID instead of fixture-position helpers or table order. Row-order selection becomes flaky when cleanup is partial or older test data is still visible.
+- In Expected/Actual test-case flows, prefer `TestCasesPage.openExpectedActualTab(...)` plus `checkExpectedActualCheckbox(...)` or `uncheckExpectedActualCheckbox(...)` over direct tab clicks and raw boolean checkbox actions. On Monday, July 20, 2026, focused Cypress validation showed the split-panel sash can leave expected-value checkboxes clipped or reported as covered even when the selector is correct. Avoid pre-asserting `be.visible` on those clipped boolean inputs; rely on the shared helper to normalize the panel first.
 
 ## Refactor Rules
 

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Quality Architecture Backlog
 
-Last updated: 2026-07-20
+Last updated: 2026-07-21
 
 Stable rules live in `docs/quality/cypress-automation-guidelines.md`. Keep this backlog limited to current state, next actions, measured audit signal, and validation.
 
@@ -62,8 +62,8 @@ Why this is the best next step:
 - `CQLLibraryPage.ts` now passes focused version-action coverage after replacing its helper-level sleeps with action-trigger visibility and list-row readiness checks.
 - `MeasureGroupPage.ts` no longer contains fixed waits after replacing helper-level CQL seeding sleeps with editor-write readiness, save-success assertions, and a stable return to Population Criteria via the existing editor-collapse control plus group-tab retry.
 - Focused helper validation now shifts the best next value to `TestCasesPage.ts`, where remaining waits and heavy forced interactions overlap with the currently observed Expected/Actual sash-actionability failures.
-- Focused Cypress validation on Monday, July 20, 2026 now proves the shared Expected/Actual helper path in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`. The remaining value in this slice is broader adoption across the other specs that still use direct tab clicks and raw checkbox actions in the split-panel layout.
-- An inventory sweep on Monday, July 20, 2026 found 55 Expected/Actual-touching WebInterface specs, with the highest migration risk concentrated in a smaller bucket of boolean-checkbox flows that still use direct tab clicks, raw checkbox actions, or clipped-checkbox visibility assertions. The current top targets are `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `RatioPatientTwoIPsWithMOs.cy.ts`, `ExecuteTestCasesByNonMeasureOwner.cy.ts`, `RunAndExecuteTestCaseButtonValidations.cy.ts`, `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts`, and `QDMRunExecuteTC.cy.ts`.
+- Focused Cypress validation on Tuesday, July 21, 2026 now proves the shared Expected/Actual helper path in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, `RatioPatientSingleIPNoMOwithDRC.cy.ts`, `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `CohortEpisodeEncounter.cy.ts`, `CohortPatientBoolean.cy.ts`, `CohortEncounter600.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, `CVEpisodeWithMO.cy.ts`, `CVPatientwithMO.cy.ts`, `CVEpisodeWithStratification.cy.ts`, `CVPatientWithStratification.cy.ts`, `CohortPatientWithStratification.cy.ts`, `CohortEpisodeWithStratification.cy.ts`, `ProportionEpisode.cy.ts`, `RatioEncounterSingleIPWithMOs600.cy.ts`, `CVEncounterWithMOandStrat600.cy.ts`, `RatioEpisodeTwoIPsWithMOs.cy.ts`, `Cohort_ListQDMPositiveEncounterPerformed.cy.ts`, `Proportion_ListQDMPositiveProcedurePerformed.cy.ts`, and `ProportionPatient.cy.ts`. Local Cypress validation on Tuesday, July 21, 2026 also confirmed `CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts`, `Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts`, `Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts`, and `ExecuteTestCasesByNonMeasureOwner.cy.ts` passing after the shared helper update. `TestCasesPage.openExpectedActualTab(...)` now also tolerates QDM Expected/Actual layouts that do not render the split-panel population container, while still normalizing the Qi-Core split-panel scroll position when that container exists. The remaining value in this slice now shifts to non-smoke execution, import, and validation specs that still bypass the shared Expected/Actual helper path, while the product-question ratio observation files remain blocked on SME confirmation.
+- An inventory sweep on Monday, July 20, 2026 found 55 Expected/Actual-touching WebInterface specs, with the highest migration risk concentrated in a smaller bucket of boolean-checkbox flows that still use direct tab clicks, raw checkbox actions, or clipped-checkbox visibility assertions. The current top targets are `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts`. Keep `RatioPatientTwoIPsWithMOs.cy.ts` and `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts` sidelined until product or SME confirmation resolves the observation-row behavior.
 
 Work boundary for the next slice:
 
@@ -95,7 +95,7 @@ Recently proven service/helper slices:
 - UI CQL library shared-page-object reliability proof: `CQLLibraryPage.ts` no longer contains fixed waits after replacing helper-level action-menu and first-row sleeps with trigger visibility plus row-readiness assertions, and `AddVersionToCQLLibrary.cy.ts` passes against both the list and edit-screen action-center flows.
 - UI measure-group shared-page-object reliability proof: `MeasureGroupPage.ts` no longer contains fixed waits after consolidating repeated CQL setup behind editor-write and save-success assertions plus the existing editor-collapse control before returning to Population Criteria. Focused `MeasureObservations.cy.ts` validation on Monday, July 20, 2026 passed 7 tests, including `Add Measure Observations for Ratio Measure` and `Add Measure Observations for Continuous Variable Measure`; the remaining 2 failures were downstream Expected/Actual checkbox actionability issues caused by the test-case sash overlay, not by the measure-group helper path.
 - UI Expected/Actual reliability proof: focused Cypress validation on Monday, July 20, 2026 showed `MeasureObservations.cy.ts` passing 9/9 after routing boolean Expected/Actual flows through `TestCasesPage.openExpectedActualTab(...)` plus `checkExpectedActualCheckbox(...)` and `uncheckExpectedActualCheckbox(...)`. The same helper path now also passes in `MeasureObservationExpectedValues.cy.ts` and `RatioPatientSingleIPNoMOwithDRC.cy.ts`, proving the sash-covered checkbox issue is a reusable split-panel readiness problem rather than a spec-local selector defect.
-- UI Expected/Actual migration inventory: the Monday, July 20, 2026 scan identified 8 high-risk specs, 18 medium-risk specs, and 26 lower-risk specs still using some form of direct Expected/Actual tab interaction or raw checkbox flow. Only 3 specs are fully migrated to the shared helper path so far: `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`.
+- UI Expected/Actual migration inventory: the Monday, July 20, 2026 scan identified 8 high-risk specs, 18 medium-risk specs, and 26 lower-risk specs still using some form of direct Expected/Actual tab interaction or raw checkbox flow. 27 specs are now proven on the shared helper path through focused or local validation: `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, `RatioPatientSingleIPNoMOwithDRC.cy.ts`, `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `CohortEpisodeEncounter.cy.ts`, `CohortPatientBoolean.cy.ts`, `CohortEncounter600.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, `CVEpisodeWithMO.cy.ts`, `CVPatientwithMO.cy.ts`, `CVEpisodeWithStratification.cy.ts`, `CVPatientWithStratification.cy.ts`, `CohortPatientWithStratification.cy.ts`, `CohortEpisodeWithStratification.cy.ts`, `ProportionEpisode.cy.ts`, `RatioEncounterSingleIPWithMOs600.cy.ts`, `CVEncounterWithMOandStrat600.cy.ts`, `RatioEpisodeTwoIPsWithMOs.cy.ts`, `Cohort_ListQDMPositiveEncounterPerformed.cy.ts`, `Proportion_ListQDMPositiveProcedurePerformed.cy.ts`, `ProportionPatient.cy.ts`, `CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts`, `Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts`, `Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts`, and `ExecuteTestCasesByNonMeasureOwner.cy.ts`.
 - Shared auth/lock helper cleanup: `Utilities.ts` now routes share-permission requests plus measure/library/test-case lock and unlock-cleanup requests through `TestData` reads and authenticated request helpers.
 - Shared measure cleanup completion: `Utilities.deleteMeasure` and `Utilities.deleteVersionedMeasure` now delegate authenticated delete flows to `TestData` by-ID helpers while preserving graceful missing-fixture cleanup behavior.
 - Shared builder fixture cleanup: `TestCaseBuilder.ts` now routes builder resource fixture naming through `TestData`, so shared helpers own that user-scoped fixture convention.
@@ -111,14 +111,14 @@ Recently diagnosed non-refactor failures:
 
 ## Latest Audit Signal
 
-Command: `npm run quality:audit` on 2026-07-20
+Command: `npm run quality:no-focused-tests` on 2026-07-21
 
-- Inventory: 256 specs / 65645 spec lines; 29 shared files / 18677 shared lines; 3 support files / 633 support lines; 9 scripts / 1511 script lines.
+- Inventory: 256 specs / 65547 spec lines; 29 shared files / 18778 shared lines; 3 support files / 633 support lines; 9 scripts / 1511 script lines.
 - Skipped tests: 11.
 - Manual fixture path plumbing: 191.
 - Manual access token plumbing: 87.
 - Fixed waits: 38.
-- Forced interactions: 194.
+- Forced interactions: 193.
 - Global uncaught exception suppression: 1.
 
 Largest risk concentrations:
@@ -127,9 +127,7 @@ Largest risk concentrations:
 - `OktaLogin.ts` and `TestCasesPage.ts` now carry the remaining shared-helper fixed waits.
 - `QDMRunExecuteTC.cy.ts` dropped out of the fixed-wait hotspot list after its three execution waits were replaced with editor-ready and modal-aware assertions that held in focused Cypress validation on Friday, July 17, 2026.
 - `CQLLibraryPage.ts` dropped out of the fixed-wait hotspot list after its two helper sleeps were replaced with shared action-trigger and row-readiness assertions that held in focused Cypress validation on Friday, July 17, 2026.
-- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions; fixture-path and create-test-case API setup cleanup is complete.
-- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions and the broader migration of Expected/Actual specs onto the shared split-panel helper path; fixture-path and create-test-case API setup cleanup is complete.
-- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions and the broader migration of Expected/Actual specs onto the shared split-panel helper path; fixture-path and create-test-case API setup cleanup is complete. The next adoption wave should start with the 8 high-risk inventory specs before the medium- and low-risk buckets.
+- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions and the remaining non-smoke Expected/Actual execution, import, and validation specs that still bypass the shared helper path; fixture-path and create-test-case API setup cleanup is complete.
 - `AdminLibraryTransfer.cy.ts` and related transfer coverage: UI transfer specs still mix API-eligible setup with browser-only assertions, duplicate transfer/history checks, and combine distinct validation concerns in the same test flow.
 - `CorrectExpectedValues.cy.ts`, `DeleteTest-Case.cy.ts`, and selected admin/measure/test-case service specs: remaining service-tail cleanup.
 - highlighting specs, remaining QDM export or execution specs, and shared page objects: UI reliability debt from waits and forced interactions.
@@ -152,8 +150,8 @@ Completed signal:
 Current target order:
 
 - shared page objects with remaining waits and high reuse: `OktaLogin.ts`, `TestCasesPage.ts`
-- `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream layout and forced-interaction debt, including sash-covered checkbox interactions seen in `MeasureObservationExpectedValues.cy.ts` and `MeasureObservations.cy.ts`
-- `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream layout and forced-interaction debt, including sash-covered checkbox interactions proven in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`
+- `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream forced-interaction debt, but the shared helper path is now proven across the smoke-folder rollout plus `ExecuteTestCasesByNonMeasureOwner.cy.ts`, including both Qi-Core split-panel and QDM non-panel Expected/Actual layouts
+- the next Expected/Actual adoption wave should focus on non-smoke execution, import, and validation specs such as `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and the remaining QDM execution specs
 - remaining export specs that still rely on repeated unzip or download setup
 - export and terminology-heavy UI specs surfaced near the top of the wait audit
 - forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Quality Architecture Backlog
 
-Last updated: 2026-07-14
+Last updated: 2026-07-20
 
 Stable rules live in `docs/quality/cypress-automation-guidelines.md`. Keep this backlog limited to current state, next actions, measured audit signal, and validation.
 
@@ -42,21 +42,34 @@ Do not begin the next backlog item until the current one is complete.
 
 Current active item:
 
-- P2 shared helper hardening, next target `cypress/Shared/TestCaseBuilder.ts`
+- P2 UI reliability debt, next target `cypress/Shared/TestCasesPage.ts`
 
 Why this is the best next step:
 
-- P1 CQL library service cleanup is already proven.
+- Earlier CQL library service cleanup is already proven.
 - `TestCasesPage.ts` fixture-path plumbing and create-test-case API setup now route through `TestData`.
-- `CreateMeasurePage.ts` no longer has direct fixture-path plumbing in shared helper code.
-- `Utilities.ts` delete, admin-cleanup, sharing, and lock helper request setup now route through `TestData`.
-- `TestCaseBuilder.ts` is now the clearest remaining shared-helper owner of user-scoped fixture-path plumbing.
+- `CreateMeasurePage.ts` now routes user scope, fixture writes, and create or clone request setup through `TestData`, so that shared helper no longer owns custom measure-create request plumbing.
+- `TestCaseBuilder.ts` now routes builder resource fixture naming through `TestData`, concentrating the remaining P1 value in a smaller number of shared helpers.
+- Shared-helper request setup is now centralized behind `TestData` for the remaining reusable page-object and utility paths that previously owned custom user-scope, fixture, lock, share, and create-request plumbing.
+- `MinimizeAlerts.cy.ts` now proves the alert-toggle readiness pattern by waiting on visible page state instead of fixed sleeps and by routing repeated minimize or reopen mechanics through `CQLEditorPage`.
+- `CQLCodeSystem.cy.ts` now proves the editor-return readiness pattern by replacing fixed post-tab sleeps with visible editor assertions and retried error checks.
+- `QmigSTU5FileValidations.cy.ts` now proves the export-archive readiness pattern by replacing post-unzip sleeps with extracted-file existence checks and by consolidating repeated export or unzip setup behind local helpers.
+- `TestCaseJSON_TerminologyTests.cy.ts` now proves the JSON-editor readiness pattern by moving terminology cases onto shared editor-ready helpers instead of fixed sleeps before typing JSON content.
+- `MeasureListNewColumnsSort.cy.ts` and `CQLLibraryListPageColumnSort.cy.ts` now prove a reusable list-sorting pattern that replaces fixed sleeps with route aliases plus shared list-render readiness helpers.
+- `QICoreMeasureExport.cy.ts` now proves the export-file readiness pattern by waiting on the version dialog field and the unzipped local HTML file instead of fixed sleeps.
+- `CQLEditorPage.ts` now proves the shared builder-expand and replace-document readiness pattern by replacing helper-level sleeps with editor focusability and document-ready checks that passed in both mismatch and Qi Core function editor flows.
+- `QDMRunExecuteTC.cy.ts` now passes its focused execution-validation coverage after replacing three fixed waits with API-seeded setup, editor-ready saves, and explicit dirty-state handling.
+- `CQLLibraryPage.ts` now passes focused version-action coverage after replacing its helper-level sleeps with action-trigger visibility and list-row readiness checks.
+- `MeasureGroupPage.ts` no longer contains fixed waits after replacing helper-level CQL seeding sleeps with editor-write readiness, save-success assertions, and a stable return to Population Criteria via the existing editor-collapse control plus group-tab retry.
+- Focused helper validation now shifts the best next value to `TestCasesPage.ts`, where remaining waits and heavy forced interactions overlap with the currently observed Expected/Actual sash-actionability failures.
+- Focused Cypress validation on Monday, July 20, 2026 now proves the shared Expected/Actual helper path in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`. The remaining value in this slice is broader adoption across the other specs that still use direct tab clicks and raw checkbox actions in the split-panel layout.
+- An inventory sweep on Monday, July 20, 2026 found 55 Expected/Actual-touching WebInterface specs, with the highest migration risk concentrated in a smaller bucket of boolean-checkbox flows that still use direct tab clicks, raw checkbox actions, or clipped-checkbox visibility assertions. The current top targets are `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `RatioPatientTwoIPsWithMOs.cy.ts`, `ExecuteTestCasesByNonMeasureOwner.cy.ts`, `RunAndExecuteTestCaseButtonValidations.cy.ts`, `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts`, and `QDMRunExecuteTC.cy.ts`.
 
 Work boundary for the next slice:
 
-- Stay inside `TestCaseBuilder.ts` unless a small supporting `TestData` change is required.
-- Prefer moving service-style setup and path conventions behind existing helpers before touching UI interaction patterns.
-- Do not combine this with broader builder wait/force cleanup.
+- Stay inside `cypress/Shared/TestCasesPage.ts` unless a very small consuming-spec adjustment is required to prove the helper change.
+- Prioritize reusable readiness or layout helpers for Expected/Actual and related test-case editor flows before touching broader spec logic.
+- Do not combine this slice with broader export, highlighting, or transfer refactors.
 
 ## Current State
 
@@ -65,64 +78,84 @@ Recently proven service/helper slices:
 - Measure service: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QI Core Test-Cases.cy.ts`.
 - QDM service: `QDM Test-Cases.cy.ts`, `QDM Measure.cy.ts`, `QDMMeasureVersion.cy.ts`.
 - CQL library service: `CreateCQL-Library.cy.ts`, `EditCQL-Library.cy.ts`, `VersionAndDraftCQL-Library.cy.ts`, `CQLLibraryDelete.cy.ts`.
-- Shared create/fixture path: `CreateMeasurePage.ts` now routes fixture writes, measure create/clone requests, and draft measure ID reads through `TestData` helpers.
-- Shared cleanup/request helpers: `Utilities.deleteLibrary` and the API create/update setup in `MeasureGroupPage.ts` now route fixture reads and authenticated requests through `TestData`.
+- Shared create/fixture path: `CreateMeasurePage.ts` now routes user scope, fixture writes, measure create/clone requests, and draft measure ID reads through `TestData` helpers.
+- Shared cleanup/request helpers: `Utilities.deleteLibrary`, `Utilities` lock and unlock flows, and the `MeasureGroupPage.ts` API create, update, and stratification setup now route fixture reads and authenticated requests through `TestData`.
 - Shared test-case helper cleanup: `TestCasesPage.ts` now routes element/test-case fixture writes, measure/test-case fixture reads, and create-test-case API requests through `TestData`.
+- Shared validation proof: `QDM Measure.cy.ts` and `QI Core Test-Cases.cy.ts` now pass against the recent shared-helper conversions in the current workspace once Cypress is run with the invalid `NODE_EXTRA_CA_CERTS` placeholder unset.
+- Shared sharing helper cleanup: `Utilities.setSharePermissions(...)` now delegates library and measure share or unshare request construction through `TestData`, and `CQLLibrarySharing.cy.ts` passes against that path in the current workspace.
+- UI sort reliability proof: `MeasureListNewColumnsSort.cy.ts` now passes after replacing its fixed post-sort waits with route-alias and render-readiness checks, including status assertions tied to the sorted API responses instead of environment-specific row assumptions.
+- UI sort reliability proof: `CQLLibraryListPageColumnSort.cy.ts` now passes after replacing its fixed post-sort waits with route-alias and render-readiness checks, including status assertions tied to the sorted API responses instead of environment-specific row assumptions.
+- UI export reliability proof: `QICoreMeasureExport.cy.ts` now passes after replacing fixed waits with version-dialog visibility checks plus unzipped-file existence and local HTML readiness assertions for the human-readable export flows.
+- UI QMIG export reliability proof: `QmigSTU5FileValidations.cy.ts` now passes after replacing repeated post-unzip sleeps with extracted-archive existence checks while preserving the existing archive-content assertions.
+- UI alert reliability proof: `MinimizeAlerts.cy.ts` now passes after replacing navigation and alert re-open sleeps with visible-state assertions and shared `CQLEditorPage` minimize or reopen helpers.
+- UI code-system reliability proof: `CQLCodeSystem.cy.ts` now passes after replacing repeated fixed waits with helper-backed editor-return assertions that let Cypress retry on the editor state instead of sleeping between tab switches.
+- UI shared-editor reliability proof: `CQLEditorPage.ts` no longer contains fixed waits after replacing replace-document sleeps with focused editor clearing and builder-expand sleeps with document-ready retries, and both `MeasureLibraryMismatch.cy.ts` and `QiCoreCQLFunctions.cy.ts` pass against that shared path.
+- UI terminology reliability proof: `TestCaseJSON_TerminologyTests.cy.ts` now passes after replacing repeated fixed waits before JSON editing with shared `TestCasesPage` JSON-editor readiness helpers used by both the spec and the custom command.
+- UI QDM execution reliability proof: `QDMRunExecuteTC.cy.ts` now passes focused coverage for its three former fixed-wait paths after seeding valid CQL in API setup, reusing `CQLEditorPage.saveCql(...)` for editor-ready saves, and handling the test-case dirty-state modal explicitly before returning to the execution list.
+- UI CQL library shared-page-object reliability proof: `CQLLibraryPage.ts` no longer contains fixed waits after replacing helper-level action-menu and first-row sleeps with trigger visibility plus row-readiness assertions, and `AddVersionToCQLLibrary.cy.ts` passes against both the list and edit-screen action-center flows.
+- UI measure-group shared-page-object reliability proof: `MeasureGroupPage.ts` no longer contains fixed waits after consolidating repeated CQL setup behind editor-write and save-success assertions plus the existing editor-collapse control before returning to Population Criteria. Focused `MeasureObservations.cy.ts` validation on Monday, July 20, 2026 passed 7 tests, including `Add Measure Observations for Ratio Measure` and `Add Measure Observations for Continuous Variable Measure`; the remaining 2 failures were downstream Expected/Actual checkbox actionability issues caused by the test-case sash overlay, not by the measure-group helper path.
+- UI Expected/Actual reliability proof: focused Cypress validation on Monday, July 20, 2026 showed `MeasureObservations.cy.ts` passing 9/9 after routing boolean Expected/Actual flows through `TestCasesPage.openExpectedActualTab(...)` plus `checkExpectedActualCheckbox(...)` and `uncheckExpectedActualCheckbox(...)`. The same helper path now also passes in `MeasureObservationExpectedValues.cy.ts` and `RatioPatientSingleIPNoMOwithDRC.cy.ts`, proving the sash-covered checkbox issue is a reusable split-panel readiness problem rather than a spec-local selector defect.
+- UI Expected/Actual migration inventory: the Monday, July 20, 2026 scan identified 8 high-risk specs, 18 medium-risk specs, and 26 lower-risk specs still using some form of direct Expected/Actual tab interaction or raw checkbox flow. Only 3 specs are fully migrated to the shared helper path so far: `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`.
 - Shared auth/lock helper cleanup: `Utilities.ts` now routes share-permission requests plus measure/library/test-case lock and unlock-cleanup requests through `TestData` reads and authenticated request helpers.
 - Shared measure cleanup completion: `Utilities.deleteMeasure` and `Utilities.deleteVersionedMeasure` now delegate authenticated delete flows to `TestData` by-ID helpers while preserving graceful missing-fixture cleanup behavior.
+- Shared builder fixture cleanup: `TestCaseBuilder.ts` now routes builder resource fixture naming through `TestData`, so shared helpers own that user-scoped fixture convention.
+- Shared CQL library fixture cleanup: `CQLLibraryPage.ts` now routes created-library fixture writes through `TestData` helpers instead of hard-coded `cqlLibraryId` fixture names.
+- Shared test-case fixture cleanup: `TestCasesPage.ts` now routes `elementId`, `testCaseId`, and `testCasePId` fixture reads and writes through dedicated `TestData` helpers instead of raw fixture keys.
+- Shared measure-group fixture cleanup: `MeasureGroupPage.ts` now routes standard `groupId` and `groupId2` fixture writes through `TestData` helpers instead of raw fixture names, while preserving the existing `measureGroupId` exception used by older consumers.
 
 Recently diagnosed non-refactor failures:
 
 - `CQLLibraryDelete.cy.ts` still fails on current `master` because transfer cases return inactive-user `400` responses and admin delete-all cases return `403 insufficient_scope`. Treat that as environment or account-state drift, not as the next refactor target.
 - `CQLLibraryTransfer.cy.ts` currently mixes two separate issues on `dev`: transfer and sharing flows can fail with `400 The provided HARP ID is not associated with an active MADiE user.` for the configured alt user, and the owned-library action-center flow remains slow and intermittently fails on action visibility or missing success toast after long UI login/user-switch cycles. Treat the inactive-user path as environment or account-state drift first; do not attempt session-login conversion in this file until that is resolved.
+- `Measure.cy.ts` still has a non-refactor service failure on July 16, 2026 in `Validation Error: CQL library Name contains special characters`, where the service returns `500` instead of the expected `400` while other measure-service validation paths stay green.
 
 ## Latest Audit Signal
 
-Command: `npm run quality:audit`
+Command: `npm run quality:audit` on 2026-07-20
 
-- Inventory: 256 specs / 65636 spec lines; 29 shared files / 18518 shared lines; 3 support files / 637 support lines; 8 scripts / 1296 script lines.
+- Inventory: 256 specs / 65645 spec lines; 29 shared files / 18677 shared lines; 3 support files / 633 support lines; 9 scripts / 1511 script lines.
 - Skipped tests: 11.
-- Manual fixture path plumbing: 208.
+- Manual fixture path plumbing: 191.
 - Manual access token plumbing: 87.
-- Fixed waits: 101.
-- Forced interactions: 195.
+- Fixed waits: 38.
+- Forced interactions: 194.
 - Global uncaught exception suppression: 1.
 
 Largest risk concentrations:
 
-- `TestCaseBuilder.ts`: remaining shared-helper fixture-path plumbing still writes builder resource IDs through hand-built user-scoped paths.
+- `MeasureGroupPage.ts` dropped out of the fixed-wait hotspot list after its three helper sleeps were replaced with editor-ready and save-success assertions that held in focused measure-observation coverage on Monday, July 20, 2026.
+- `OktaLogin.ts` and `TestCasesPage.ts` now carry the remaining shared-helper fixed waits.
+- `QDMRunExecuteTC.cy.ts` dropped out of the fixed-wait hotspot list after its three execution waits were replaced with editor-ready and modal-aware assertions that held in focused Cypress validation on Friday, July 17, 2026.
+- `CQLLibraryPage.ts` dropped out of the fixed-wait hotspot list after its two helper sleeps were replaced with shared action-trigger and row-readiness assertions that held in focused Cypress validation on Friday, July 17, 2026.
 - `TestCasesPage.ts`: remaining UI reliability debt from forced interactions; fixture-path and create-test-case API setup cleanup is complete.
+- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions and the broader migration of Expected/Actual specs onto the shared split-panel helper path; fixture-path and create-test-case API setup cleanup is complete.
+- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions and the broader migration of Expected/Actual specs onto the shared split-panel helper path; fixture-path and create-test-case API setup cleanup is complete. The next adoption wave should start with the 8 high-risk inventory specs before the medium- and low-risk buckets.
 - `AdminLibraryTransfer.cy.ts` and related transfer coverage: UI transfer specs still mix API-eligible setup with browser-only assertions, duplicate transfer/history checks, and combine distinct validation concerns in the same test flow.
 - `CorrectExpectedValues.cy.ts`, `DeleteTest-Case.cy.ts`, and selected admin/measure/test-case service specs: remaining service-tail cleanup.
-- `MeasureListNewColumnsSort.cy.ts`, `CQLLibraryListPageColumnSort.cy.ts`, export specs, highlighting specs, and editor flows: UI reliability debt from waits and forced interactions.
+- highlighting specs, remaining QDM export or execution specs, and shared page objects: UI reliability debt from waits and forced interactions.
 - `cypress/support/e2e.ts`: global `uncaught:exception` suppression.
 
 ## Priorities
 
-### P1: CQL Library Service Cleanup
+### P1: Shared Helper and Infrastructure Hardening
 
 Status: Done
 
 Completed signal:
 
-- Repeated token/header/request setup moved behind shared helpers.
-- Negative states stayed explicit.
-- Focused validation exposed preexisting non-refactor failures instead of helper regressions.
+- Shared helpers now own the reusable user-scoped fixture naming and common request setup that had been spread across `CreateMeasurePage.ts`, `TestCasesPage.ts`, `MeasureGroupPage.ts`, `Utilities.ts`, `CQLLibraryPage.ts`, and `TestCaseBuilder.ts`.
+- Focused validation passed for the recent helper conversions in `QDM Measure.cy.ts`, `QI Core Test-Cases.cy.ts`, and `CQLLibrarySharing.cy.ts`.
+- Remaining hotspots in the audit now center on UI reliability and service-tail specs rather than shared helper request mechanics.
 
-### P2: Shared Helper and Infrastructure Hardening
+### P2: UI Reliability Debt
 
 Current target order:
 
-- `TestCaseBuilder.ts`
-- remaining shared page-object service helpers
-
-Done when shared helpers own path conventions and common request setup, and page objects no longer spread service setup mechanics.
-
-### P3: UI Reliability Debt
-
-Start with:
-
-- fixed waits in list sorting, export, and terminology-heavy specs
+- shared page objects with remaining waits and high reuse: `OktaLogin.ts`, `TestCasesPage.ts`
+- `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream layout and forced-interaction debt, including sash-covered checkbox interactions seen in `MeasureObservationExpectedValues.cy.ts` and `MeasureObservations.cy.ts`
+- `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream layout and forced-interaction debt, including sash-covered checkbox interactions proven in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`
+- remaining export specs that still rely on repeated unzip or download setup
+- export and terminology-heavy UI specs surfaced near the top of the wait audit
 - forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows
 - transfer specs that should move setup and ownership/share mechanics behind APIs before UI assertions, starting with `cypress/e2e/WebInterface/CQL Library/CQL Library Transfer/AdminLibraryTransfer.cy.ts`
 - global exception suppression in `cypress/support/e2e.ts`
@@ -130,7 +163,7 @@ Start with:
 
 Done when waits are replaced by route aliases, visible/enabled assertions, or polling helpers; forced interactions are justified or removed; exception handling is targeted.
 
-### P4: Remaining Service Tail Cleanup
+### P3: Remaining Service Tail Cleanup
 
 Candidates:
 


### PR DESCRIPTION
## Update Summary

This branch continues the `TestCasesPage` Expected/Actual reliability rollout by moving more specs onto the shared helper path and tightening the shared helper behavior itself.

### What changed

- Expanded shared Expected/Actual helper adoption across Qi-Core and QDM specs
- Updated `TestCasesPage.openExpectedActualTab(...)` to support both:
  - Qi-Core split-panel Expected/Actual layouts
  - QDM Expected/Actual layouts that do not render the population panel
- Replaced more direct `Expected / Actual` tab clicks and raw checkbox flows with shared helper usage

### Main areas updated

- `cypress/Shared/TestCasesPage.ts`
- Qi-Core execution specs:
  - `BooleanAndNonBooleanExpectedValues.cy.ts`
  - `TestCaseExpectedValues.cy.ts`
  - `TestCasePopulationValues.cy.ts`
  - `ExecuteTestCasesByNonMeasureOwner.cy.ts`
- Qi-Core and QDM smoke specs covering cohort, CV, proportion, and ratio Expected/Actual flows
- `docs/quality/test-refactor-backlog.md`

### Validation

Validated with:
- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`
- focused Cypress smoke and execution batches during migration

Local validation on Tuesday, July 21, 2026 also confirmed these passing after the helper updates:
- `Ratio_EncounterPerformed_multipleCriterias_WithMO`
- `CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification`
- `Ratio_ListQDMPositiveEncounterPerformed_WithMO`
- `ExecuteTestCasesByNonMeasureOwner.cy.ts`

### Status

- Smoke-folder Expected/Actual rollout is effectively complete for this helper-adoption slice
- `ExecuteTestCasesByNonMeasureOwner.cy.ts` is no longer treated as an unfinished top target
- Backlog accounting now reflects 27 specs proven on the shared helper path through focused or local validation

### Still deferred

These remain intentionally sidelined pending product/SME confirmation of observation-row behavior:
- `RatioPatientTwoIPsWithMOs.cy.ts`
- `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts`

### Next likely targets

- `RunAndExecuteTestCaseButtonValidations.cy.ts`
- `MeasureObservationActualValues.cy.ts`
- `ExecutionAndCoverageValidations.cy.ts`
- `TestCaseExecutionWithCode.cy.ts`
- remaining QDM execution specs still bypassing the shared helper path