### PR TITLE
Fix CI hang and rerun targeting

### DIFF
--- a/cypress/e2e/WebInterface/CQL Library/CompareLibraryVersions/CompareLibraryVersions.cy.ts
+++ b/cypress/e2e/WebInterface/CQL Library/CompareLibraryVersions/CompareLibraryVersions.cy.ts
@@ -91,6 +91,6 @@ describe('CompareLibraryVersions', () => {
         //Verify Popup Screen
         cy.contains('h2', 'Compare Library Versions').should('be.visible')
         cy.get('[data-testid="library-name"]').should('contain.text', '-- ' + CqlLibraryOne + ' ++ ' + updatedCqlLibraryName)
-        cy.pause()
+        cy.get('[data-testid="compare-version-dialog-content"]').should('be.visible')
     })
 })

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -8,6 +8,8 @@ const primaryUsers = ['harpUser', 'harpUser2', 'harpUser3']
 const altUsers = ['altHarpUser', 'altHarpUser2', 'altHarpUser3']
 const lockFilePath = path.join(__dirname, 'userLock.json')
 const altLockFilePath = path.join(__dirname, 'altUserLock.json')
+const lockAcquireTimeoutMs = Number(process.env.CYPRESS_USER_LOCK_TIMEOUT_MS || 30000)
+const lockRetryIntervalMs = Number(process.env.CYPRESS_USER_LOCK_RETRY_MS || 100)
 
 function getConfigurationByFile(file) {
     const pathToConfigFile = path.resolve('./cypress/', 'config', `${file}.json`)
@@ -26,31 +28,76 @@ function readLock(filePath) {
         return {}
     }
 
-    return JSON.parse(fs.readFileSync(filePath))
+    try {
+        return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+    } catch (err) {
+        console.warn(`Unable to parse lock file ${filePath}; resetting it. ${err.message}`)
+        return {}
+    }
 }
 
 function writeLock(filePath, lock) {
     fs.writeFileSync(filePath, JSON.stringify(lock))
 }
 
-function claimFirstAvailableUser(filePath, users) {
-    const lock = readLock(filePath)
-    const user = users.find((candidate) => !lock[candidate])
+function sleepMs(ms) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
 
+function withFileLock(filePath, action) {
+    const mutexDir = `${filePath}.mutex`
+    const startedAt = Date.now()
+
+    while (true) {
+        try {
+            fs.mkdirSync(mutexDir)
+            break
+        } catch (err) {
+            if (err.code !== 'EEXIST') {
+                throw err
+            }
+
+            if (Date.now() - startedAt >= lockAcquireTimeoutMs) {
+                throw new Error(`Timed out acquiring user lock for ${path.basename(filePath)} after ${lockAcquireTimeoutMs}ms`)
+            }
+
+            sleepMs(lockRetryIntervalMs)
+        }
+    }
+
+    try {
+        return action()
+    } finally {
+        fs.removeSync(mutexDir)
+    }
+}
+
+function claimFirstAvailableUser(filePath, users) {
+    return withFileLock(filePath, () => {
+        const lock = readLock(filePath)
+        const user = users.find((candidate) => !lock[candidate])
+
+        if (!user) {
+            return null
+        }
+
+        lock[user] = true
+        writeLock(filePath, lock)
+        return user
+    })
+}
+
+function releaseLockedUser(filePath, user) {
     if (!user) {
         return null
     }
 
-    lock[user] = true
-    writeLock(filePath, lock)
-    return user
-}
-
-function releaseLockedUser(filePath, user) {
-    const lock = readLock(filePath)
-    lock[user] = false
-    writeLock(filePath, lock)
-    return null
+    return withFileLock(filePath, () => {
+        const lock = readLock(filePath)
+        lock[user] = false
+        writeLock(filePath, lock)
+        return null
+    })
 }
 
 module.exports = (on, config) => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs-extra')
+const nativeFs = require('fs')
 const path = require('path')
 const unzipper = require('unzipper')
 const { removeDirectory } = require('cypress-delete-downloads-folder')
@@ -24,12 +25,12 @@ function unzipFile(zipFile, outputPath) {
 }
 
 function readLock(filePath) {
-    if (!fs.existsSync(filePath)) {
+    if (!nativeFs.existsSync(filePath)) {
         return {}
     }
 
     try {
-        return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+        return JSON.parse(nativeFs.readFileSync(filePath, 'utf8'))
     } catch (err) {
         console.warn(`Unable to parse lock file ${filePath}; resetting it. ${err.message}`)
         return {}
@@ -37,7 +38,7 @@ function readLock(filePath) {
 }
 
 function writeLock(filePath, lock) {
-    fs.writeFileSync(filePath, JSON.stringify(lock))
+    nativeFs.writeFileSync(filePath, JSON.stringify(lock))
 }
 
 function sleepMs(ms) {
@@ -48,28 +49,23 @@ function withFileLock(filePath, action) {
     const mutexDir = `${filePath}.mutex`
     const startedAt = Date.now()
 
-    while (true) {
+    while (Date.now() - startedAt < lockAcquireTimeoutMs) {
         try {
-            fs.mkdirSync(mutexDir)
-            break
+            nativeFs.mkdirSync(mutexDir)
+            try {
+                return action()
+            } finally {
+                nativeFs.rmSync(mutexDir, { recursive: true, force: true })
+            }
         } catch (err) {
             if (err.code !== 'EEXIST') {
                 throw err
             }
-
-            if (Date.now() - startedAt >= lockAcquireTimeoutMs) {
-                throw new Error(`Timed out acquiring user lock for ${path.basename(filePath)} after ${lockAcquireTimeoutMs}ms`)
-            }
-
             sleepMs(lockRetryIntervalMs)
         }
     }
 
-    try {
-        return action()
-    } finally {
-        fs.removeSync(mutexDir)
-    }
+    throw new Error(`Timed out acquiring user lock for ${path.basename(filePath)} after ${lockAcquireTimeoutMs}ms`)
 }
 
 function claimFirstAvailableUser(filePath, users) {

--- a/scripts/rerun-failed-tests.js
+++ b/scripts/rerun-failed-tests.js
@@ -9,7 +9,11 @@ const summaryFile =
   process.env.FAILED_TEST_SUMMARY ||
   (process.env.BUILD_NUMBER ? `failure-summary-${process.env.BUILD_NUMBER}.json` : '')
 const configFile = process.argv[3] || process.env.CYPRESS_RERUN_CONFIG || 'test'
-const rerunMetadataFile = process.argv[4] || process.env.RERUN_METADATA_FILE || ''
+const rerunMetadataFile =
+  process.argv[4] ||
+  process.env.RERUN_METADATA_FILE ||
+  process.env.RERUN_TARGETING_FILE ||
+  ''
 const browser = process.env.CYPRESS_RERUN_BROWSER || 'chrome'
 const headed = process.env.CYPRESS_RERUN_HEADED !== 'false'
 


### PR DESCRIPTION
## Summary
Fix the initial CI hang and improve rerun reliability.

The initial run hang was traced to a committed `cy.pause()` in the compare-library-versions UI spec, which caused a headed Cypress worker to stall until Jenkins hit the outer 8-hour timeout. This change removes that pause and replaces it with a normal dialog assertion.

This PR also keeps the CI follow-up fixes that improved rerun behavior by hardening pooled user locking and ensuring rerun targeting metadata is written to the file Jenkins already passes in.

## Changes
- Replace `cy.pause()` in `CompareLibraryVersions.cy.ts` with a visible dialog-content assertion
- Make pooled user lock acquisition and release atomic in `cypress/plugins/index.js`
- Accept `RERUN_TARGETING_FILE` in `scripts/rerun-failed-tests.js` so rerun targeting metadata is recorded correctly

## Technical Notes
- The spec change preserves the existing test intent and just removes the interactive debug stop that blocks headed CI
- The user-lock change stays inside the existing file-based locking approach rather than introducing a new mechanism
- The rerun change aligns the script with the current Jenkins environment variable contract

## Testing
- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`

## Risk
- Low to moderate
- The spec change is narrow and should only affect the compare-versions flow
- The lock-file change touches shared CI infrastructure, so the next parallel rerun is the best place to confirm behavior

## Documentation
Documentation Updates:
None