### PR TITLE
Add locked test case dropdown tooltip coverage

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -6,6 +6,7 @@ import { CQLEditorPage } from './CQLEditorPage'
 import { MeasuresPage } from './MeasuresPage'
 import { step } from '../utils/step'
 import { FixtureOwner, TestData } from './TestData'
+import { LockedEntityValidation } from './LockedEntityValidation'
 
 export type TestCase = {
   title: string
@@ -300,6 +301,8 @@ export class TestCasesPage {
   public static readonly highlightingPCTabSelector = '[data-testid="population-criterion-selector"]'
   public static readonly lastSavedDate = '[data-testid="test-case-title-0_lastModifiedAt"]'
   public static readonly testCaseNameDropdown = '#edit-test-case-bread-crumbs > .MuiInputBase-root > .MuiSelect-select'
+  public static readonly testCaseNameDropdownLockedIcon = `${TestCasesPage.testCaseNameDropdown} [data-testid="locked-icon"]`
+  public static readonly testCaseNameDropdownOptions = 'li[role="option"]'
   public static readonly testCaseListCheckBox = '.px-1 > input'
   public static readonly testCaseLockedModalMessage = '[data-testid="test case-locked-modal-message"]'
   public static readonly testCaseLockedModalMessageText = '[data-testid="test case-locked-modal-message"] p'
@@ -1141,6 +1144,45 @@ export class TestCasesPage {
         cy.url({ timeout: 60000 }).should('include', `/test-cases/${tcId}`)
         cy.get(this.detailsTab, { timeout: 60000 }).should('be.visible')
       })
+  }
+
+  public static assertSelectedLockedTestCaseDropdownTooltip(expectedTooltip: string): void {
+    step('Assert locked test case dropdown selected value tooltip')
+
+    cy.get(this.testCaseNameDropdownLockedIcon)
+      .should('be.visible')
+      .trigger('mouseover', { force: true })
+
+    cy.get(this.testCaseNameDropdownLockedIcon)
+      .invoke('attr', 'aria-label')
+      .then((ariaLabel) => {
+        expect((ariaLabel ?? '').trim()).to.contain(expectedTooltip)
+      })
+  }
+
+  public static assertLockedTestCaseDropdownOptionTooltip(optionText: string, expectedTooltip: string): void {
+    step('Assert locked test case dropdown option tooltip')
+
+    cy.get(this.testCaseNameDropdown).should('be.visible').click()
+    cy.contains(this.testCaseNameDropdownOptions, optionText, { timeout: 30000 })
+      .should('be.visible')
+      .as('lockedTestCaseOption')
+
+    cy.get('@lockedTestCaseOption').trigger('mouseover', { force: true })
+    cy.get('@lockedTestCaseOption')
+      .find('[data-testid="locked-icon"]')
+      .should('be.visible')
+      .trigger('mouseover', { force: true })
+      .invoke('attr', 'aria-label')
+      .then((ariaLabel) => {
+        expect((ariaLabel ?? '').trim()).to.contain(expectedTooltip)
+      })
+
+    cy.get('body').then(($body) => {
+      if ($body.find('.MuiTooltip-tooltip').length > 0) {
+        LockedEntityValidation.assertVisibleTooltipText(expectedTooltip)
+      }
+    })
   }
 
   public static CreateTestCaseAPI(

--- a/cypress/e2e/WebInterface/Measure/Locking/LockedEntityTooltipDisplayName.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/Locking/LockedEntityTooltipDisplayName.cy.ts
@@ -17,6 +17,11 @@ const testCase: TestCase = {
     group: 'PASS',
     description: 'Used for locked test case tooltip coverage'
 }
+const secondTestCase: TestCase = {
+    title: 'Unlocked companion test case',
+    group: 'PASS',
+    description: 'Used for locked dropdown tooltip coverage'
+}
 
 let harpUserALT = ''
 let qicoreMeasureName = ''
@@ -31,6 +36,12 @@ const openLockedTestCaseInView = (): void => {
     step('Open locked test case in view mode')
     MeasuresPage.actionCenter('edit')
     TestCasesPage.clickEditforCreatedTestCase()
+}
+
+const openUnlockedSecondTestCaseInView = (): void => {
+    step('Open unlocked second test case in view mode')
+    MeasuresPage.actionCenter('edit')
+    TestCasesPage.clickEditforCreatedTestCase(true)
 }
 
 describe('Locked Measure, Library, and Test Case tooltips display user name', () => {
@@ -158,6 +169,14 @@ describe('Locked Measure, Library, and Test Case tooltips display user name', ()
                 'boolean'
             )
             TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description)
+            TestCasesPage.CreateTestCaseAPI(
+                secondTestCase.title,
+                secondTestCase.group,
+                secondTestCase.description,
+                undefined,
+                false,
+                true
+            )
 
             Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
             Utilities.lockSharedTestCase(true)
@@ -198,6 +217,14 @@ describe('Locked Measure, Library, and Test Case tooltips display user name', ()
                 'boolean'
             )
             TestCasesPage.CreateTestCaseAPI(testCase.title, testCase.group, testCase.description)
+            TestCasesPage.CreateTestCaseAPI(
+                secondTestCase.title,
+                secondTestCase.group,
+                secondTestCase.description,
+                undefined,
+                false,
+                true
+            )
 
             Utilities.setSharePermissions(MadieObject.Measure, PermissionActions.GRANT, harpUserALT)
             Utilities.lockSharedTestCase(true)
@@ -230,7 +257,7 @@ describe('Locked Measure, Library, and Test Case tooltips display user name', ()
             })
         })
 
-        it.skip('Locked test case dropdown tooltip includes display name and HARP ID', () => {
+        it('Locked test case dropdown selected value tooltip includes display name and HARP ID', () => {
             LockedEntityValidation.getDisplayName(harpUserALT).then((displayName) => {
                 const expectedTooltip = LockedEntityValidation.lockedTooltipText(displayName, harpUserALT)
                 const expectedModalMessage = LockedEntityValidation.lockedModalMessageText(
@@ -241,11 +268,16 @@ describe('Locked Measure, Library, and Test Case tooltips display user name', ()
 
                 openLockedTestCaseInView()
                 TestCasesPage.dismissTestCaseLockedModal(expectedModalMessage)
+                TestCasesPage.assertSelectedLockedTestCaseDropdownTooltip(expectedTooltip)
+            })
+        })
 
-                // The Jira notes this tooltip has a separate app bug. Keep the assertion here so the
-                // test is ready once the dropdown reliably exposes the lock tooltip in the UI.
-                cy.get(TestCasesPage.testCaseNameDropdown).trigger('mouseover')
-                LockedEntityValidation.assertVisibleTooltipText(expectedTooltip)
+        it('Locked test case dropdown option tooltip includes display name and HARP ID when another test case is selected', () => {
+            LockedEntityValidation.getDisplayName(harpUserALT).then((displayName) => {
+                const expectedTooltip = LockedEntityValidation.lockedTooltipText(displayName, harpUserALT)
+
+                openUnlockedSecondTestCaseInView()
+                TestCasesPage.assertLockedTestCaseDropdownOptionTooltip(testCase.title, expectedTooltip)
             })
         })
     })


### PR DESCRIPTION
## Summary
- Adds locked test case dropdown tooltip coverage for both selected-value and alternate-option states.
- Updates `TestCasesPage` with reusable selectors/helpers for locked dropdown tooltip assertions.
- Creates a second companion test case in the locking spec so the locked option tooltip can be validated from another selected test case.

## Validation
- `npm run compile`
- `npm run quality:no-focused-tests`
- Focused Cypress validation for `cypress/e2e/WebInterface/Measure/Locking/LockedEntityTooltipDisplayName.cy.ts`
- Focused passing result for locked dropdown option tooltip:
  - `cypress/results/mochawesome_07242026_112801.json`