### PR TITLE
Stabilize TestCasesPage expected actual flows

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -307,6 +307,12 @@ export class TestCasesPage {
     '[data-testid="Strata 1-measurePopulation-expected"]'
   public static readonly initialPopulationStrata2ExpectedValue = '[data-testid="Strata 2-initialPopulation-expected"]'
   public static readonly measurePopulationStrata2ExpectedValue = '[data-testid="Strata 2-measurePopulation-expected"]'
+  public static readonly qdmStrata1ExpectedValue = '[data-testid="test-population-Strata-1 -expected-0"]'
+  public static readonly qdmStrata2ExpectedValue = '[data-testid="test-population-Strata-2 -expected-0"]'
+  public static readonly qdmStratifiedInitialPopulationExpectedValue =
+    '[data-testid="strat-test-population-initialPopulation-expected-0"]'
+  public static readonly qdmStratifiedMeasurePopulationExpectedValue =
+    '[data-testid="strat-test-population-measurePopulation-expected-1"]'
 
   //measure versioning attempt with invalid test case
   public static readonly versionMeasureWithTCErrors =
@@ -456,6 +462,10 @@ export class TestCasesPage {
 
   private static measureNumber(secondMeasure?: boolean, measureNumber = 0): number {
     return secondMeasure ? 2 : measureNumber
+  }
+
+  public static qdmStratifiedMeasureObservationExpectedValue(index: number): string {
+    return `[data-testid="strat-test-population-measurePopulationObservation-expected-${index}"]`
   }
 
   //This function grabs the data-testid value off of the view button and extracts the id out of it.
@@ -888,6 +898,36 @@ export class TestCasesPage {
     }
 
     checkbox.should('exist').uncheck({ scrollBehavior: 'center' })
+  }
+
+  public static typeExpectedActualValue(
+    inputSelector: string,
+    value: string,
+    options: {
+      clearFirst?: boolean
+      index?: number
+    } = {},
+  ): void {
+    const { clearFirst = false, index } = options
+
+    this.normalizeExpectedActualPopulationPanel()
+    const typeValue = (input: Cypress.Chainable<JQuery<HTMLElement>>) => {
+      const readyInput = input.should('exist').scrollIntoView().should('be.enabled')
+
+      if (clearFirst) {
+        readyInput.clear().type(value)
+        return
+      }
+
+      readyInput.type(value)
+    }
+
+    if (typeof index === 'number') {
+      typeValue(cy.get(inputSelector).eq(index))
+      return
+    }
+
+    typeValue(cy.get(inputSelector))
   }
 
   private static normalizeExpectedActualPopulationPanel(options: {

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -541,10 +541,7 @@ export class TestCasesPage {
       .then((id) => {
         measureID = id
         cy.intercept('POST', '/api/measures/' + measureID + '/test-cases').as('testcase')
-        cy.get(this.createTestCaseSaveButton).should('exist')
-        Utilities.waitForElementVisible(this.createTestCaseSaveButton, 50000)
-        Utilities.waitForElementEnabled(this.createTestCaseSaveButton, 50000)
-        cy.get(this.createTestCaseSaveButton).wait(3000).click()
+        this.clickVisibleEnabled(this.createTestCaseSaveButton, 50000)
         //saving testCaseId to file to use later
         cy.wait('@testcase', { timeout: 60000 }).then(({ response }) => {
           expect(response?.statusCode).to.eq(201)
@@ -553,7 +550,8 @@ export class TestCasesPage {
         })
       })
 
-    cy.get(EditMeasurePage.testCasesTab).click()
+    cy.get(this.createTestCaseDialog, { timeout: 60000 }).should('not.exist')
+    cy.get(EditMeasurePage.testCasesTab).should('have.attr', 'aria-selected', 'true')
   }
 
   public static grabValidateTestCaseNumber(testCaseNumber: number): void {
@@ -566,19 +564,13 @@ export class TestCasesPage {
   }
 
   public static grabValidateTestCaseTitleAndSeries(testCaseTitle: string, testCaseSeries: string): void {
-    cy.get('[data-testid="test-case-title-0_series"]').should('be.visible').wait(1000)
-    cy.get('[data-testid="test-case-title-0_series"]')
-      .invoke('text')
-      .then((seriesText) => {
-        expect(seriesText).to.include(testCaseSeries)
-      })
+    cy.get('[data-testid="test-case-title-0_series"]', { timeout: 30000 })
+      .should('be.visible')
+      .and('contain.text', testCaseSeries)
 
-    cy.get('[data-testid="test-case-title-0_title"]').should('be.visible').wait(1000)
-    cy.get('[data-testid="test-case-title-0_title"]')
-      .invoke('text')
-      .then((titleText) => {
-        expect(titleText).to.include(testCaseTitle)
-      })
+    cy.get('[data-testid="test-case-title-0_title"]', { timeout: 30000 })
+      .should('be.visible')
+      .and('contain.text', testCaseTitle)
   }
   //Similar to our other action functions for test cases and measures,
   //this function gives it's user the ability to pass a required text that
@@ -587,53 +579,21 @@ export class TestCasesPage {
   public static qdmTestCaseElementAction(action: string): void {
     TestData.readElementId()
       .then((fileContents) => {
-        cy.get('[data-testid="action-center-' + fileContents + '"]').scrollIntoView()
-        cy.scrollTo(0, 500)
-        Utilities.waitForElementVisible('[data-testid="action-center-' + fileContents + '"]', 50000)
-        cy.get('[data-testid="action-center-' + fileContents + '"]').should('be.visible')
+        const actionCenterSelector = `[data-testid="action-center-${fileContents}"]`
         switch (action.valueOf().toString().toLowerCase()) {
           case 'edit': {
-            cy.get('[data-testid="action-center-' + fileContents + '"]').scrollIntoView()
-            cy.scrollTo(0, 500)
-            cy.get('[data-testid="action-center-' + fileContents + '"]').scrollIntoView()
-            Utilities.waitForElementVisible('[data-testid="action-center-' + fileContents + '"]', 50000)
-            cy.get('[data-testid="action-center-' + fileContents + '"]').should('be.visible')
-            cy.get('[data-testid="action-center-' + fileContents + '"]').click()
-            cy.get('[data-testid="edit-element-' + fileContents + '"]').scrollIntoView()
-            Utilities.waitForElementVisible('[data-testid="edit-element-' + fileContents + '"]', 55000)
-            cy.get('[data-testid="edit-element-' + fileContents + '"]').should('be.visible')
-            Utilities.waitForElementEnabled('[data-testid="edit-element-' + fileContents + '"]', 55000)
-            cy.get('[data-testid="edit-element-' + fileContents + '"]').should('be.enabled')
-            cy.get('[data-testid="edit-element-' + fileContents + '"]')
-              .scrollIntoView()
-              .click({ force: true })
+            this.openQdmElementActionMenu(actionCenterSelector)
+            this.clickVisibleEnabled(`[data-testid="edit-element-${fileContents}"]`, 55000)
             break
           }
           case 'clone': {
-            cy.get('[data-testid="action-center-' + fileContents + '"]').scrollIntoView()
-            cy.scrollTo(0, 500)
-            cy.get('[data-testid="action-center-' + fileContents + '"]').click({ force: true })
-            Utilities.waitForElementVisible('[data-testid="clone-element-' + fileContents + '"]', 55000)
-            cy.get('[data-testid="clone-element-' + fileContents + '"]').scrollIntoView()
-            cy.get('[data-testid="clone-element-' + fileContents + '"]').should('be.visible')
-            Utilities.waitForElementEnabled('[data-testid="clone-element-' + fileContents + '"]', 55000)
-            cy.get('[data-testid="clone-element-' + fileContents + '"]').should('be.enabled')
-            cy.get('[data-testid="clone-element-' + fileContents + '"]')
-              .scrollIntoView()
-              .click({ force: true })
+            this.openQdmElementActionMenu(actionCenterSelector)
+            this.clickVisibleEnabled(`[data-testid="clone-element-${fileContents}"]`, 55000)
             break
           }
           case 'delete': {
-            cy.get('[data-testid="action-center-' + fileContents + '"]').scrollIntoView()
-            cy.scrollTo(0, 500)
-            cy.get('[data-testid="action-center-' + fileContents + '"]').click({ force: true })
-            Utilities.waitForElementVisible('[data-testid="delete-element-' + fileContents + '"]', 55000)
-            cy.get('[data-testid="delete-element-' + fileContents + '"]').should('be.visible')
-            Utilities.waitForElementEnabled('[data-testid="delete-element-' + fileContents + '"]', 55000)
-            cy.get('[data-testid="delete-element-' + fileContents + '"]').should('be.enabled')
-            cy.get('[data-testid="delete-element-' + fileContents + '"]')
-              .scrollIntoView()
-              .click({ force: true })
+            this.openQdmElementActionMenu(actionCenterSelector)
+            this.clickVisibleEnabled(`[data-testid="delete-element-${fileContents}"]`, 55000)
             break
           }
           default: {
@@ -646,29 +606,21 @@ export class TestCasesPage {
     TestData.readElementId()
       .then((fileContents) => {
         // Click tooltip first
-        cy.get('[data-testid="action-center-tooltip-' + fileContents + '"]')
-          .should('be.visible')
-          .click({ force: true })
+        this.clickVisibleEnabled(`[data-testid="action-center-tooltip-${fileContents}"]`, 30000)
 
         switch (action.toLowerCase()) {
           case 'edit':
-            cy.get('[data-testid="action-center-' + fileContents + '_Edit"]')
-              .should('be.visible')
-              .click({ force: true })
+            this.clickVisibleEnabled(`[data-testid="action-center-${fileContents}_Edit"]`, 30000)
             break
 
           case 'clone':
           case 'copy':
-            cy.get('[data-testid="action-center-' + fileContents + '_Clone"]')
-              .should('be.visible')
-              .click({ force: true })
+            this.clickVisibleEnabled(`[data-testid="action-center-${fileContents}_Clone"]`, 30000)
             break
 
           case 'delete':
           case 'remove':
-            cy.get('[data-testid="action-center-' + fileContents + '_Remove"]')
-              .should('be.visible')
-              .click({ force: true })
+            this.clickVisibleEnabled(`[data-testid="action-center-${fileContents}_Remove"]`, 30000)
             break
 
           default:
@@ -728,45 +680,30 @@ export class TestCasesPage {
       //edit test test case
       this.clickEditforCreatedTestCase()
 
-      if (handleElementsTab) {
-        cy.get(TestCasesPage.jsonTab).click()
-      }
+      this.editTestCaseJson(testCaseJson, handleElementsTab)
 
-      // modify testcase JSON
-      Utilities.waitForElementVisible(TestCasesPage.aceEditor, 37700)
-      Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
-      cy.get(TestCasesPage.aceEditor).should('exist')
-      cy.get(TestCasesPage.aceEditor).should('be.visible')
-      cy.get(TestCasesPage.aceEditorJsonInput)
-        .should('exist')
-        .click({ force: true })
-        .clear({ force: true })
-        .type(testCaseJson, { parseSpecialCharSequences: false, force: true })
-
-      cy.wait(1500)
-
-      cy.get(this.detailsTab).click()
+      this.clickVisibleEnabled(this.detailsTab, 30000)
 
       //Save edited / updated to test case
-      cy.get(this.editTestCaseSaveButton).click()
+      this.clickVisibleEnabled(this.editTestCaseSaveButton, 30000)
       Utilities.waitForElementDisabled(this.editTestCaseSaveButton, 9500)
       cy.log('JSON added to test case successfully')
 
-      cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-      cy.get(EditMeasurePage.testCasesTab).click()
+      this.clickVisibleEnabled(EditMeasurePage.testCasesTab, 30000)
     }
   }
 
   public static editTestCaseJson(testCaseJson: string, navigateToJsonTab = false): void {
     if (navigateToJsonTab) {
-      cy.get(TestCasesPage.jsonTab).click()
+      this.clickVisibleEnabled(TestCasesPage.jsonTab, 30000)
     }
 
     this.waitForJsonEditorReady()
     cy.get(TestCasesPage.aceEditorJsonInput)
-      .click({ force: true })
-      .clear({ force: true })
-      .type(testCaseJson, { parseSpecialCharSequences: false, force: true })
+      .should('be.visible')
+      .focus()
+      .type('{selectAll}{backspace}')
+      .type(testCaseJson, { parseSpecialCharSequences: false })
   }
 
   public static waitForJsonEditorReady(): void {
@@ -880,17 +817,19 @@ export class TestCasesPage {
 
   public static openExpectedActualTab(options: {
     checkboxSelector?: string
+    readySelector?: string
   } = {}): void {
-    const { checkboxSelector } = options
+    const { checkboxSelector, readySelector } = options
+    const selector = checkboxSelector ?? readySelector
 
     cy.get(this.tctExpectedActualSubTab, { timeout: 35000 }).should('exist').scrollIntoView().should('be.visible').click()
 
-    if (checkboxSelector) {
-      cy.get(checkboxSelector).should('exist')
+    if (selector) {
+      cy.get(selector).should('exist')
     }
 
     this.normalizeExpectedActualPopulationPanel({
-      requirePanel: !checkboxSelector,
+      requirePanel: !selector,
     })
   }
 
@@ -968,16 +907,35 @@ export class TestCasesPage {
       }
 
       cy.get(this.testCasePopulationList).should('be.visible').then(($panel) => {
-      const scrollContainers = [
-        $panel[0] as HTMLElement,
-        ...$panel.parents().toArray().map((element) => element as HTMLElement),
-      ].filter((element) => element.scrollWidth > element.clientWidth)
+        const scrollContainers = [
+          $panel[0] as HTMLElement,
+          ...$panel.parents().toArray().map((element) => element as HTMLElement),
+        ].filter((element) => element.scrollWidth > element.clientWidth)
 
-      scrollContainers.forEach((element) => {
-        element.scrollLeft = 0
-      })
+        scrollContainers.forEach((element) => {
+          element.scrollLeft = 0
+        })
       })
     })
+  }
+
+  private static clickVisibleEnabled(selector: string, timeout = 20000): void {
+    cy.get(selector, { timeout })
+      .scrollIntoView()
+      .should('be.visible')
+      .should('be.enabled')
+      .click()
+  }
+
+  private static clickVisible(selector: string, timeout = 20000): void {
+    cy.get(selector, { timeout })
+      .scrollIntoView()
+      .should('be.visible')
+      .click()
+  }
+
+  private static openQdmElementActionMenu(actionCenterSelector: string): void {
+    this.clickVisibleEnabled(actionCenterSelector, 50000)
   }
 
   // -----------------------------
@@ -1073,11 +1031,9 @@ export class TestCasesPage {
       .then((tcId) => {
         const buttonSelector = `[data-testid=view-edit-test-case-button-${tcId}]`
 
-        cy.get(buttonSelector).scrollIntoView()
-        cy.get(buttonSelector).should('be.enabled')
-        cy.get(buttonSelector).click()
+        this.clickVisibleEnabled(buttonSelector, 30000)
 
-        cy.wait(1000).then(() => {
+        cy.then(() => {
           if (callstackIntercepted) {
             cy.wait('@callstacks', { timeout: 90000 })
           } else {
@@ -1193,37 +1149,34 @@ export class TestCasesPage {
     ethnicity?: string,
   ): void {
     if (livingStatus) {
-      Utilities.waitForElementVisible(TestCasesPage.QDMLivingStatus, 50000)
-      cy.get(TestCasesPage.QDMLivingStatus).click()
-      cy.get(TestCasesPage.QDMLivingStatusOPtion).contains(livingStatus).click()
+      this.clickVisible(TestCasesPage.QDMLivingStatus, 50000)
+      cy.contains(TestCasesPage.SelectionOptionChoice, livingStatus).click()
     }
 
     if (race) {
-      cy.get(TestCasesPage.QDMRace).click()
-      Utilities.waitForElementVisible('[data-value="' + race + '__2.16.840.1.114222.4.11.836"]', 50000)
-      cy.get('[data-value="' + race + '__2.16.840.1.114222.4.11.836"]').click()
-      cy.get(TestCasesPage.editTestCaseSaveButton).click().wait(2000)
+      const raceSelector = `[data-value="${race}__2.16.840.1.114222.4.11.836"]`
+
+      this.clickVisible(TestCasesPage.QDMRace, 50000)
+      this.clickVisible(raceSelector, 50000)
+      this.clickVisibleEnabled(TestCasesPage.editTestCaseSaveButton, 30000)
+      Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 30000)
     }
 
     if (gender) {
-      cy.get(TestCasesPage.QDMGender).click()
-      Utilities.waitForElementVisible(TestCasesPage.SelectionOptionChoice, 30000)
-      cy.get(TestCasesPage.SelectionOptionChoice).contains(gender).click()
+      this.clickVisible(TestCasesPage.QDMGender, 30000)
+      cy.contains(TestCasesPage.SelectionOptionChoice, gender).click()
     }
 
     if (ethnicity) {
-      cy.get(TestCasesPage.QDMEthnicity).click()
-
       const ethnicityOne = `[data-value="${ethnicity}__2.16.840.1.114222.4.11.837"]`
       const ethnicityTwo = `[data-value="${ethnicity}__2.16.840.1.114222.4.11.877"]`
 
+      this.clickVisible(TestCasesPage.QDMEthnicity, 30000)
       cy.get('body', { timeout: 10000 }).then(($body: JQuery<HTMLElement>) => {
         if ($body.find(ethnicityOne).length > 0) {
-          Utilities.waitForElementVisible(ethnicityOne, 30000)
-          cy.get(ethnicityOne).click()
+          this.clickVisible(ethnicityOne, 30000)
         } else if ($body.find(ethnicityTwo).length > 0) {
-          Utilities.waitForElementVisible(ethnicityTwo, 30000)
-          cy.get(ethnicityTwo).click()
+          this.clickVisible(ethnicityTwo, 30000)
         } else {
           throw new Error('No matching ethnicity element found in the DOM.')
         }
@@ -1231,8 +1184,12 @@ export class TestCasesPage {
     }
 
     if (dob) {
-      cy.get(TestCasesPage.QDMDob).clear().click()
-      cy.get(TestCasesPage.QDMDob).wait(500).type(dob).click().wait(500)
+      cy.get(TestCasesPage.QDMDob)
+        .should('be.visible')
+        .should('be.enabled')
+        .clear()
+        .type(dob)
+        .should('have.value', dob)
     }
   }
 
@@ -1242,7 +1199,7 @@ export class TestCasesPage {
       .parent('tr')
       .find('input[type="checkbox"]')
       .click()
-      .wait(200)
+      .should('be.checked')
   }
 
   public static checkTestCaseByTitle(testCaseTitle: string): void {
@@ -1250,7 +1207,7 @@ export class TestCasesPage {
       .parent('tr')
       .find('input[type="checkbox"]')
       .click()
-      .wait(200)
+      .should('be.checked')
   }
 
   /*

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
@@ -80,7 +80,10 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                 'Increased score indicates improvement'
             )
 
+            cy.intercept('POST', '/api/measures/**/groups').as('createMeasureGroup')
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+            cy.wait('@createMeasureGroup').its('response.statusCode').should('be.oneOf', [200, 201])
+
             //validation successful save message
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
@@ -95,8 +98,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             //click on Expected/Actual tab
             cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
             cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click().wait(500)
-
+            TestCasesPage.openExpectedActualTab()
             //Click on RunTest Button
             cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -112,7 +114,6 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             cy.get(EditMeasurePage.cqlEditorTab).click()
 
             cy.get(EditMeasurePage.cqlEditorTextBox).invoke('click')
-
             //remove the dayObs line(s) from CQL
             cy.get(EditMeasurePage.cqlEditorTextBox).type(
                 '{end}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{downArrow}{end}{backspace}' +
@@ -259,7 +260,9 @@ describe('CQL Changes and how that impacts test cases, observations and populati
                 'Increased score indicates improvement'
             )
 
+            cy.intercept('POST', '/api/measures/**/groups').as('createMeasureGroup')
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
+            cy.wait('@createMeasureGroup').its('response.statusCode').should('be.oneOf', [200, 201])
             //validation successful save message
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
@@ -274,7 +277,7 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             //click on Expected/Actual tab
             cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
             cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab()
 
             //Click on RunTest Button
             cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')

--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/MeasureVersionValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/MeasureVersionValidations.cy.ts
@@ -272,7 +272,7 @@ describe('Edit and Delete Test case for Qi Core Versioned Measure', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Edit Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible').wait(1000)
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')

--- a/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/MeasureVersionValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/VersionAndDraftMeasure/MeasureVersionValidations.cy.ts
@@ -272,12 +272,10 @@ describe('Edit and Delete Test case for Qi Core Versioned Measure', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Edit Test case
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible').wait(1000)
 
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Test case updated successfully with warnings in JSON')

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
@@ -316,14 +316,19 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
-        cy.get(TestCasesPage.measureObservationRow).clear().type('60')
-        cy.get('[data-testid="test-population-Strata-1 -expected-0"]').type('1')
-        cy.get('[data-testid="strat-test-population-initialPopulation-expected-0"]').eq(0).type('1')
-        cy.get('[data-testid="strat-test-population-measurePopulation-expected-1"]').eq(0).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '60', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStrata1ExpectedValue, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, '1', { index: 0 })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasurePopulationExpectedValue, '1', {
+            index: 0
+        })
         //Commented until MAT-6608 is fixed
-        cy.get('[data-testid="strat-test-population-measurePopulationObservation-expected-3"]').eq(0).clear().type('60')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasureObservationExpectedValue(3), '60', {
+            clearFirst: true,
+            index: 0
+        })
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -459,13 +464,20 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('2')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('2')
-        cy.get(TestCasesPage.measureObservationRow).eq(1).clear().type('45')
-        cy.get('[data-testid="test-population-Strata-1 -expected-0"]').type('2')
-        cy.get('[data-testid="strat-test-population-initialPopulation-expected-0"]').eq(0).type('2')
-        cy.get('[data-testid="strat-test-population-measurePopulation-expected-1"]').eq(0).type('2')
-        cy.get('[data-testid="strat-test-population-measurePopulationObservation-expected-4"]').clear().type('45')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '45', {
+            clearFirst: true,
+            index: 1
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStrata1ExpectedValue, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, '2', { index: 0 })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasurePopulationExpectedValue, '2', {
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasureObservationExpectedValue(4), '45', {
+            clearFirst: true
+        })
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeSingleIPNoMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeSingleIPNoMO.cy.ts
@@ -110,10 +110,7 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
 
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -158,25 +155,10 @@ describe('Measure Creation and Testing: Ratio Episode Single IP w/o MO', () => {
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('2')
-
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('2')
-
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('2')
-
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMEXExpected, '1')
 
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CloneAndCopyTo/QDMTestCaseCopyToNewMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CloneAndCopyTo/QDMTestCaseCopyToNewMeasure.cy.ts
@@ -130,7 +130,7 @@ describe('Copy test cases from existing measure into new measure', () => {
         TestCasesPage.grabTestCaseId(8)
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('have.attr', 'value', '1')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('have.attr', 'value', '1')
@@ -218,7 +218,7 @@ describe('Copy test cases from existing measure into new measure', () => {
         TestCasesPage.grabTestCaseId(8)
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
 
         /// these differ from previous test since it's a cohort measure now
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CreateUpdateQDMTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/CreateUpdateQDMTestCase.cy.ts
@@ -230,8 +230,8 @@ describe('Create and Update QDM Test Case', () => {
         cy.get(TestCasesPage.QDMDob).type('01/01/2000').click()
 
         //Navigate to Expected/Actual tab and add Expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         //save the Test Case
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -277,7 +277,7 @@ describe('Non Boolean Test case Expected Values', () => {
         cy.get(TestCasesPage.QDMDob).type('01/01/2000').click()
 
         //Navigate to Expected/Actual tab and add Expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).type('2')
 
         //save the Test Case

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -172,7 +172,7 @@ describe('Measure Creation: Patient Based: CV measure with multiple groups with 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -348,7 +348,7 @@ describe('Measure Creation: Non-patient based: CV measure with multiple groups w
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -172,12 +172,9 @@ describe('Measure Creation: Patient Based: CV measure with multiple groups with 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).check()
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
         cy.get(TestCasesPage.measureObservationRow).eq(0).clear().type('8')
         cy.get(TestCasesPage.measureObservationRow).eq(1).clear().type('8')
 
@@ -348,16 +345,31 @@ describe('Measure Creation: Non-patient based: CV measure with multiple groups w
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).clear().type('1')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).clear().type('1')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).eq(0).clear().type('1')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).eq(1).clear().type('1')
-        cy.get(TestCasesPage.measureObservationRow).eq(0).clear().type('24')
-        cy.get(TestCasesPage.measureObservationRow).eq(1).clear().type('24')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', {
+            clearFirst: true,
+            index: 1
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', {
+            clearFirst: true,
+            index: 1
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '24', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '24', {
+            clearFirst: true,
+            index: 1
+        })
 
         //save changes
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
@@ -281,7 +281,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
 
         //enter 3 for the expected denominator to generate 3 observation field
         cy.get(TestCasesPage.testCaseDENOMExpected).type('3')
@@ -318,7 +318,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
 
         //validate values that were saved in the E/A fields retain values
         cy.get(TestCasesPage.testCaseDENOMExpected).should('contain.value', 3)
@@ -374,7 +374,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
 
         //enter 3 for the expected denominator to generate 3 observation field
         cy.get(TestCasesPage.testCaseDENOMExpected).type('3')
@@ -418,7 +418,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
 
         //observation fields cannot be edited
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.enabled')
@@ -494,7 +494,7 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
 
         //enter 1 for expected initial population
         cy.get(TestCasesPage.testCaseIPPExpected).type('1')
@@ -526,7 +526,7 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.runQDMTestCaseBtn })
 
         cy.get(TestCasesPage.runQDMTestCaseBtn).click()
 

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts
@@ -281,26 +281,26 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //enter 3 for the expected denominator to generate 3 observation field
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '3')
         cy.get(TestCasesPage.denom0Observation).should('be.visible')
         cy.get(TestCasesPage.denom1Observation).should('be.visible')
         cy.get(TestCasesPage.denom2Observation).should('be.visible')
 
         //if one is entered in the denominator exclusion field then one of the denominator observation fields will be removed
-        cy.get(TestCasesPage.testCaseDENEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1')
         cy.get(TestCasesPage.denom2Observation).should('not.exist')
 
         //enter 3 for the expected denominator to generate 3 observation field
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '3')
         cy.get(TestCasesPage.numer0Observation).should('be.visible')
         cy.get(TestCasesPage.numer1Observation).should('be.visible')
         cy.get(TestCasesPage.numer2Observation).should('be.visible')
 
         //if one is entered in the numerator exclusion field then one of the numerator observation fields will be removed
-        cy.get(TestCasesPage.testCaseNUMEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMEXExpected, '1')
         cy.get(TestCasesPage.numer2Observation).should('not.exist')
 
         //save test case
@@ -318,7 +318,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //validate values that were saved in the E/A fields retain values
         cy.get(TestCasesPage.testCaseDENOMExpected).should('contain.value', 3)
@@ -374,26 +374,26 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //enter 3 for the expected denominator to generate 3 observation field
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '3')
         cy.get(TestCasesPage.denom0Observation).should('be.visible')
         cy.get(TestCasesPage.denom1Observation).should('be.visible')
         cy.get(TestCasesPage.denom2Observation).should('be.visible')
 
         //if one is entered in the denominator exclusion field then one of the denominator observation fields will be removed
-        cy.get(TestCasesPage.testCaseDENEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1')
         cy.get(TestCasesPage.denom2Observation).should('not.exist')
 
         //enter 3 for the expected denominator to generate 3 observation field
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '3')
         cy.get(TestCasesPage.numer0Observation).should('be.visible')
         cy.get(TestCasesPage.numer1Observation).should('be.visible')
         cy.get(TestCasesPage.numer2Observation).should('be.visible')
 
         //if one is entered in the numerator exclusion field then one of the numerator observation fields will be removed
-        cy.get(TestCasesPage.testCaseNUMEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMEXExpected, '1')
         cy.get(TestCasesPage.numer2Observation).should('not.exist')
 
         //save test case
@@ -418,7 +418,7 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseDENOMExpected })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //observation fields cannot be edited
         cy.get(TestCasesPage.testCaseDENOMExpected).should('not.be.enabled')
@@ -494,24 +494,24 @@ describe('QDM Measure: Test Case: with Observations: Expected / Actual results',
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on the Expected / Actual tab
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         //enter 1 for expected initial population
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
 
         //enter 1 for the expected denominator to generate 1 observation field
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1')
         cy.get(TestCasesPage.denom0Observation).should('be.visible')
 
         //enter 1 for denominator observation field
-        cy.get(TestCasesPage.denom0Observation).clear().type('6')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denom0Observation, '6', { clearFirst: true })
 
         //enter 1 for the expected numerator to generate 1 observation field
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1')
         cy.get(TestCasesPage.numer0Observation).should('be.visible')
 
         //enter 6 for the numerator observation field
-        cy.get(TestCasesPage.numer0Observation).clear().type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numer0Observation, '1', { clearFirst: true })
 
         //save test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -154,15 +154,12 @@ describe('Measure Creation: Patient Based: Ratio measure with multiple groups wi
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).check()
-        cy.get(TestCasesPage.testCaseDENOMExpected).check()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
         cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('8')
         cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).clear().type('8')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check()
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         //save changes
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
@@ -313,18 +310,39 @@ describe('Measure Creation: Non-patient based: Ratio measure with multiple group
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).clear().type('1')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).clear().type('1')
-        cy.get(TestCasesPage.testCaseDENOMExpected).eq(0).clear().type('1')
-        cy.get(TestCasesPage.testCaseDENOMExpected).eq(1).clear().type('1')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('24')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).clear().type('24')
-        cy.get(TestCasesPage.testCaseNUMERExpected).eq(0).clear().type('1')
-        cy.get(TestCasesPage.testCaseNUMERExpected).eq(1).clear().type('1')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', {
+            clearFirst: true,
+            index: 1
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1', {
+            clearFirst: true,
+            index: 1
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '24', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '24', {
+            clearFirst: true,
+            index: 1
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1', {
+            clearFirst: true,
+            index: 0
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1', {
+            clearFirst: true,
+            index: 1
+        })
 
         //save changes
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -154,7 +154,7 @@ describe('Measure Creation: Patient Based: Ratio measure with multiple groups wi
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -313,7 +313,7 @@ describe('Measure Creation: Non-patient based: Ratio measure with multiple group
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -74,7 +74,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -162,7 +162,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         TestCasesPage.clickEditforCreatedTestCase()
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -281,7 +281,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -458,7 +458,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
         cy.get(TestCasesPage.QDMDob).type('01/01/2020 12:00 AM')
 
         //Add Expected/Actual value to first Population criteria
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).click()
         //save dob value
         Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 60000)
@@ -544,7 +544,7 @@ describe('Run / Execute Test Case by Non Measure Owner', () => {
         cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.enabled')
         cy.get(TestCasesPage.runQDMTestCaseBtn).click()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         Utilities.waitForElementVisible(TestCasesPage.testCaseIPPExpected, 15000)
 
         cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.enabled')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -1,13 +1,13 @@
-import { OktaLogin } from "../../../../../Shared/OktaLogin"
-import { CreateMeasureOptions, CreateMeasurePage } from "../../../../../Shared/CreateMeasurePage"
-import { MeasuresPage } from "../../../../../Shared/MeasuresPage"
-import { TestCasesPage } from "../../../../../Shared/TestCasesPage"
-import { EditMeasurePage } from "../../../../../Shared/EditMeasurePage"
-import { TestCaseJson } from "../../../../../Shared/TestCaseJson"
-import { Utilities } from "../../../../../Shared/Utilities"
-import { MeasureGroupPage } from "../../../../../Shared/MeasureGroupPage"
-import { CQLEditorPage } from "../../../../../Shared/CQLEditorPage"
-import { MeasureCQL } from "../../../../../Shared/MeasureCQL"
+import { OktaLogin } from '../../../../../Shared/OktaLogin'
+import { CreateMeasureOptions, CreateMeasurePage } from '../../../../../Shared/CreateMeasurePage'
+import { MeasuresPage } from '../../../../../Shared/MeasuresPage'
+import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
+import { EditMeasurePage } from '../../../../../Shared/EditMeasurePage'
+import { TestCaseJson } from '../../../../../Shared/TestCaseJson'
+import { Utilities } from '../../../../../Shared/Utilities'
+import { MeasureGroupPage } from '../../../../../Shared/MeasureGroupPage'
+import { CQLEditorPage } from '../../../../../Shared/CQLEditorPage'
+import { MeasureCQL } from '../../../../../Shared/MeasureCQL'
 
 const measureName = 'QDMRunExecuteTC' + Date.now()
 let CqlLibraryName = 'TestLibrary' + Date.now()
@@ -18,9 +18,7 @@ const validTestCaseJson = TestCaseJson.QDMTestCaseJson
 const measureCQL = MeasureCQL.QDMCQL4MAT5645
 const measureData: CreateMeasureOptions = {}
 describe('Run / Execute Test case and verify passing percentage and coverage', () => {
-
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
-
         CqlLibraryName = 'QDMExecPercentages' + Date.now()
 
         measureData.ecqmTitle = measureName
@@ -49,16 +47,17 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         //Save Supplemental data
         cy.get('[data-testid="measure-Supplemental Data-save"]').click({ force: true })
-        cy.get(EditMeasurePage.successMessage).should('contain.text', 'Measure Supplemental Data have been Saved Successfully')
+        cy.get(EditMeasurePage.successMessage).should(
+            'contain.text',
+            'Measure Supplemental Data have been Saved Successfully'
+        )
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Run / Execute single passing Test Case', () => {
-
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
         OktaLogin.Login()
 
@@ -70,20 +69,24 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         TestCasesPage.clickEditforCreatedTestCase()
         //enter a value of the dob, Race and gender
-        TestCasesPage.enterPatientDemographics('07/01/2002 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
+        TestCasesPage.enterPatientDemographics(
+            '07/01/2002 12:00 AM',
+            'Living',
+            'White',
+            'Male',
+            'Not Hispanic or Latino'
+        )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).check()
-
-        cy.get('[data-testid="test-population-Strata-1 -expected-0"]').check()
-        cy.get('[data-testid="strat-test-population-initialPopulation-expected-0"]').eq(0).check()
-        cy.get('[data-testid="test-population-Strata-2 -expected-0"]').check()
-        cy.get('[data-testid="strat-test-population-initialPopulation-expected-0"]').eq(1).check()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.qdmStrata1ExpectedValue)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, {
+            index: 0
+        })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.qdmStrata2ExpectedValue)
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, {
+            index: 1
+        })
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -111,7 +114,6 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
     })
 
     it('Run / Execute one passing and one failing Test Cases', () => {
-
         OktaLogin.Login()
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
@@ -136,7 +138,8 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type('TestDesc')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-        cy.get(TestCasesPage.createTestCaseGroupInput).type('SBTestSeries')
+        cy.get(TestCasesPage.createTestCaseGroupInput)
+            .type('SBTestSeries')
             .type('{downArrow}')
             .should('have.attr', 'aria-controls', 'test-case-series-listbox')
             .click()
@@ -149,7 +152,13 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.enterPatientDemographics('01/01/2020 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
+        TestCasesPage.enterPatientDemographics(
+            '01/01/2020 12:00 AM',
+            'Living',
+            'White',
+            'Male',
+            'Not Hispanic or Latino'
+        )
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -160,13 +169,8 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.clickEditforCreatedTestCase()
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -196,7 +200,8 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type('PTC')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-        cy.get(TestCasesPage.createTestCaseGroupInput).type('ICFTCSeries')
+        cy.get(TestCasesPage.createTestCaseGroupInput)
+            .type('ICFTCSeries')
             .type('{downArrow}')
             .should('have.attr', 'aria-controls', 'test-case-series-listbox')
             .click()
@@ -209,7 +214,13 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.enterPatientDemographics('01/01/2020 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
+        TestCasesPage.enterPatientDemographics(
+            '01/01/2020 12:00 AM',
+            'Living',
+            'White',
+            'Male',
+            'Not Hispanic or Latino'
+        )
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -238,7 +249,6 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
     })
 
     it('Run / Execute single failing Test Cases', () => {
-
         OktaLogin.Login()
 
         MeasuresPage.actionCenter('edit')
@@ -264,7 +274,8 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(TestCasesPage.createTestCaseDescriptionInput).type('FTC')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('exist')
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
-        cy.get(TestCasesPage.createTestCaseGroupInput).type('ICFTCSeries')
+        cy.get(TestCasesPage.createTestCaseGroupInput)
+            .type('ICFTCSeries')
             .type('{downArrow}')
             .should('have.attr', 'aria-controls', 'test-case-series-listbox')
             .click()
@@ -277,15 +288,16 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.enterPatientDemographics('01/01/2020 12:00 AM', 'Living', 'White', 'Male', 'Not Hispanic or Latino')
+        TestCasesPage.enterPatientDemographics(
+            '01/01/2020 12:00 AM',
+            'Living',
+            'White',
+            'Male',
+            'Not Hispanic or Latino'
+        )
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).check()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -308,9 +320,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 })
 
 describe('Run / Execute QDM Test Case button validations', () => {
-
     beforeEach('Login and Create Measure', () => {
-
         CqlLibraryName = 'QDMExecButtons' + Date.now()
 
         measureData.ecqmTitle = measureName
@@ -324,7 +334,6 @@ describe('Run / Execute QDM Test Case button validations', () => {
     })
 
     afterEach('Logout and Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
@@ -380,7 +389,6 @@ describe('Run / Execute QDM Test Case button validations', () => {
     })
 
     it('Run / Execute Test Case button is disabled -- missing TC Json', () => {
-
         //Click on Edit Measure
         MeasuresPage.actionCenter('edit')
 
@@ -399,7 +407,10 @@ describe('Run / Execute QDM Test Case button validations', () => {
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully.'
+        )
 
         TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries)
 
@@ -408,9 +419,7 @@ describe('Run / Execute QDM Test Case button validations', () => {
 })
 
 describe('Run / Execute Test case for multiple Population Criteria', () => {
-
     beforeEach('Create Measure, Measure group and login', () => {
-
         CqlLibraryName = 'QDMExecMultiplePC' + Date.now()
 
         measureData.ecqmTitle = measureName
@@ -427,12 +436,10 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
     })
 
     afterEach('Logout and Clean up Measures', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Run and Execute Test case for multiple Population Criteria', () => {
-
         //Add second Measure Group
         cy.get(EditMeasurePage.measureGroupsTab).click()
         cy.get(MeasureGroupPage.addMeasureGroupButton).should('be.visible')
@@ -447,7 +454,10 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
 
         //validation successful save message
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
-        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('contain.text', 'Population details for this group saved successfully.')
+        cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
+            'contain.text',
+            'Population details for this group saved successfully.'
+        )
 
         //Navigate to Test Cases page and add Test Case details
         TestCasesPage.createTestCase(testCaseTitle, testCaseDescription, testCaseSeries)
@@ -458,8 +468,8 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
         cy.get(TestCasesPage.QDMDob).type('01/01/2020 12:00 AM')
 
         //Add Expected/Actual value to first Population criteria
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected, { index: 0 })
         //save dob value
         Utilities.waitForElementEnabled(TestCasesPage.editTestCaseSaveButton, 60000)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -485,9 +495,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
 })
 
 describe('Run / Execute Test Case by Non Measure Owner', () => {
-
     beforeEach('Create Measure, Measure group and Test case', () => {
-
         CqlLibraryName = 'QDMExecNonOwner' + Date.now()
 
         measureData.ecqmTitle = measureName
@@ -501,16 +509,14 @@ describe('Run / Execute Test Case by Non Measure Owner', () => {
         TestCasesPage.CreateQDMTestCaseAPI(testCaseTitle, testCaseDescription, testCaseSeries)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
-        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })       
+        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
     })
 
     afterEach('Logout and Clean up', () => {
-
         Utilities.deleteMeasure()
     })
 
     it('Non Measure owner should be able to Run/Execute Test case', () => {
-
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.clickEditforCreatedTestCase()
@@ -544,8 +550,7 @@ describe('Run / Execute Test Case by Non Measure Owner', () => {
         cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.enabled')
         cy.get(TestCasesPage.runQDMTestCaseBtn).click()
 
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        Utilities.waitForElementVisible(TestCasesPage.testCaseIPPExpected, 15000)
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.runQDMTestCaseBtn).should('be.enabled')
         cy.get(TestCasesPage.runQDMTestCaseBtn).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseDirtyCheck.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseDirtyCheck.cy.ts
@@ -115,7 +115,7 @@ describe('Dirty Check Validations', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //Navigate to Expected/Actual tab and enter Expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).type('2')
         cy.get(TestCasesPage.testCaseNUMERExpected).type('3')
         cy.get(TestCasesPage.testCaseDENOMExpected).type('4')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseRelevantElementWarning.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseRelevantElementWarning.cy.ts
@@ -115,7 +115,7 @@ describe('QDM Test cases - Checks for CQL Changes', () => {
         QDMElements.addCode('SNOMEDCT', '111527005')
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseRelevantElementWarning.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseRelevantElementWarning.cy.ts
@@ -115,12 +115,9 @@ describe('QDM Test cases - Checks for CQL Changes', () => {
         QDMElements.addCode('SNOMEDCT', '111527005')
 
         //Add Expected value for Test case
-        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('1')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1')
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/QDM Test Case Validations/QDMTestCaseValidations.cy.ts
@@ -78,7 +78,7 @@ describe('Test Case Ownership Validations for QDM Measures', () => {
         cy.get(TestCasesPage.createTestCaseGroupInput).should('have.attr', 'readonly', 'readonly')
 
         //Navigate to Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.enabled')
     })
 })

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/ExcelTestCaseExport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Test Case Export/ExcelTestCaseExport.cy.ts
@@ -195,7 +195,7 @@ describe('QDM Test Case Excel Export', () => {
         QDMElements.addCode('SOP', '1')
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -247,7 +247,7 @@ describe('QDM Test Case Excel Export', () => {
         QDMElements.addCode('SOP', '1')
 
         //Add Expected value for Test case
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ readySelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/CloneAndCopyTo/TestCaseCopyToNewMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/CloneAndCopyTo/TestCaseCopyToNewMeasure.cy.ts
@@ -90,7 +90,7 @@ describe('Copy test cases from existing measure into new measure', () => {
         TestCasesPage.grabTestCaseId(2)
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('have.value', '1')
     })
@@ -153,7 +153,7 @@ describe('Copy test cases from existing measure into new measure', () => {
         TestCasesPage.grabTestCaseId(2)
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         /// these differ from previous test since it's a proportion measure now
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.empty')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecutionAndCoverageValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/ExecutionAndCoverageValidations.cy.ts
@@ -16,20 +16,22 @@ const CqlLibraryName = 'ExecCoverageValidationsLib' + now
 const testCase: TestCase = {
     title: 'test case title',
     description: 'DENOMFail' + now,
-    group: 'SBTestSeries',
+    group: 'SBTestSeries'
 }
 const validTestCaseJson = TestCaseJson.TestCaseJson_Valid
 const measureCQL = QiCore4Cql.reduced_CQL_Multiple_Populations
 
 describe('Run / Execute Test case and verify passing percentage and coverage', () => {
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
-        CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore4, { measureCql: measureCQL })
+        CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore4, {
+            measureCql: measureCQL
+        })
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne')
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({
             collapseEditor: true,
-            successTimeout: 20700,
+            successTimeout: 20700
         })
     })
 
@@ -38,17 +40,12 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
     })
 
     it('Run / Execute single passing Test Case', () => {
-
         TestCasesPage.createTestCase(testCase.title, testCase.description, testCase.group, validTestCaseJson, false)
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -88,12 +85,8 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         TestCasesPage.createTestCase('PassingTestCase', testCase.description, testCase.group, validTestCaseJson, false)
 
         TestCasesPage.clickEditforCreatedTestCase()
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -131,8 +124,13 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
     })
 
     it('Run / Execute single failing Test Cases', () => {
-
-        TestCasesPage.createTestCase('FailingTestCase', testCase.description, testCase.group, validTestCaseJson, undefined)
+        TestCasesPage.createTestCase(
+            'FailingTestCase',
+            testCase.description,
+            testCase.group,
+            validTestCaseJson,
+            undefined
+        )
 
         //Click on Execute Test Case button on Edit Test Case page
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationActualValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationActualValues.cy.ts
@@ -95,10 +95,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         //Click on RunTest Button
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
@@ -106,7 +103,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         cy.get(TestCasesPage.runTestButton).should('exist')
         cy.get(TestCasesPage.runTestButton).should('be.visible')
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
-        cy.get(TestCasesPage.runTestButton).click({ force: true })
+        cy.get(TestCasesPage.runTestButton).click()
         cy.get(TestCasesPage.cvMeasureObservationActualValue).should('have.value', '30')
     })
 
@@ -168,10 +165,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         //Click on RunTest Button
         cy.get(TestCasesPage.testCaseDENOMExpected).type('1')
@@ -180,7 +174,7 @@ describe('Non Boolean Measure Observation Actual values', () => {
         cy.get(TestCasesPage.runTestButton).should('exist')
         cy.get(TestCasesPage.runTestButton).should('be.visible')
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
-        cy.get(TestCasesPage.runTestButton).click({ force: true })
+        cy.get(TestCasesPage.runTestButton).click()
         cy.get(TestCasesPage.denominatorMeasureObservationActualValue).should('have.value', '30')
         cy.get(TestCasesPage.numeratorMeasureObservationActualValue).should('have.value', '30')
     })
@@ -232,18 +226,16 @@ describe('Boolean Measure Observation Actual values', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
 
         //Click on RunTest Button
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
+        cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.runTestButton).should('exist')
         cy.get(TestCasesPage.runTestButton).should('be.visible')
         cy.get(TestCasesPage.runTestButton).should('be.enabled')
-        cy.get(TestCasesPage.runTestButton).click({ force: true })
+        cy.get(TestCasesPage.runTestButton).click()
         cy.get(TestCasesPage.cvMeasureObservationActualValue).should('have.value', '1')
     })
 
@@ -299,21 +291,20 @@ describe('Boolean Measure Observation Actual values', () => {
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on Expected/Actual tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //Click on RunTest Button
-        cy.get(TestCasesPage.testCaseDENOMExpected).check().should('be.checked')
-        cy.get(TestCasesPage.testCaseNUMERExpected).check().should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
+        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.checked')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
+        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         cy.get(TestCasesPage.detailsTab).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(TestCasesPage.successMsg).should('be.visible')
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         cy.get(TestCasesPage.runTestButton).should('exist')
         cy.get(TestCasesPage.runTestButton).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
@@ -41,19 +41,19 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Validate measure observation expected values
-        cy.get(TestCasesPage.measureObservationRow).clear().type('@#')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '@#', { clearFirst: true })
         cy.get(TestCasesPage.measureObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.measureObservationRow).clear().type('ab12')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, 'ab12', { clearFirst: true })
         cy.get(TestCasesPage.measureObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.measureObservationRow).clear().type('-15')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '-15', { clearFirst: true })
         cy.get(TestCasesPage.measureObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
@@ -61,7 +61,7 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
         //Save measure observation expected values
-        cy.get(TestCasesPage.measureObservationRow).clear().type('1.3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1.3', { clearFirst: true })
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         // cy.get(Toasts.otherSuccessToast).should('have.text', Toasts.warningOffsetText)
@@ -71,7 +71,7 @@ describe('Measure Observation Expected values', () => {
         )
 
         //Assert saved observation values
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
         cy.get(TestCasesPage.measureObservationRow).should('contain.value', '1.3')
     })
 
@@ -117,19 +117,19 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         //Validate measure observation expected values
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).type('@#')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '@#')
         cy.get(TestCasesPage.denominatorObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.numeratorObservationRow).type('ab12')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, 'ab12')
         cy.get(TestCasesPage.numeratorObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.numeratorObservationRow).type('-15')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '-15')
         cy.get(TestCasesPage.numeratorObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
@@ -137,15 +137,15 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
 
         //Save measure observation expected values
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).clear().type('1.3')
-        cy.get(TestCasesPage.numeratorObservationRow).clear().type('5')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '1.3', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '5', { clearFirst: true })
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 10000)
 
         //Assert saved observation values
         cy.get(EditMeasurePage.testCasesTab).click()
         TestCasesPage.clickEditforCreatedTestCase()
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
         cy.get(TestCasesPage.denominatorObservationExpectedRow).should('contain.value', '1.3')
         cy.get(TestCasesPage.numeratorObservationRow).should('contain.value', '5')
     })
@@ -164,7 +164,7 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Enter value in to Measure observation Expected values
-        cy.get(TestCasesPage.measureObservationRow).type('1.3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1.3')
 
         //attempt to navigate away from the test case page
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -240,11 +240,11 @@ describe('Measure observation expected result', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
 
         //Enter values in to Measure population(MP) & Measure population exclusion(MPE) fields and verify MP-MPE = number of observation rows
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('5')
-        cy.get(TestCasesPage.testCaseMSRPOPLEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '5')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLEXExpected, '1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Observation 1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Observation 2')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Observation 3')
@@ -325,18 +325,18 @@ describe('Measure observation expected result', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //click on Expected/Actual tab
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //Enter values in to Denominator & Denominator exclusion(DE) fields and verify Denominator-DE = number of Denominator observation rows
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('4')
-        cy.get(TestCasesPage.testCaseDENEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '4')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Observation 1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Observation 2')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Observation 3')
 
         //Enter values in to Numerator & Numerator exclusion(NE) fields and verify Denominator-NE = number of Numerator observation rows
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('4')
-        cy.get(TestCasesPage.testCaseNUMEXExpected).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '4')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMEXExpected, '1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Observation 1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Observation 2')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Observation 3')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/RunAndExecuteTestCaseButtonValidations.cy.ts
@@ -16,12 +16,12 @@ const CqlLibraryName = 'RETCBVLibrary' + now
 const testCase: TestCase = {
     title: 'test case title',
     description: 'DENOMFail' + now,
-    group: 'SBTestSeries',
+    group: 'SBTestSeries'
 }
 const failingTestCase: TestCase = {
     title: 'Test Case with errors',
     description: 'TCwE',
-    group: 'ICFTCwESeries',
+    group: 'ICFTCwESeries'
 }
 const validTestCaseJson = TestCaseJson.TestCaseJson_Valid
 const invalidTestCaseJson = TestCaseJson.TestCaseJson_Invalid
@@ -87,7 +87,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         TestCasesPage.createTestCase(testCase.title, testCase.description, testCase.group, validTestCaseJson, true)
@@ -168,7 +168,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         TestCasesPage.createTestCase(testCase.title, testCase.description, testCase.group, invalidTestCaseJson, true)
@@ -229,7 +229,7 @@ describe('Run / Execute Test Case button validations', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         TestCasesPage.createTestCase(testCase.title, testCase.description, testCase.group)
@@ -251,7 +251,7 @@ describe('Run / Execute Test Case button validations', () => {
 describe('Run / Execute Test case for multiple Population Criteria', () => {
     beforeEach('Create measure and login', () => {
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, {
-            measureCql: measureCQL,
+            measureCql: measureCQL
         })
         MeasureGroupPage.CreateProportionMeasureGroupAPI(
             0,
@@ -262,7 +262,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
             'Initial Population',
             '',
             'Initial Population',
-            'boolean',
+            'boolean'
         )
         TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description, validTestCaseJson)
         OktaLogin.Login()
@@ -305,7 +305,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         TestCasesPage.createTestCase(
@@ -313,7 +313,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
             testCase.description + ' 2',
             testCase.group + '2',
             validTestCaseJson,
-            true,
+            true
         )
 
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -337,7 +337,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
                 Utilities.waitForElementVisible(TestCasesPage.tcNUMERHighlightingDetails, 35000)
                 cy.get(TestCasesPage.tcNUMERHighlightingDetails).should(
                     'contain.text',
-                    '\ndefine "Initial Population":\n   true\nResultstrue Definition(s) Used',
+                    '\ndefine "Initial Population":\n   true\nResultstrue Definition(s) Used'
                 )
                 cy.get('[data-ref-id="260"]').should('have.color', '#20744c')
             })
@@ -365,7 +365,7 @@ describe('Run / Execute Test case for multiple Population Criteria', () => {
 describe('Verify that "Run Test" works with warnings but does not with errors', () => {
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, {
-            measureCql: measureCQL,
+            measureCql: measureCQL
         })
         MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Initial PopulationOne')
         OktaLogin.Login()
@@ -383,7 +383,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
             testCase.description,
             testCase.group,
             errorTestCaseJSON_no_ResourceID,
-            true,
+            true
         )
 
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -391,23 +391,17 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on actual / expected sub-tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-        //check the check box for the expected IP
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).scrollIntoView()
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).click({ force: true })
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
         Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 8500)
 
         //Verify Highlighting tab before clicking on Run Test button
-        cy.get(TestCasesPage.tcHighlightingTab).wait(1000).click()
+        cy.get(TestCasesPage.tcHighlightingTab).should('be.visible').click()
         cy.get(TestCasesPage.runTestAlertMsg).should('contain.text', "To see the logic highlights, click 'Run Test'")
 
         //Click on Execute Test Case button on Edit Test Case page
@@ -415,18 +409,14 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
         cy.get(EditMeasurePage.testCasesTab).click()
 
         TestCasesPage.clickEditforCreatedTestCase()
-        cy.get(TestCasesPage.jsonTab).click()
-        Utilities.waitForElementWriteEnabled(TestCasesPage.aceEditor, 37700)
-        cy.get(TestCasesPage.aceEditorJsonInput).should('exist')
-        cy.get(TestCasesPage.aceEditor).type('{selectAll}{backspace}')
-        cy.editTestCaseJSON(warningTestCaseJson)
+        TestCasesPage.editTestCaseJson(warningTestCaseJson, true)
         cy.get(TestCasesPage.editTestCaseSaveButton).scrollIntoView()
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
 
         cy.get(Toasts.otherSuccessToast, { timeout: 16500 }).should(
             'have.text',
-            'Test case updated successfully! Test case validation has started running, please continue working in MADiE.',
+            'Test case updated successfully! Test case validation has started running, please continue working in MADiE.'
         )
 
         //Click on Execute Test Case button on Edit Test Case page
@@ -469,7 +459,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
             failingTestCase.description,
             failingTestCase.group,
             errorTestCaseJSON_no_ResourceID,
-            true,
+            true
         )
 
         cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -477,24 +467,18 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on actual / expected sub-tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-
-        //check the check box for the expected IP
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
-        cy.get(TestCasesPage.editTestCaseSaveButton).click({ force: true })
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
         Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 7500)
 
         //Click on Execute Test Case button on Edit Test Case page
         Utilities.waitForElementVisible(EditMeasurePage.testCasesTab, 30000)
-        cy.get(EditMeasurePage.testCasesTab).wait(1000).click()
+        cy.get(EditMeasurePage.testCasesTab).click()
         cy.get(TestCasesPage.executeTestCaseButton).should('be.disabled')
 
         //refresh test case list page
@@ -516,7 +500,7 @@ describe('Verify that "Run Test" works with warnings but does not with errors', 
 describe('Verify "Run Test Cases" results based on missing/empty group populations are treated as zeroes', () => {
     beforeEach('Create measure, login and update CQL, create group, and login', () => {
         CreateMeasurePage.CreateMeasureAPI(measureName, CqlLibraryName, SupportedModels.qiCore6, {
-            measureCql: measureCQLPFTests,
+            measureCql: measureCQLPFTests
         })
         MeasureGroupPage.CreateProportionMeasureGroupAPI(
             0,
@@ -527,13 +511,13 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             'Initial Population',
             '',
             'Initial Population',
-            'boolean',
+            'boolean'
         )
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({
             collapseEditor: true,
-            successTimeout: 20700,
+            successTimeout: 20700
         })
     })
 
@@ -573,7 +557,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group updated successfully.',
+            'Population details for this group updated successfully.'
         )
 
         TestCasesPage.createTestCase(testCase.title, testCase.description, testCase.group, validTestCaseJson, true)
@@ -583,14 +567,9 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        //click on actual / expected sub-tab
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         //check the check box for the expected IP
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
 
         //Verify Highlighting tab before clicking on Run Test button
@@ -627,7 +606,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.reportingTab).click()
             Utilities.dropdownSelect(
                 MeasureGroupPage.improvementNotationSelect,
-                'Increased score indicates improvement',
+                'Increased score indicates improvement'
             )
 
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
@@ -644,7 +623,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
                 'contain.text',
-                'Population details for this group updated successfully.',
+                'Population details for this group updated successfully.'
             )
 
             TestCasesPage.createTestCase(testCase.title, testCase.description, testCase.group, validTestCaseJson, true)
@@ -654,21 +633,16 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             TestCasesPage.clickEditforCreatedTestCase()
 
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
             //check the check box for the expected IP
-            cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-            cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
             cy.get(TestCasesPage.testCaseIPPExpected).should('not.be.checked')
 
             //Verify Highlighting tab before clicking on Run Test button
             cy.get(TestCasesPage.tcHighlightingTab).click()
             cy.get(TestCasesPage.runTestAlertMsg).should(
                 'contain.text',
-                "To see the logic highlights, click 'Run Test'",
+                "To see the logic highlights, click 'Run Test'"
             )
 
             //Click on Execute Test Case button on Edit Test Case page
@@ -711,7 +685,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.reportingTab).click()
             Utilities.dropdownSelect(
                 MeasureGroupPage.improvementNotationSelect,
-                'Increased score indicates improvement',
+                'Increased score indicates improvement'
             )
 
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('exist')
@@ -720,7 +694,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
             cy.get(MeasureGroupPage.scoreUpdateMGConfirmMsg).should(
                 'contain.text',
-                'Your Measure Population Basis is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure group.',
+                'Your Measure Population Basis is about to be saved and updated based on these changes. Any expected values on your test cases will be cleared for this measure group.'
             )
             cy.get(MeasureGroupPage.updatePopulationBasisConfirmationBtn).click()
 
@@ -728,7 +702,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
                 'contain.text',
-                'Population details for this group updated successfully.',
+                'Population details for this group updated successfully.'
             )
 
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -736,10 +710,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             TestCasesPage.clickEditforCreatedTestCase()
 
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab()
 
             //enter values for the expected population
             cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -755,7 +726,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(TestCasesPage.tcHighlightingTab).click()
             cy.get(TestCasesPage.runTestAlertMsg).should(
                 'contain.text',
-                "To see the logic highlights, click 'Run Test'",
+                "To see the logic highlights, click 'Run Test'"
             )
 
             //Click on Execute Test Case button on Edit Test Case page
@@ -791,7 +762,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
             cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
                 'contain.text',
-                'Population details for this group updated successfully.',
+                'Population details for this group updated successfully.'
             )
 
             cy.get(EditMeasurePage.testCasesTab).should('be.visible')
@@ -799,10 +770,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             TestCasesPage.clickEditforCreatedTestCase()
 
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab()
 
             //enter values for the expected populations
             cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
@@ -826,7 +794,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
             cy.get(TestCasesPage.tcHighlightingTab).click()
             cy.get(TestCasesPage.runTestAlertMsg).should(
                 'contain.text',
-                "To see the logic highlights, click 'Run Test'",
+                "To see the logic highlights, click 'Run Test'"
             )
 
             //Click on Execute Test Case button on Edit Test Case page
@@ -841,10 +809,7 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             TestCasesPage.clickEditforCreatedTestCase()
 
-            //click on actual / expected sub-tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+            TestCasesPage.openExpectedActualTab()
 
             //attempt to click on 'Run Test Case' to run the test case via the edit page
             cy.get(TestCasesPage.runTestButton).scrollIntoView()
@@ -856,6 +821,6 @@ describe('Verify "Run Test Cases" results based on missing/empty group populatio
 
             //confirm no message
             cy.get(TestCasesPage.testCaseJsonValidationDisplayList).should('be.visible')
-        },
+        }
     )
 })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExecutionWithCode.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExecutionWithCode.cy.ts
@@ -70,13 +70,9 @@ describe('Test Case Execution with codes', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
-        cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
+        cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
         cy.get(TestCasesPage.detailsTab).should('exist')
         cy.get(TestCasesPage.detailsTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/FluentFunction.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/FluentFunction.cy.ts
@@ -71,7 +71,7 @@ describe('Fluent Function Capability', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/FluentFunction.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/FluentFunction.cy.ts
@@ -71,13 +71,8 @@ describe('Fluent Function Capability', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.openExpectedActualTab()
-        cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).check().should('be.checked')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.detailsTab).should('exist')
         cy.get(TestCasesPage.detailsTab).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ExpectedValuesForObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ExpectedValuesForObservations.cy.ts
@@ -89,7 +89,7 @@ describe('Ratio based measure with measure observations', () => {
         TestCasesPage.ValidateValueAddedToTestCaseJson('http://local/Encounter')
 
         // set expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).type('3')
         cy.get(TestCasesPage.testCaseDENOMExpected).type('1')
         cy.get(TestCasesPage.testCaseNUMERExpected).type('1')
@@ -137,7 +137,7 @@ describe('Ratio based measure with measure observations', () => {
         cy.get(TestCasesPage.testCaseAction0Btn).click()
 
         // check expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('have.value', '3')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('have.value', '1')
@@ -193,7 +193,7 @@ describe('Proportion based measure with no observations', () => {
         TestCasesPage.ValidateValueAddedToTestCaseJson('http://local/Encounter')
 
         // set expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCaseIPPExpected).type('3')
         cy.get(TestCasesPage.testCaseDENOMExpected).type('2')
         cy.get(TestCasesPage.testCaseNUMERExpected).type('1')
@@ -238,11 +238,10 @@ describe('Proportion based measure with no observations', () => {
         cy.get(TestCasesPage.testCaseAction0Btn).click()
 
         // check expected values
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('have.value', '3')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('have.value', '2')
         cy.get(TestCasesPage.testCaseNUMERExpected).should('have.value', '1')
     })
 })
-

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ImportTestCaseWithMultipleMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ImportTestCaseWithMultipleMOs.cy.ts
@@ -102,7 +102,7 @@ describe('Import test case with 2 MOs using QMIG STU5 group name structures', ()
         TestCasesPage.grabTestCaseId(1)
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.runTestButton).click()
 
         // validate pass - checkmark icon at top of table

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
@@ -65,12 +65,8 @@ describe('MADIE Zip Test Case Import', () => {
         TestCasesPage.clickEditforCreatedTestCase(true)
 
         //edit second test case so that it will fail
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -89,12 +85,8 @@ describe('MADIE Zip Test Case Import', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //edit second test case so that it will fail
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -172,12 +164,8 @@ describe('MADIE Zip Test Case Import', () => {
         TestCasesPage.clickEditforCreatedTestCase(true)
 
         //edit second test case so that it will fail
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -196,12 +184,8 @@ describe('MADIE Zip Test Case Import', () => {
         TestCasesPage.clickEditforCreatedTestCase()
 
         //edit second test case so that it will fail
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/MadieZipTestCaseImport.cy.ts
@@ -67,7 +67,7 @@ describe('MADIE Zip Test Case Import', () => {
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
@@ -91,7 +91,7 @@ describe('MADIE Zip Test Case Import', () => {
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
@@ -174,7 +174,7 @@ describe('MADIE Zip Test Case Import', () => {
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })
@@ -198,7 +198,7 @@ describe('MADIE Zip Test Case Import', () => {
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).scrollIntoView().check({ force: true })

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -93,7 +93,7 @@ describe('Test Case Import: functionality tests', () => {
         //edit second test case so that it will fail
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
@@ -723,4 +723,3 @@ describe('Test Case Import: New Test cases on measure validations: PC does not m
         cy.get(TestCasesPage.importTestCaseAlertMessage).find(TestCasesPage.importTestCaseSuccessInfo).should('contain.text', 'Following test case(s) were imported successfully, but the measure populations do not match the populations in the import file. The Test Case has been imported, but no expected values have been')
     })
 })
-

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
@@ -633,7 +633,7 @@ describe('JSON Resource ID tests - Proportion Score Type', () => {
 
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Initial Population')
     })
@@ -717,7 +717,7 @@ describe('JSON Resource ID tests -- CV', () => {
 
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Initial Population')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Population')

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
@@ -67,7 +67,7 @@ describe('Sort by each of the test case list page\'s columns', () => {
 
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
         cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Versioned Measure/VersionedMeasure_CreateEditDeleteTestCase.cy.ts
@@ -123,7 +123,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
@@ -214,7 +214,7 @@ describe('Test Cases: Versioned Measure: Create, Edit, Delete Test Case', () => 
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).click()
+        TestCasesPage.openExpectedActualTab()
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -318,11 +318,7 @@ Cypress.Commands.add('UMLSAPIKeyLogin', () => {
 })
 
 Cypress.Commands.add('editTestCaseJSON', (jsonContent: string) => {
-    TestCasesPage.waitForJsonEditorReady()
-    cy.get(TestCasesPage.aceEditorJsonInput)
-        .click({ force: true })
-        .clear({ force: true })
-        .type(jsonContent, { parseSpecialCharSequences: false, force: true })
+    TestCasesPage.editTestCaseJson(jsonContent)
 })
 
 const compareColor = (color: string, property: keyof CSSStyleDeclaration) => (targetEle: JQuery) => {

--- a/docs/ai/debugging.md
+++ b/docs/ai/debugging.md
@@ -48,6 +48,15 @@ If a failure happens on the Test Case Expected/Actual panel and Cypress reports 
 
 Focused Cypress validation on Monday, July 20, 2026 showed this issue in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, and `RatioPatientSingleIPNoMOwithDRC.cy.ts`, and the stable fix was to use the shared Expected/Actual helper path rather than raw tab clicks plus checkbox actions.
 
+## Split-View And JSON Editor Failures
+
+When a Cypress interaction appears to shift a split-view layout:
+
+1. Reproduce it in headed Chrome and record a video before changing shared helpers.
+2. Compare one interaction change at a time; do not infer a visible regression from an internal `scrollLeft` value alone.
+3. Keep the JSON-editor tab activation inside `TestCasesPage.editTestCaseJson(...)`. Its native button activation is intentional because Cypress actionability scrolling changed the observed split-view layout during JSON-editor flows.
+4. Do not generalize a JSON-editor finding to the Expected/Actual panel. Expected/Actual has its own shared readiness and panel-normalization path and must be validated independently.
+
 ## Selector Debugging
 
 Prefer this order:

--- a/docs/ai/refactoring.md
+++ b/docs/ai/refactoring.md
@@ -21,6 +21,7 @@ Rules:
 - Keep negative/error assertions explicit.
 - Preserve test intent.
 - Keep the change small.
+- When a refactor slice is complete, reassess the remaining scope before choosing the next target. Do not automatically continue to the next nearby file if a larger repeated pattern or higher-value bucket has emerged.
 
 Output:
 

--- a/docs/quality/cypress-automation-guidelines.md
+++ b/docs/quality/cypress-automation-guidelines.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Automation Guidelines
 
-Last updated: 2026-07-20
+Last updated: 2026-07-22
 
 This guide captures stable test-architecture rules used in this repo. Keep tactical plans and changing counts in `docs/quality/test-refactor-backlog.md`.
 
@@ -16,6 +16,7 @@ This guide captures stable test-architecture rules used in this repo. Keep tacti
 - Service specs under `cypress/e2e/Services/` should set up and verify service behavior through APIs.
 - UI specs under `cypress/e2e/WebInterface/` should use the browser for UI behavior: navigation, rendering, editor behavior, permissions, and user interaction.
 - Page objects should not own service setup mechanics.
+- When a feature-flagged change alters an existing contract, keep the current coverage active and add the new coverage alongside it. Put persistence and payload assertions in service specs first, then add UI coverage only for the flagged browser behavior once that UI is exposed.
 - Split large specs by behavior only after shared setup and data helpers are stable.
 
 ## Shared Test Data Rules
@@ -40,12 +41,14 @@ These helper paths are already established and should be reused before adding ne
 
 - Do not commit focused tests. `npm run quality:no-focused-tests` is the guardrail.
 - Skipped tests need an owner, ticket, or removal decision.
+- For tests written ahead of a feature flag rollout, keep them present but not enabled until the flag is available in the target environment. Retire the legacy assertions only after the new path is enabled by default or the old path is removed.
 - Replace fixed numeric waits with route aliases, visible/enabled assertions, or purposeful polling helpers.
 - Use `{ force: true }` only when validating intentionally hidden or native controls; otherwise fix readiness or selector strategy.
 - Avoid global exception suppression. If an exception must be tolerated, make the handling targeted and explain the scope.
 - Prefer stable `data-testid` selectors when available.
 - When a spec creates uniquely named rows in a list, select those rows by generated name or stored ID instead of fixture-position helpers or table order. Row-order selection becomes flaky when cleanup is partial or older test data is still visible.
 - In Expected/Actual test-case flows, prefer `TestCasesPage.openExpectedActualTab(...)` plus `checkExpectedActualCheckbox(...)` or `uncheckExpectedActualCheckbox(...)` over direct tab clicks and raw boolean checkbox actions. On Monday, July 20, 2026, focused Cypress validation showed the split-panel sash can leave expected-value checkboxes clipped or reported as covered even when the selector is correct. Avoid pre-asserting `be.visible` on those clipped boolean inputs; rely on the shared helper to normalize the panel first.
+- When a reusable test-case editor control needs a `data-testid` selector, add it to `TestCasesPage` instead of leaving the literal selector in a spec. Inline `data-testid` strings are acceptable for one-off assertions, but reusable Expected/Actual, stratification, action-center, and editor controls should stay behind the page object so selector churn is localized.
 
 ## Refactor Rules
 

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -13,9 +13,11 @@ After every completed refactor:
 1. Determine whether the completed item can be marked Done.
 2. Determine whether priorities have changed.
 3. Determine whether new work has been discovered.
-4. Recommend updates before moving to the next backlog item.
+4. Re-scan the remaining scope for a larger or higher-value repeated pattern before selecting any next target.
+5. Recommend updates before moving to the next backlog item.
 
 Do not skip unfinished work unless a higher-priority issue is found.
+Do not assume the next listed target is still correct after a completed slice; explicitly reprioritize against the current architecture, audit signal, and remaining duplication first.
 
 ## AI Execution Rules
 
@@ -30,6 +32,7 @@ A backlog item is complete when:
 - Documentation has been evaluated for updates.
 
 Do not begin the next backlog item until the current one is complete.
+When a backlog item is complete, pause and reprioritize before continuing so the next slice is selected from the highest current-value pattern, not by automatic list order.
 
 ## Current Direction
 
@@ -42,37 +45,24 @@ Do not begin the next backlog item until the current one is complete.
 
 Current active item:
 
-- P2 UI reliability debt, next target `cypress/Shared/TestCasesPage.ts`
+- P2 UI reliability debt, `TestCasesPage` Expected/Actual migration by repeated consumer pattern
+- Current bucket: raw boolean checkbox flows
 
 Why this is the best next step:
 
-- Earlier CQL library service cleanup is already proven.
-- `TestCasesPage.ts` fixture-path plumbing and create-test-case API setup now route through `TestData`.
-- `CreateMeasurePage.ts` now routes user scope, fixture writes, and create or clone request setup through `TestData`, so that shared helper no longer owns custom measure-create request plumbing.
-- `TestCaseBuilder.ts` now routes builder resource fixture naming through `TestData`, concentrating the remaining P1 value in a smaller number of shared helpers.
-- Shared-helper request setup is now centralized behind `TestData` for the remaining reusable page-object and utility paths that previously owned custom user-scope, fixture, lock, share, and create-request plumbing.
-- `MinimizeAlerts.cy.ts` now proves the alert-toggle readiness pattern by waiting on visible page state instead of fixed sleeps and by routing repeated minimize or reopen mechanics through `CQLEditorPage`.
-- `CQLCodeSystem.cy.ts` now proves the editor-return readiness pattern by replacing fixed post-tab sleeps with visible editor assertions and retried error checks.
-- `QmigSTU5FileValidations.cy.ts` now proves the export-archive readiness pattern by replacing post-unzip sleeps with extracted-file existence checks and by consolidating repeated export or unzip setup behind local helpers.
-- `TestCaseJSON_TerminologyTests.cy.ts` now proves the JSON-editor readiness pattern by moving terminology cases onto shared editor-ready helpers instead of fixed sleeps before typing JSON content.
-- `MeasureListNewColumnsSort.cy.ts` and `CQLLibraryListPageColumnSort.cy.ts` now prove a reusable list-sorting pattern that replaces fixed sleeps with route aliases plus shared list-render readiness helpers.
-- `QICoreMeasureExport.cy.ts` now proves the export-file readiness pattern by waiting on the version dialog field and the unzipped local HTML file instead of fixed sleeps.
-- `CQLEditorPage.ts` now proves the shared builder-expand and replace-document readiness pattern by replacing helper-level sleeps with editor focusability and document-ready checks that passed in both mismatch and Qi Core function editor flows.
-- `QDMRunExecuteTC.cy.ts` now passes its focused execution-validation coverage after replacing three fixed waits with API-seeded setup, editor-ready saves, and explicit dirty-state handling.
-- `CQLLibraryPage.ts` now passes focused version-action coverage after replacing its helper-level sleeps with action-trigger visibility and list-row readiness checks.
-- `MeasureGroupPage.ts` no longer contains fixed waits after replacing helper-level CQL seeding sleeps with editor-write readiness, save-success assertions, and a stable return to Population Criteria via the existing editor-collapse control plus group-tab retry.
-- Focused helper validation now shifts the best next value to `TestCasesPage.ts`, where remaining waits and heavy forced interactions overlap with the currently observed Expected/Actual sash-actionability failures.
-- Focused Cypress validation on Tuesday, July 21, 2026 now proves the shared Expected/Actual helper path in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, `RatioPatientSingleIPNoMOwithDRC.cy.ts`, `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `CohortEpisodeEncounter.cy.ts`, `CohortPatientBoolean.cy.ts`, `CohortEncounter600.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, `CVEpisodeWithMO.cy.ts`, `CVPatientwithMO.cy.ts`, `CVEpisodeWithStratification.cy.ts`, `CVPatientWithStratification.cy.ts`, `CohortPatientWithStratification.cy.ts`, `CohortEpisodeWithStratification.cy.ts`, `ProportionEpisode.cy.ts`, `RatioEncounterSingleIPWithMOs600.cy.ts`, `CVEncounterWithMOandStrat600.cy.ts`, `RatioEpisodeTwoIPsWithMOs.cy.ts`, `Cohort_ListQDMPositiveEncounterPerformed.cy.ts`, `Proportion_ListQDMPositiveProcedurePerformed.cy.ts`, and `ProportionPatient.cy.ts`. Local Cypress validation on Tuesday, July 21, 2026 also confirmed `CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts`, `Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts`, `Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts`, and `ExecuteTestCasesByNonMeasureOwner.cy.ts` passing after the shared helper update. `TestCasesPage.openExpectedActualTab(...)` now also tolerates QDM Expected/Actual layouts that do not render the split-panel population container, while still normalizing the Qi-Core split-panel scroll position when that container exists. The remaining value in this slice now shifts to non-smoke execution, import, and validation specs that still bypass the shared Expected/Actual helper path, while the product-question ratio observation files remain blocked on SME confirmation.
-- An inventory sweep on Monday, July 20, 2026 found 55 Expected/Actual-touching WebInterface specs, with the highest migration risk concentrated in a smaller bucket of boolean-checkbox flows that still use direct tab clicks, raw checkbox actions, or clipped-checkbox visibility assertions. `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts` now use the shared Expected/Actual helper path. Local validation passed for `ExecutionAndCoverageValidations.cy.ts` and the full `RunAndExecuteTestCaseButtonValidations.cy.ts` file. Keep `RatioPatientTwoIPsWithMOs.cy.ts` and `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts` sidelined until product or SME confirmation resolves the observation-row behavior.
-- `CreateUpdateQDMTestCase.cy.ts`, `QDMTestCaseDirtyCheck.cy.ts`, and `QDMTestCaseValidations.cy.ts` now use the shared Expected/Actual helper path for their QDM tab flows. Headed local validation passed for all three files.
-- `TestCasesPage.ts` now also routes create-test-case save, title or series verification, JSON editor save-return flow, QDM element action-menu clicks, demographics entry, and row-checkbox toggles through shared readiness assertions instead of helper-level sleeps or repeated forced clicks. Local validation on Wednesday, July 22, 2026 confirmed `Add Test Case Expected values for Boolean Measure` and `Add Test Case Expected values for Non Boolean Measure` as the relevant passing coverage for this slice.
-- The remaining Expected/Actual migration inventory is 18 files and 62 direct tab references. Start the next batch with `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts` and `QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts`; keep the product-sidelined ratio observation files out of that batch.
+- Shared helper and request-boundary cleanup is already proven across `TestData`, `CreateMeasurePage.ts`, `CQLEditorPage.ts`, `MeasureGroupPage.ts`, `CQLLibraryPage.ts`, and the earlier service and shared-page-object slices.
+- The remaining high-value UI work is concentrated in `TestCasesPage.ts`, where Expected/Actual flows still drive repeated raw interaction patterns, leftover forced-interaction debt, and mixed readiness handling.
+- The shared Expected/Actual path is now proven across a broad set of Qi-Core and QDM specs, including smoke, execution, validation, multi-group, and ratio-observation coverage.
+- `TestCasesPage.openExpectedActualTab(...)` now handles both Qi-Core split-panel layouts and QDM layouts without the split population panel, and reusable QDM stratified selectors plus `typeExpectedActualValue(...)` are in place.
+- The raw numeric Expected/Actual entry bucket is now proven across QDM, Qi-Core, and observation-heavy consumers, so the next highest-value bucket is raw boolean checkbox flows, followed by legacy `readySelector` openings that can use a concrete Expected/Actual control selector.
+- Keep product-question observation files sidelined until SME confirmation, and keep known environment-dependent failures such as the remaining `QDMRunExecuteTC.cy.ts` non-helper issues out of this slice.
 
 Work boundary for the next slice:
 
-- Stay inside `cypress/Shared/TestCasesPage.ts` unless a very small consuming-spec adjustment is required to prove the helper change.
-- Prioritize reusable readiness or layout helpers for Expected/Actual and related test-case editor flows before touching broader spec logic.
-- Do not combine this slice with broader export, highlighting, or transfer refactors.
+- Keep the active work inside the `TestCasesPage` Expected/Actual migration slice, but organize execution by repeated consumer pattern rather than by spec family.
+- Prefer helper-backed consumer conversion over new abstraction unless a missing shared mechanic is blocking an entire interaction bucket.
+- Do not combine this slice with broader export, highlighting, transfer, or unrelated page-object refactors.
+- Stop the slice only after one interaction bucket is fully migrated, validated, and recorded; do not partially advance multiple buckets in parallel.
 
 ## Current State
 
@@ -85,6 +75,8 @@ Recently proven service/helper slices:
 - Shared cleanup/request helpers: `Utilities.deleteLibrary`, `Utilities` lock and unlock flows, and the `MeasureGroupPage.ts` API create, update, and stratification setup now route fixture reads and authenticated requests through `TestData`.
 - Shared test-case helper cleanup: `TestCasesPage.ts` now routes element/test-case fixture writes, measure/test-case fixture reads, and create-test-case API requests through `TestData`.
 - Shared test-case UI reliability proof: `TestCasesPage.ts` removed helper-level sleeps from create-test-case save, title or series verification, JSON edit-save return, QDM demographics entry, and row-checkbox toggles while consolidating repeated QDM element action-menu clicks behind shared readiness helpers.
+- Shared Expected/Actual proof summary: `TestCasesPage.openExpectedActualTab(...)`, `checkExpectedActualCheckbox(...)`, `uncheckExpectedActualCheckbox(...)`, reusable QDM stratified selectors, and `typeExpectedActualValue(...)` are now proven across Qi-Core and QDM smoke, execution, multi-group, and ratio-observation flows, including `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts` passing 3/3 on Wednesday, July 22, 2026.
+- Raw numeric Expected/Actual entry proof: focused validation on Wednesday, July 22, 2026 passed `QDMTestCaseRelevantElementWarning.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, and `MeasureObservationExpectedValues.cy.ts` after moving raw numeric entry onto `typeExpectedActualValue(...)` and tightening the shared helper to scroll clipped inputs into view before typing.
 - Shared validation proof: `QDM Measure.cy.ts` and `QI Core Test-Cases.cy.ts` now pass against the recent shared-helper conversions in the current workspace once Cypress is run with the invalid `NODE_EXTRA_CA_CERTS` placeholder unset.
 - Shared sharing helper cleanup: `Utilities.setSharePermissions(...)` now delegates library and measure share or unshare request construction through `TestData`, and `CQLLibrarySharing.cy.ts` passes against that path in the current workspace.
 - UI sort reliability proof: `MeasureListNewColumnsSort.cy.ts` now passes after replacing its fixed post-sort waits with route-alias and render-readiness checks, including status assertions tied to the sorted API responses instead of environment-specific row assumptions.
@@ -98,8 +90,6 @@ Recently proven service/helper slices:
 - UI QDM execution reliability proof: `QDMRunExecuteTC.cy.ts` now passes focused coverage for its three former fixed-wait paths after seeding valid CQL in API setup, reusing `CQLEditorPage.saveCql(...)` for editor-ready saves, and handling the test-case dirty-state modal explicitly before returning to the execution list.
 - UI CQL library shared-page-object reliability proof: `CQLLibraryPage.ts` no longer contains fixed waits after replacing helper-level action-menu and first-row sleeps with trigger visibility plus row-readiness assertions, and `AddVersionToCQLLibrary.cy.ts` passes against both the list and edit-screen action-center flows.
 - UI measure-group shared-page-object reliability proof: `MeasureGroupPage.ts` no longer contains fixed waits after consolidating repeated CQL setup behind editor-write and save-success assertions plus the existing editor-collapse control before returning to Population Criteria. Focused `MeasureObservations.cy.ts` validation on Monday, July 20, 2026 passed 7 tests, including `Add Measure Observations for Ratio Measure` and `Add Measure Observations for Continuous Variable Measure`; the remaining 2 failures were downstream Expected/Actual checkbox actionability issues caused by the test-case sash overlay, not by the measure-group helper path.
-- UI Expected/Actual reliability proof: focused Cypress validation on Monday, July 20, 2026 showed `MeasureObservations.cy.ts` passing 9/9 after routing boolean Expected/Actual flows through `TestCasesPage.openExpectedActualTab(...)` plus `checkExpectedActualCheckbox(...)` and `uncheckExpectedActualCheckbox(...)`. The same helper path now also passes in `MeasureObservationExpectedValues.cy.ts` and `RatioPatientSingleIPNoMOwithDRC.cy.ts`, proving the sash-covered checkbox issue is a reusable split-panel readiness problem rather than a spec-local selector defect.
-- UI Expected/Actual migration inventory: the Monday, July 20, 2026 scan identified 8 high-risk specs, 18 medium-risk specs, and 26 lower-risk specs still using some form of direct Expected/Actual tab interaction or raw checkbox flow. 27 specs are now proven on the shared helper path through focused or local validation: `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, `RatioPatientSingleIPNoMOwithDRC.cy.ts`, `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `CohortEpisodeEncounter.cy.ts`, `CohortPatientBoolean.cy.ts`, `CohortEncounter600.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, `CVEpisodeWithMO.cy.ts`, `CVPatientwithMO.cy.ts`, `CVEpisodeWithStratification.cy.ts`, `CVPatientWithStratification.cy.ts`, `CohortPatientWithStratification.cy.ts`, `CohortEpisodeWithStratification.cy.ts`, `ProportionEpisode.cy.ts`, `RatioEncounterSingleIPWithMOs600.cy.ts`, `CVEncounterWithMOandStrat600.cy.ts`, `RatioEpisodeTwoIPsWithMOs.cy.ts`, `Cohort_ListQDMPositiveEncounterPerformed.cy.ts`, `Proportion_ListQDMPositiveProcedurePerformed.cy.ts`, `ProportionPatient.cy.ts`, `CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts`, `Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts`, `Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts`, and `ExecuteTestCasesByNonMeasureOwner.cy.ts`.
 - Shared auth/lock helper cleanup: `Utilities.ts` now routes share-permission requests plus measure/library/test-case lock and unlock-cleanup requests through `TestData` reads and authenticated request helpers.
 - Shared measure cleanup completion: `Utilities.deleteMeasure` and `Utilities.deleteVersionedMeasure` now delegate authenticated delete flows to `TestData` by-ID helpers while preserving graceful missing-fixture cleanup behavior.
 - Shared builder fixture cleanup: `TestCaseBuilder.ts` now routes builder resource fixture naming through `TestData`, so shared helpers own that user-scoped fixture convention.
@@ -112,6 +102,7 @@ Recently diagnosed non-refactor failures:
 - `CQLLibraryDelete.cy.ts` still fails on current `master` because transfer cases return inactive-user `400` responses and admin delete-all cases return `403 insufficient_scope`. Treat that as environment or account-state drift, not as the next refactor target.
 - `CQLLibraryTransfer.cy.ts` currently mixes two separate issues on `dev`: transfer and sharing flows can fail with `400 The provided HARP ID is not associated with an active MADiE user.` for the configured alt user, and the owned-library action-center flow remains slow and intermittently fails on action visibility or missing success toast after long UI login/user-switch cycles. Treat the inactive-user path as environment or account-state drift first; do not attempt session-login conversion in this file until that is resolved.
 - `Measure.cy.ts` still has a non-refactor service failure on July 16, 2026 in `Validation Error: CQL library Name contains special characters`, where the service returns `500` instead of the expected `400` while other measure-service validation paths stay green.
+- `QDMRunExecuteTC.cy.ts` focused validation on Wednesday, July 22, 2026 no longer points at Expected/Actual selector debt for its remaining failures. The current red paths are `Run Test Case button is disabled -- CQL Errors`, which now fails on a detached outlined button click from `cypress/support/commands.ts`, and `Non Measure owner should be able to Run/Execute Test case`, which showed VSAC `401` terminology errors after the alt-user flow and should be revisited as a likely environment or session-dependent dependency instead of Expected/Actual helper debt. Keep those as separate reliability issues from the completed Expected/Actual helper migration in this file.
 
 ## Latest Audit Signal
 
@@ -131,7 +122,7 @@ Largest risk concentrations:
 - `OktaLogin.ts` now carries the remaining shared-helper fixed waits after the latest `TestCasesPage.ts` readiness cleanup removed two more helper sleeps.
 - `QDMRunExecuteTC.cy.ts` dropped out of the fixed-wait hotspot list after its three execution waits were replaced with editor-ready and modal-aware assertions that held in focused Cypress validation on Friday, July 17, 2026.
 - `CQLLibraryPage.ts` dropped out of the fixed-wait hotspot list after its two helper sleeps were replaced with shared action-trigger and row-readiness assertions that held in focused Cypress validation on Friday, July 17, 2026.
-- `TestCasesPage.ts`: remaining UI reliability debt now centers on its leftover forced interactions plus the remaining non-smoke Expected/Actual execution, import, and validation specs that still bypass the shared helper path; fixture-path, create-test-case API setup, and the shared create or edit readiness cleanup are complete.
+- `TestCasesPage.ts`: remaining UI reliability debt now centers on its leftover forced interactions plus the remaining non-smoke Expected/Actual execution, import, and validation specs that still bypass the shared helper path; fixture-path, create-test-case API setup, and the shared create or edit readiness cleanup are complete. The remaining Expected/Actual debt is now primarily organizational: the repo already has the needed shared helper path, but migration progress slows when work is selected by file adjacency instead of by repeated interaction pattern.
 - `AdminLibraryTransfer.cy.ts` and related transfer coverage: UI transfer specs still mix API-eligible setup with browser-only assertions, duplicate transfer/history checks, and combine distinct validation concerns in the same test flow.
 - `CorrectExpectedValues.cy.ts`, `DeleteTest-Case.cy.ts`, and selected admin/measure/test-case service specs: remaining service-tail cleanup.
 - highlighting specs, remaining QDM export or execution specs, and shared page objects: UI reliability debt from waits and forced interactions.
@@ -155,7 +146,7 @@ Current target order:
 
 - shared page objects with remaining waits and high reuse: `OktaLogin.ts`, `TestCasesPage.ts`
 - `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream forced-interaction debt, but the shared helper path is now proven across the smoke-folder rollout plus `ExecuteTestCasesByNonMeasureOwner.cy.ts`, including both Qi-Core split-panel and QDM non-panel Expected/Actual layouts
-- the next Expected/Actual adoption wave should focus on the remaining non-smoke execution, import, and validation specs outside the completed `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts` batch
+- the next Expected/Actual adoption wave should continue one repeated interaction bucket at a time across the remaining non-smoke execution, import, and validation specs, instead of advancing by neighboring file. The raw numeric entry bucket is now complete; shift to raw boolean checkbox flows next, then `readySelector` cleanup outside the completed `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts`, `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts`, and `QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts` proof batch
 - remaining export specs that still rely on repeated unzip or download setup
 - export and terminology-heavy UI specs surfaced near the top of the wait audit
 - forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -46,7 +46,7 @@ When a backlog item is complete, pause and reprioritize before continuing so the
 Current active item:
 
 - P2 UI reliability debt, `TestCasesPage` Expected/Actual migration by repeated consumer pattern
-- Current bucket: raw boolean checkbox flows
+- Current bucket: remaining raw numeric value-entry consumers
 
 Why this is the best next step:
 
@@ -54,7 +54,8 @@ Why this is the best next step:
 - The remaining high-value UI work is concentrated in `TestCasesPage.ts`, where Expected/Actual flows still drive repeated raw interaction patterns, leftover forced-interaction debt, and mixed readiness handling.
 - The shared Expected/Actual path is now proven across a broad set of Qi-Core and QDM specs, including smoke, execution, validation, multi-group, and ratio-observation coverage.
 - `TestCasesPage.openExpectedActualTab(...)` now handles both Qi-Core split-panel layouts and QDM layouts without the split population panel, and reusable QDM stratified selectors plus `typeExpectedActualValue(...)` are in place.
-- The raw numeric Expected/Actual entry bucket is now proven across QDM, Qi-Core, and observation-heavy consumers, so the next highest-value bucket is raw boolean checkbox flows, followed by legacy `readySelector` openings that can use a concrete Expected/Actual control selector.
+- The shared Expected/Actual checkbox path is now effectively migrated: focused proof files were already helper-backed, and the remaining direct checkbox straggler in `MeasureVersionValidations.cy.ts` has been moved onto `checkExpectedActualCheckbox(...)`.
+- The next higher-value bucket is the remaining raw numeric value-entry consumers, followed by legacy `readySelector` openings that can use a concrete Expected/Actual control selector.
 - Keep product-question observation files sidelined until SME confirmation, and keep known environment-dependent failures such as the remaining `QDMRunExecuteTC.cy.ts` non-helper issues out of this slice.
 
 Work boundary for the next slice:
@@ -77,6 +78,7 @@ Recently proven service/helper slices:
 - Shared test-case UI reliability proof: `TestCasesPage.ts` removed helper-level sleeps from create-test-case save, title or series verification, JSON edit-save return, QDM demographics entry, and row-checkbox toggles while consolidating repeated QDM element action-menu clicks behind shared readiness helpers.
 - Shared Expected/Actual proof summary: `TestCasesPage.openExpectedActualTab(...)`, `checkExpectedActualCheckbox(...)`, `uncheckExpectedActualCheckbox(...)`, reusable QDM stratified selectors, and `typeExpectedActualValue(...)` are now proven across Qi-Core and QDM smoke, execution, multi-group, and ratio-observation flows, including `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts` passing 3/3 on Wednesday, July 22, 2026.
 - Raw numeric Expected/Actual entry proof: focused validation on Wednesday, July 22, 2026 passed `QDMTestCaseRelevantElementWarning.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, and `MeasureObservationExpectedValues.cy.ts` after moving raw numeric entry onto `typeExpectedActualValue(...)` and tightening the shared helper to scroll clipped inputs into view before typing.
+- Raw boolean Expected/Actual checkbox proof: repository scan on Thursday, July 23, 2026 found the helper migration already covered the active proof set, with only one direct checkbox straggler left in `MeasureVersionValidations.cy.ts`; that straggler now uses `openExpectedActualTab({ checkboxSelector: ... })` plus `checkExpectedActualCheckbox(...)`, so the boolean checkbox bucket can be treated as complete.
 - Shared validation proof: `QDM Measure.cy.ts` and `QI Core Test-Cases.cy.ts` now pass against the recent shared-helper conversions in the current workspace once Cypress is run with the invalid `NODE_EXTRA_CA_CERTS` placeholder unset.
 - Shared sharing helper cleanup: `Utilities.setSharePermissions(...)` now delegates library and measure share or unshare request construction through `TestData`, and `CQLLibrarySharing.cy.ts` passes against that path in the current workspace.
 - UI sort reliability proof: `MeasureListNewColumnsSort.cy.ts` now passes after replacing its fixed post-sort waits with route-alias and render-readiness checks, including status assertions tied to the sorted API responses instead of environment-specific row assumptions.
@@ -146,7 +148,7 @@ Current target order:
 
 - shared page objects with remaining waits and high reuse: `OktaLogin.ts`, `TestCasesPage.ts`
 - `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream forced-interaction debt, but the shared helper path is now proven across the smoke-folder rollout plus `ExecuteTestCasesByNonMeasureOwner.cy.ts`, including both Qi-Core split-panel and QDM non-panel Expected/Actual layouts
-- the next Expected/Actual adoption wave should continue one repeated interaction bucket at a time across the remaining non-smoke execution, import, and validation specs, instead of advancing by neighboring file. The raw numeric entry bucket is now complete; shift to raw boolean checkbox flows next, then `readySelector` cleanup outside the completed `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts`, `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts`, and `QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts` proof batch
+- the next Expected/Actual adoption wave should continue one repeated interaction bucket at a time across the remaining non-smoke execution, import, and validation specs, instead of advancing by neighboring file. The boolean checkbox bucket is now complete; shift to the remaining raw numeric value-entry consumers next, then `readySelector` cleanup outside the completed `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts`, `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts`, and `QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts` proof batch
 - remaining export specs that still rely on repeated unzip or download setup
 - export and terminology-heavy UI specs surfaced near the top of the wait audit
 - forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Quality Architecture Backlog
 
-Last updated: 2026-07-21
+Last updated: 2026-07-22
 
 Stable rules live in `docs/quality/cypress-automation-guidelines.md`. Keep this backlog limited to current state, next actions, measured audit signal, and validation.
 
@@ -63,7 +63,10 @@ Why this is the best next step:
 - `MeasureGroupPage.ts` no longer contains fixed waits after replacing helper-level CQL seeding sleeps with editor-write readiness, save-success assertions, and a stable return to Population Criteria via the existing editor-collapse control plus group-tab retry.
 - Focused helper validation now shifts the best next value to `TestCasesPage.ts`, where remaining waits and heavy forced interactions overlap with the currently observed Expected/Actual sash-actionability failures.
 - Focused Cypress validation on Tuesday, July 21, 2026 now proves the shared Expected/Actual helper path in `MeasureObservations.cy.ts`, `MeasureObservationExpectedValues.cy.ts`, `RatioPatientSingleIPNoMOwithDRC.cy.ts`, `BooleanAndNonBooleanExpectedValues.cy.ts`, `TestCaseExpectedValues.cy.ts`, `TestCasePopulationValues.cy.ts`, `CohortEpisodeEncounter.cy.ts`, `CohortPatientBoolean.cy.ts`, `CohortEncounter600.cy.ts`, `RatioEpisodeSingleIPNoMO.cy.ts`, `CVEpisodeWithMO.cy.ts`, `CVPatientwithMO.cy.ts`, `CVEpisodeWithStratification.cy.ts`, `CVPatientWithStratification.cy.ts`, `CohortPatientWithStratification.cy.ts`, `CohortEpisodeWithStratification.cy.ts`, `ProportionEpisode.cy.ts`, `RatioEncounterSingleIPWithMOs600.cy.ts`, `CVEncounterWithMOandStrat600.cy.ts`, `RatioEpisodeTwoIPsWithMOs.cy.ts`, `Cohort_ListQDMPositiveEncounterPerformed.cy.ts`, `Proportion_ListQDMPositiveProcedurePerformed.cy.ts`, and `ProportionPatient.cy.ts`. Local Cypress validation on Tuesday, July 21, 2026 also confirmed `CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts`, `Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts`, `Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts`, and `ExecuteTestCasesByNonMeasureOwner.cy.ts` passing after the shared helper update. `TestCasesPage.openExpectedActualTab(...)` now also tolerates QDM Expected/Actual layouts that do not render the split-panel population container, while still normalizing the Qi-Core split-panel scroll position when that container exists. The remaining value in this slice now shifts to non-smoke execution, import, and validation specs that still bypass the shared Expected/Actual helper path, while the product-question ratio observation files remain blocked on SME confirmation.
-- An inventory sweep on Monday, July 20, 2026 found 55 Expected/Actual-touching WebInterface specs, with the highest migration risk concentrated in a smaller bucket of boolean-checkbox flows that still use direct tab clicks, raw checkbox actions, or clipped-checkbox visibility assertions. The current top targets are `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts`. Keep `RatioPatientTwoIPsWithMOs.cy.ts` and `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts` sidelined until product or SME confirmation resolves the observation-row behavior.
+- An inventory sweep on Monday, July 20, 2026 found 55 Expected/Actual-touching WebInterface specs, with the highest migration risk concentrated in a smaller bucket of boolean-checkbox flows that still use direct tab clicks, raw checkbox actions, or clipped-checkbox visibility assertions. `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts` now use the shared Expected/Actual helper path. Local validation passed for `ExecutionAndCoverageValidations.cy.ts` and the full `RunAndExecuteTestCaseButtonValidations.cy.ts` file. Keep `RatioPatientTwoIPsWithMOs.cy.ts` and `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts` sidelined until product or SME confirmation resolves the observation-row behavior.
+- `CreateUpdateQDMTestCase.cy.ts`, `QDMTestCaseDirtyCheck.cy.ts`, and `QDMTestCaseValidations.cy.ts` now use the shared Expected/Actual helper path for their QDM tab flows. Headed local validation passed for all three files.
+- `TestCasesPage.ts` now also routes create-test-case save, title or series verification, JSON editor save-return flow, QDM element action-menu clicks, demographics entry, and row-checkbox toggles through shared readiness assertions instead of helper-level sleeps or repeated forced clicks. Local validation on Wednesday, July 22, 2026 confirmed `Add Test Case Expected values for Boolean Measure` and `Add Test Case Expected values for Non Boolean Measure` as the relevant passing coverage for this slice.
+- The remaining Expected/Actual migration inventory is 18 files and 62 direct tab references. Start the next batch with `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts` and `QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts`; keep the product-sidelined ratio observation files out of that batch.
 
 Work boundary for the next slice:
 
@@ -81,6 +84,7 @@ Recently proven service/helper slices:
 - Shared create/fixture path: `CreateMeasurePage.ts` now routes user scope, fixture writes, measure create/clone requests, and draft measure ID reads through `TestData` helpers.
 - Shared cleanup/request helpers: `Utilities.deleteLibrary`, `Utilities` lock and unlock flows, and the `MeasureGroupPage.ts` API create, update, and stratification setup now route fixture reads and authenticated requests through `TestData`.
 - Shared test-case helper cleanup: `TestCasesPage.ts` now routes element/test-case fixture writes, measure/test-case fixture reads, and create-test-case API requests through `TestData`.
+- Shared test-case UI reliability proof: `TestCasesPage.ts` removed helper-level sleeps from create-test-case save, title or series verification, JSON edit-save return, QDM demographics entry, and row-checkbox toggles while consolidating repeated QDM element action-menu clicks behind shared readiness helpers.
 - Shared validation proof: `QDM Measure.cy.ts` and `QI Core Test-Cases.cy.ts` now pass against the recent shared-helper conversions in the current workspace once Cypress is run with the invalid `NODE_EXTRA_CA_CERTS` placeholder unset.
 - Shared sharing helper cleanup: `Utilities.setSharePermissions(...)` now delegates library and measure share or unshare request construction through `TestData`, and `CQLLibrarySharing.cy.ts` passes against that path in the current workspace.
 - UI sort reliability proof: `MeasureListNewColumnsSort.cy.ts` now passes after replacing its fixed post-sort waits with route-alias and render-readiness checks, including status assertions tied to the sorted API responses instead of environment-specific row assumptions.
@@ -111,23 +115,23 @@ Recently diagnosed non-refactor failures:
 
 ## Latest Audit Signal
 
-Command: `npm run quality:no-focused-tests` on 2026-07-21
+Command: `npm run quality:no-focused-tests` on 2026-07-22
 
-- Inventory: 256 specs / 65547 spec lines; 29 shared files / 18778 shared lines; 3 support files / 633 support lines; 9 scripts / 1511 script lines.
+- Inventory: 256 specs / 65494 spec lines; 29 shared files / 18728 shared lines; 3 support files / 629 support lines; 9 scripts / 1511 script lines.
 - Skipped tests: 11.
 - Manual fixture path plumbing: 191.
 - Manual access token plumbing: 87.
-- Fixed waits: 38.
-- Forced interactions: 193.
+- Fixed waits: 36.
+- Forced interactions: 168.
 - Global uncaught exception suppression: 1.
 
 Largest risk concentrations:
 
 - `MeasureGroupPage.ts` dropped out of the fixed-wait hotspot list after its three helper sleeps were replaced with editor-ready and save-success assertions that held in focused measure-observation coverage on Monday, July 20, 2026.
-- `OktaLogin.ts` and `TestCasesPage.ts` now carry the remaining shared-helper fixed waits.
+- `OktaLogin.ts` now carries the remaining shared-helper fixed waits after the latest `TestCasesPage.ts` readiness cleanup removed two more helper sleeps.
 - `QDMRunExecuteTC.cy.ts` dropped out of the fixed-wait hotspot list after its three execution waits were replaced with editor-ready and modal-aware assertions that held in focused Cypress validation on Friday, July 17, 2026.
 - `CQLLibraryPage.ts` dropped out of the fixed-wait hotspot list after its two helper sleeps were replaced with shared action-trigger and row-readiness assertions that held in focused Cypress validation on Friday, July 17, 2026.
-- `TestCasesPage.ts`: remaining UI reliability debt from forced interactions and the remaining non-smoke Expected/Actual execution, import, and validation specs that still bypass the shared helper path; fixture-path and create-test-case API setup cleanup is complete.
+- `TestCasesPage.ts`: remaining UI reliability debt now centers on its leftover forced interactions plus the remaining non-smoke Expected/Actual execution, import, and validation specs that still bypass the shared helper path; fixture-path, create-test-case API setup, and the shared create or edit readiness cleanup are complete.
 - `AdminLibraryTransfer.cy.ts` and related transfer coverage: UI transfer specs still mix API-eligible setup with browser-only assertions, duplicate transfer/history checks, and combine distinct validation concerns in the same test flow.
 - `CorrectExpectedValues.cy.ts`, `DeleteTest-Case.cy.ts`, and selected admin/measure/test-case service specs: remaining service-tail cleanup.
 - highlighting specs, remaining QDM export or execution specs, and shared page objects: UI reliability debt from waits and forced interactions.
@@ -151,7 +155,7 @@ Current target order:
 
 - shared page objects with remaining waits and high reuse: `OktaLogin.ts`, `TestCasesPage.ts`
 - `TestCasesPage.ts` Expected/Actual and editor flows now also carry the most actionable downstream forced-interaction debt, but the shared helper path is now proven across the smoke-folder rollout plus `ExecuteTestCasesByNonMeasureOwner.cy.ts`, including both Qi-Core split-panel and QDM non-panel Expected/Actual layouts
-- the next Expected/Actual adoption wave should focus on non-smoke execution, import, and validation specs such as `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and the remaining QDM execution specs
+- the next Expected/Actual adoption wave should focus on the remaining non-smoke execution, import, and validation specs outside the completed `RunAndExecuteTestCaseButtonValidations.cy.ts`, `MeasureObservationActualValues.cy.ts`, `ExecutionAndCoverageValidations.cy.ts`, `TestCaseExecutionWithCode.cy.ts`, and `QDMRatioMeasure_with_MOs_on_TC_AE_tab.cy.ts` batch
 - remaining export specs that still rely on repeated unzip or download setup
 - export and terminology-heavy UI specs surfaced near the top of the wait audit
 - forced interactions in `TestCasesPage.ts`, import validations, highlighting specs, and editor flows


### PR DESCRIPTION
## Summary
Stabilize shared TestCasesPage Expected/Actual and JSON-editor flows so Cypress relies on shared readiness helpers instead of helper-level sleeps and repeated forced clicks.

## Changes
- refactor `cypress/Shared/TestCasesPage.ts` create/save, JSON edit/save, demographics, row checkbox, and QDM element action-center flows onto shared readiness helpers
- migrate remaining consuming specs and `cypress/support/commands.ts` onto the shared Expected/Actual and JSON-editor helper path
- update `docs/ai/debugging.md` and `docs/quality/test-refactor-backlog.md` with the durable debugging note, current audit signal, and next target files

## Technical Notes
- keep Expected/Actual panel normalization inside `TestCasesPage.openExpectedActualTab(...)` so Qi-Core split-panel and QDM non-panel layouts share one path
- keep JSON editor entry in `TestCasesPage.editTestCaseJson(...)` so custom commands and specs reuse the same readiness behavior
- preserve test behavior while replacing fixed waits with visible/enabled assertions in the shared helper path

## Testing
- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`
- local validation covered `Add Test Case Expected values for Boolean Measure` and `Add Test Case Expected values for Non Boolean Measure`

## Risk
- `TestCasesPage.ts` is still a high-reuse shared helper, so remaining risk is concentrated in other editor/import flows that still use leftover forced interactions
- broader `P2 UI reliability debt` is still in progress; next backlog targets remain `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts` and `QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts`

## Documentation
- updated `docs/ai/debugging.md`
- updated `docs/quality/test-refactor-backlog.md`