### PR TITLE
Stabilize regression test workflows

### DIFF
--- a/cypress/Shared/CreateMeasurePage.ts
+++ b/cypress/Shared/CreateMeasurePage.ts
@@ -33,7 +33,8 @@ export type CreateMeasureOptions = {
     mpStartDate?: string,
     mpEndDate?: string,
     blankMetadata?: boolean,
-    description?: string
+    description?: string,
+    composite?: boolean
 }
 
 export class CreateMeasurePage {
@@ -183,6 +184,25 @@ export class CreateMeasurePage {
         cy.get(MeasuresPage.measureListTitles).should('be.visible')
 
         cy.log('Composite Measure created successfully')
+    }
+
+    public static CreateCompositeMeasureAPI(
+        measureName: string,
+        cqlLibraryName: string,
+        model: SupportedCompositeModels,
+        optionalParams?: CreateMeasureOptions,
+        measureNumber?: number
+    ): string {
+        return this.CreateMeasureAPI(
+            measureName,
+            cqlLibraryName,
+            model as unknown as SupportedModels,
+            {
+                ...optionalParams,
+                composite: true
+            },
+            measureNumber
+        )
     }
 
     public static CreateQICoreMeasureAPI(measureName: string, CqlLibraryName: string, measureCQL?: string,
@@ -693,6 +713,7 @@ export class CreateMeasurePage {
 
         let user,
             altUser = false,
+            composite = false,
             mpStartDate = now().subtract('2', 'year').format('YYYY-MM-DD'),
             mpEndDate = now().format('YYYY-MM-DD'),
             ecqmTitle = 'AutoTestTitle',
@@ -704,6 +725,9 @@ export class CreateMeasurePage {
 
         if (optionalParams && optionalParams.altUser) {
             altUser = optionalParams.altUser
+        }
+        if (optionalParams && optionalParams.composite) {
+            composite = optionalParams.composite
         }
         if (optionalParams && optionalParams.mpStartDate) {
             mpStartDate = optionalParams.mpStartDate
@@ -761,6 +785,13 @@ export class CreateMeasurePage {
                         "url": "www.eatrightpro.org"
                     }
                 ]
+            }
+        }
+
+        if (composite) {
+            measureMetadata = {
+                ...measureMetadata,
+                composite: true
             }
         }
 

--- a/cypress/Shared/MeasureGroupPage.ts
+++ b/cypress/Shared/MeasureGroupPage.ts
@@ -866,13 +866,14 @@ export class MeasureGroupPage {
         cy.get(this.supplementalDataDefinitionDropdown).scrollIntoView().contains('SDE Sex').click()
 
         //Save Supplemental data
-        cy.get(this.saveSupplementalDataElements).click({ force: true })
+        cy.get(this.saveSupplementalDataElements).should('be.visible').and('be.enabled').click()
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 50000)
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
             'Measure Supplemental Data have been Saved Successfully'
         )
         Utilities.waitForElementToNotExist(EditMeasurePage.successMessage, 50000)
+        Utilities.waitForElementDisabled(this.saveSupplementalDataElements, 60000)
     }
 
     public static addStratificationDataAPI(stratificationData: Array<Stratification>) {

--- a/cypress/Shared/TestCaseBuilder.ts
+++ b/cypress/Shared/TestCaseBuilder.ts
@@ -62,6 +62,9 @@ export class TestCaseBuilder {
 
     public static readonly applyButton = '[data-testid="element-editor-submit-button"]'
     public static readonly undoButton = '[data-testid="element-editor-undo-button"]'
+    public static readonly observationStatus = '[data-testid="code-selector-Observation.status"]'
+    public static readonly dropdownListbox = '[role="listbox"]'
+    public static readonly dropdownOption = '[role="option"]'
 
     public static readonly horizontalSlider = "[data-testid='builder-slider']"
 
@@ -74,37 +77,49 @@ export class TestCaseBuilder {
 
         cy.get('[data-testid="add-element-' + addition + '"]').click().wait(500)
 
-        cy.get(this.addedTab).click().wait(500)
-
         cy.window().its('store').then(store => {
 
             resourceId = store.bundle.entry[bundleIndex].resource.id
 
             TestData.writeBuilderResourceId(resourceId, resourceNumber)
 
-            const actionCenterButton = '[data-testid="action-center-button-' + resourceId + '"]'
-            const editAction = '[data-testid="action-center-' + resourceId + '_Edit"]'
+            this.editAddedResource(resourceId)
+        })
+    }
 
-            cy.get('body').then(($body) => {
-                if ($body.find(actionCenterButton).length) {
-                    cy.get(actionCenterButton).click().wait(250)
+    public static editAddedResource(resourceId: string) {
+        cy.get(this.addedTab)
+            .should('exist')
+            .should('not.have.attr', 'aria-disabled', 'true')
+            .then(($tab) => {
+                if ($tab.attr('aria-selected') !== 'true') {
+                    $tab[0].click()
                 }
-
-                if ($body.find(editAction).length) {
-                    cy.get(editAction).click()
-                    return
-                }
-
-                cy.contains('td', resourceId)
-                    .closest('tr')
-                    .within(() => {
-                        cy.get('td')
-                            .last()
-                            .find('button,[role="button"]')
-                            .first()
-                            .click()
-                    })
             })
+        cy.get(this.addedTab).should('have.attr', 'aria-selected', 'true')
+
+        const actionCenterButton = '[data-testid="action-center-button-' + resourceId + '"]'
+        const editAction = '[data-testid="action-center-' + resourceId + '_Edit"]'
+
+        cy.get('body').then(($body) => {
+            if ($body.find(actionCenterButton).length) {
+                cy.get(actionCenterButton).click()
+            }
+
+            if ($body.find(editAction).length) {
+                cy.get(editAction).click()
+                return
+            }
+
+            cy.contains('td', resourceId)
+                .closest('tr')
+                .within(() => {
+                    cy.get('td')
+                        .last()
+                        .find('button,[role="button"]')
+                        .first()
+                        .click()
+                })
         })
     }
 

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -425,10 +425,12 @@ export class TestCasesPage {
   public static readonly actionCenterClone = '[data-testid="clone-action-btn"]'
   public static readonly actionCenterCopyToMeasure = '[data-testid="copy-action-btn"]'
   public static readonly actionCenterExport = 'form [data-testid="export-action-btn"]'
+  public static readonly actionCenterMakeJsonMatchUi = '[data-testid="make-json-match-ui-action-btn"]'
   public static readonly actionCenterShiftDates = '[data-testid="shift-test-case-dates-action-btn"]'
 
   // copy to modal
   public static readonly copyToSave = '[data-testid="copy-test-cases-continue-button"]'
+  public static readonly makeJsonMatchUiContinueButton = '[data-testid="make-json-match-ui-continue-button"]'
 
   // left nav expand (means we are already collapsed)/collapse (means we are expanded/normal)
   public static readonly leftNavCollapse = '[data-testid="test-case-sidebar-collapse-icon"]'
@@ -891,7 +893,7 @@ export class TestCasesPage {
     const { checkboxSelector, readySelector } = options
     const selector = checkboxSelector ?? readySelector
 
-    cy.get(this.tctExpectedActualSubTab, { timeout: 35000 }).should('exist').scrollIntoView().should('be.visible').click()
+    this.activateTab(this.tctExpectedActualSubTab, 35000)
 
     if (selector) {
       cy.get(selector).should('exist')
@@ -900,6 +902,14 @@ export class TestCasesPage {
     this.normalizeExpectedActualPopulationPanel({
       requirePanel: !selector,
     })
+  }
+
+  public static openTestCasesTab(readySelector?: string): void {
+    this.activateTab(EditMeasurePage.testCasesTab, 30000)
+
+    if (readySelector) {
+      cy.get(readySelector, { timeout: 35000 }).should('exist')
+    }
   }
 
   public static checkExpectedActualCheckbox(
@@ -1030,7 +1040,9 @@ export class TestCasesPage {
     cy.get(selector, { timeout })
       .should('not.have.attr', 'aria-disabled', 'true')
       .then(($tab) => {
-        $tab[0].click()
+        if ($tab.attr('aria-selected') !== 'true') {
+          $tab[0].click()
+        }
       })
   }
 
@@ -1125,11 +1137,7 @@ export class TestCasesPage {
       callstackIntercepted = true
     }).as('callstacks')
 
-    cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-    cy.get(EditMeasurePage.testCasesTab)
-      .invoke('removeAttr', 'target')
-      .click()
-      .should('have.attr', 'aria-selected', 'true')
+    this.activateTab(EditMeasurePage.testCasesTab, 30000)
 
     TestData.readTestCaseId(secondTestCase ? 2 : 0)
       .then((tcId) => {

--- a/cypress/Shared/TestData.ts
+++ b/cypress/Shared/TestData.ts
@@ -867,7 +867,8 @@ export class TestData {
             return this.requestWithAccessToken<VersionedMeasureResponse>({
                 ...options,
                 url: `/api/measures/${measureId}/version?versionType=${versionType}`,
-                method: 'PUT'
+                method: 'PUT',
+                body: {}
             })
         })
     }

--- a/cypress/e2e/WebInterface/Smoke Tests/CreateCompositeMeasure.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/CreateCompositeMeasure.cy.ts
@@ -12,147 +12,147 @@ import { step } from '../../../utils/step'
 const testCase = TestCaseJson.fromCMS1017NumPass
 
 const createCompositeMeasureAndEdit = (): void => {
-  const measureName = 'CompositeTestMeasure' + Date.now()
-  const cqlLibraryName = 'CompositeTestLibrary' + Date.now()
+    const measureName = 'CompositeTestMeasure' + Date.now()
+    const cqlLibraryName = 'CompositeTestLibrary' + Date.now()
 
-  CreateMeasurePage.CreateCompositeMeasure(measureName, cqlLibraryName, SupportedCompositeModels.qiCore6)
-  cy.get(Header.mainMadiePageButton).click()
-  MeasuresPage.actionCenter('edit', 0, { expectCqlEditorTab: false })
-  cy.get(EditMeasurePage.cqlEditorTab).should('not.exist')
+    CreateMeasurePage.CreateCompositeMeasure(measureName, cqlLibraryName, SupportedCompositeModels.qiCore6)
+    cy.get(Header.mainMadiePageButton).click()
+    MeasuresPage.actionCenter('edit', 0, { expectCqlEditorTab: false })
+    cy.get(EditMeasurePage.cqlEditorTab).should('not.exist')
 }
 
 const saveCompositePopulationCriteria = (): void => {
-  cy.get(EditMeasurePage.measureGroupsTab).should('be.visible').click()
-  cy.get('[data-testid="scoring-select"]').should('contain.text', 'Composite')
-  Utilities.setMeasureGroupType()
-  cy.get(CreateMeasurePage.compositeScoringSelect).click()
-  cy.get('[data-testid="opportunity-option"]').click()
+    cy.get(EditMeasurePage.measureGroupsTab).should('be.visible').click()
+    cy.get('[data-testid="scoring-select"]').should('contain.text', 'Composite')
+    Utilities.setMeasureGroupType()
+    cy.get(CreateMeasurePage.compositeScoringSelect).click()
+    cy.get('[data-testid="opportunity-option"]').click()
 
-  cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible').and('be.enabled').click()
-  cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg)
-    .should('exist')
-    .and('contain.text', 'Population details for this group saved successfully.')
+    cy.get(MeasureGroupPage.saveMeasureGroupDetails).should('be.visible').and('be.enabled').click()
+    cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg)
+        .should('exist')
+        .and('contain.text', 'Population details for this group saved successfully.')
 }
 
 const createCompositeMeasureWithPopulationCriteria = (): void => {
-  createCompositeMeasureAndEdit()
-  saveCompositePopulationCriteria()
+    createCompositeMeasureAndEdit()
+    saveCompositePopulationCriteria()
 }
 
 const reopenMeasureForTestCases = (): void => {
-  step('Reopen Measure for Test Cases')
-  cy.get(Header.mainMadiePageButton).click()
-  MeasuresPage.actionCenter('edit', 0, { expectCqlEditorTab: false })
+    step('Reopen Measure for Test Cases')
+    cy.get(Header.mainMadiePageButton).click()
+    MeasuresPage.actionCenter('edit', 0, { expectCqlEditorTab: false })
 }
 
 const createTestCaseAndOpenEditPage = (): void => {
-  TestCasesPage.createTestCase('title', 'series', 'desc')
-  TestCasesPage.clickEditforCreatedTestCase()
+    TestCasesPage.createTestCase('title', 'series', 'desc')
+    TestCasesPage.clickEditforCreatedTestCase()
 }
 
 //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on
 describe.skip('Create Composite Measure', () => {
-  beforeEach('Login', () => {
-    OktaLogin.Login()
+    beforeEach('Login', () => {
+        OktaLogin.Login()
 
-    Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 11500)
-  })
+        Utilities.waitForElementVisible(MeasuresPage.allMeasuresTab, 11500)
+    })
 
-  // afterEach('Cleanup and Logout', () => {
+    // afterEach('Cleanup and Logout', () => {
 
-  //     Utilities.deleteMeasure()
-  // })
+    //     Utilities.deleteMeasure()
+    // })
 
-  it('Create QI Core Composite Measure and add Population Criteria', () => {
-    createCompositeMeasureWithPopulationCriteria()
-  })
-  it('Validate Composite Test Case Tabs', () => {
-    createCompositeMeasureAndEdit()
-    createTestCaseAndOpenEditPage()
+    it('Create QI Core Composite Measure and add Population Criteria', () => {
+        createCompositeMeasureWithPopulationCriteria()
+    })
+    it('Validate Composite Test Case Tabs', () => {
+        createCompositeMeasureAndEdit()
+        createTestCaseAndOpenEditPage()
 
-    cy.get(TestCasesPage.compositeAvailableTab)
-      .should('be.visible')
-      .and('have.attr', 'aria-selected', 'true')
-      .and('contain.text', 'Available')
-    cy.get(TestCasesPage.compositeAddedTab).should('be.visible').and('contain.text', 'Added')
-    cy.get(TestCasesPage.compositeJsonTab).should('be.visible').and('contain.text', 'JSON')
-  })
+        cy.get(TestCasesPage.compositeAvailableTab)
+            .should('be.visible')
+            .and('have.attr', 'aria-selected', 'true')
+            .and('contain.text', 'Available')
+        cy.get(TestCasesPage.compositeAddedTab).should('be.visible').and('contain.text', 'Added')
+        cy.get(TestCasesPage.compositeJsonTab).should('be.visible').and('contain.text', 'JSON')
+    })
 
-  it('Validate Composite Measure Insert Existing Test Case Button Functionality', () => {
-    createCompositeMeasureAndEdit()
-    createTestCaseAndOpenEditPage()
+    it('Validate Composite Measure Insert Existing Test Case Button Functionality', () => {
+        createCompositeMeasureAndEdit()
+        createTestCaseAndOpenEditPage()
 
-    cy.get(TestCasesPage.compositeInsertTestCaseBtn).should('be.visible')
-    cy.get(TestCasesPage.compositeInsertTestCaseBtn).click()
-    cy.get(TestCasesPage.compositeBackToAllProfilesBtn).should('be.visible')
-    cy.get(TestCasesPage.compositeBackToAllProfilesBtn).click()
-  })
+        cy.get(TestCasesPage.compositeInsertTestCaseBtn).should('be.visible')
+        cy.get(TestCasesPage.compositeInsertTestCaseBtn).click()
+        cy.get(TestCasesPage.compositeBackToAllProfilesBtn).should('be.visible')
+        cy.get(TestCasesPage.compositeBackToAllProfilesBtn).click()
+    })
 
-  //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on and add in the correct functionality to check the help text content
-  it.skip('Validate "How it Works" help text within inserting profiles to Test Case Measures', () => {
-    createCompositeMeasureAndEdit()
-    createTestCaseAndOpenEditPage()
-    cy.get(TestCasesPage.compositeInsertTestCaseBtn).should('be.visible')
-    cy.get(TestCasesPage.compositeInsertTestCaseBtn).click()
-    cy.get(TestCasesPage.compositeTCHowItWorksLink).should('be.visible').click()
-    cy.get(TestCasesPage.compositeTCHowItWorksContent).should('be.visible')
-    cy.get(TestCasesPage.compositeTCHowItWorksContent)
-      .invoke('text')
-      .then((text) => {
-        const normalizedText = text.replace(/\s+/g, ' ').trim()
-        expect(normalizedText).to.eq(
-          'How it Works ' +
-            'This workflow allows you to insert all profiles from a selected test case into the current test case. ' +
-            'To complete this process: ' +
-            'Select the measure that contains the test case you want to insert. ' +
-            'Select the test case you want to insert profiles from. ' +
-            'Select Insert.',
-        )
-      })
-    cy.get(TestCasesPage.compositeTCHowItWorksLinkCloseBtn).should('be.visible').click()
-    cy.get(TestCasesPage.compositeTCHowItWorksContent).should('be.visible')
-  })
+    //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on and add in the correct functionality to check the help text content
+    it.skip('Validate "How it Works" help text within inserting profiles to Test Case Measures', () => {
+        createCompositeMeasureAndEdit()
+        createTestCaseAndOpenEditPage()
+        cy.get(TestCasesPage.compositeInsertTestCaseBtn).should('be.visible')
+        cy.get(TestCasesPage.compositeInsertTestCaseBtn).click()
+        cy.get(TestCasesPage.compositeTCHowItWorksLink).should('be.visible').click()
+        cy.get(TestCasesPage.compositeTCHowItWorksContent).should('be.visible')
+        cy.get(TestCasesPage.compositeTCHowItWorksContent)
+            .invoke('text')
+            .then((text) => {
+                const normalizedText = text.replace(/\s+/g, ' ').trim()
+                expect(normalizedText).to.eq(
+                    'How it Works ' +
+                        'This workflow allows you to insert all profiles from a selected test case into the current test case. ' +
+                        'To complete this process: ' +
+                        'Select the measure that contains the test case you want to insert. ' +
+                        'Select the test case you want to insert profiles from. ' +
+                        'Select Insert.'
+                )
+            })
+        cy.get(TestCasesPage.compositeTCHowItWorksLinkCloseBtn).should('be.visible').click()
+        cy.get(TestCasesPage.compositeTCHowItWorksContent).should('be.visible')
+    })
 
-  it('Create Composite Measure and Edit Test Case through Added Builder Tab', () => {
-    createCompositeMeasureWithPopulationCriteria()
-    reopenMeasureForTestCases()
-    createTestCaseAndOpenEditPage()
+    it('Create Composite Measure and Edit Test Case through Added Builder Tab', () => {
+        createCompositeMeasureWithPopulationCriteria()
+        reopenMeasureForTestCases()
+        createTestCaseAndOpenEditPage()
 
-    cy.get(TestCasesPage.compositeAddedTab).should('be.visible').click()
-    TestCasesPage.grabAddedId(1)
-    //Validate Edit and Json tab is editable and available respectively
-    TestCasesPage.compositeTestCaseAddedAction('edit')
-  })
-  it('Create Composite Measure and Edit Test Case through Added Json Tab', () => {
-    createCompositeMeasureWithPopulationCriteria()
-    reopenMeasureForTestCases()
-    createTestCaseAndOpenEditPage()
+        cy.get(TestCasesPage.compositeAddedTab).should('be.visible').click()
+        TestCasesPage.grabAddedId(1)
+        //Validate Edit and Json tab is editable and available respectively
+        TestCasesPage.compositeTestCaseAddedAction('edit')
+    })
+    it('Create Composite Measure and Edit Test Case through Added Json Tab', () => {
+        createCompositeMeasureWithPopulationCriteria()
+        reopenMeasureForTestCases()
+        createTestCaseAndOpenEditPage()
 
-    TestCasesPage.editTestCaseJson(testCase, true)
-    cy.get(TestCasesPage.editTestCaseSaveButton).click()
-    Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
-    //Validate Edit and Json tab is editable and available respectively
-  })
-  //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on and add in the correct functionality to check that a read only viewer cannot edit through the builder or json tab
-  it.skip('Create Composite Measure and Verify Read Only Viewer Cannot Edit Test Case through Added Json Tab', () => {
-    createCompositeMeasureWithPopulationCriteria()
-    reopenMeasureForTestCases()
-    createTestCaseAndOpenEditPage()
+        TestCasesPage.editTestCaseJson(testCase, true)
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
+        //Validate Edit and Json tab is editable and available respectively
+    })
+    //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on and add in the correct functionality to check that a read only viewer cannot edit through the builder or json tab
+    it.skip('Create Composite Measure and Verify Read Only Viewer Cannot Edit Test Case through Added Json Tab', () => {
+        createCompositeMeasureWithPopulationCriteria()
+        reopenMeasureForTestCases()
+        createTestCaseAndOpenEditPage()
 
-    TestCasesPage.editTestCaseJson(testCase, true)
-    cy.get(TestCasesPage.editTestCaseSaveButton).click()
-    Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
-    //Validate Edit and Json tab is editable and available respectively
-  })
-  //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on and add in the correct functionality to check that a read only viewer cannot edit through the builder or json tab
-  it.skip('Create Composite Measure and Verify Read Only Viewer Cannot Edit Test Case through Added Builder Tab', () => {
-    createCompositeMeasureWithPopulationCriteria()
-    reopenMeasureForTestCases()
-    createTestCaseAndOpenEditPage()
+        TestCasesPage.editTestCaseJson(testCase, true)
+        cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 9500)
+        //Validate Edit and Json tab is editable and available respectively
+    })
+    //Skipping until Feature flag 'QICoreCompositeMeasure' is turned on and add in the correct functionality to check that a read only viewer cannot edit through the builder or json tab
+    it.skip('Create Composite Measure and Verify Read Only Viewer Cannot Edit Test Case through Added Builder Tab', () => {
+        createCompositeMeasureWithPopulationCriteria()
+        reopenMeasureForTestCases()
+        createTestCaseAndOpenEditPage()
 
-    cy.get(TestCasesPage.compositeAddedTab).should('be.visible').click()
-    TestCasesPage.grabAddedId(1)
-    //Validate Edit and Json tab is editable and available respectively
-    TestCasesPage.compositeTestCaseAddedAction('edit')
-  })
+        cy.get(TestCasesPage.compositeAddedTab).should('be.visible').click()
+        TestCasesPage.grabAddedId(1)
+        //Validate Edit and Json tab is editable and available respectively
+        TestCasesPage.compositeTestCaseAddedAction('edit')
+    })
 })

--- a/cypress/e2e/WebInterface/Test Cases/Composite Test Case/CompositeTestCaseActionCenter.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/Composite Test Case/CompositeTestCaseActionCenter.cy.ts
@@ -1,0 +1,223 @@
+import { CreateMeasurePage, SupportedCompositeModels, SupportedModels } from '../../../../Shared/CreateMeasurePage'
+import { CQLEditorPage } from '../../../../Shared/CQLEditorPage'
+import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
+import { Header } from '../../../../Shared/Header'
+import { MeasuresPage } from '../../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../../Shared/OktaLogin'
+import { TestCasesPage } from '../../../../Shared/TestCasesPage'
+import { TestCaseJson } from '../../../../Shared/TestCaseJson'
+import { TestData } from '../../../../Shared/TestData'
+import { MadieObject, Utilities } from '../../../../Shared/Utilities'
+import { step } from '../../../../utils/step'
+
+type CompositeActionCenterSetup = {
+    measureName: string
+    cqlLibraryName: string
+    targetMeasureName: string
+    targetCqlLibraryName: string
+}
+
+const compositePrimaryTestCase = {
+    title: 'Composite locked-in action test case',
+    group: 'PASS',
+    description: 'composite action-center coverage'
+}
+
+const compositeSecondaryTestCase = {
+    title: 'Composite companion action test case',
+    group: 'PASS',
+    description: 'second composite action-center row'
+}
+
+const buildCompositeActionCenterSetup = (): CompositeActionCenterSetup => {
+    const timestamp = Date.now()
+
+    return {
+        measureName: `CompositeActionCenter${timestamp}`,
+        cqlLibraryName: `CompositeActionCenterLib${timestamp}`,
+        targetMeasureName: `CompositeCopyTarget${timestamp}`,
+        targetCqlLibraryName: `CompositeCopyTargetLib${timestamp}`
+    }
+}
+
+const createCopyTargetMeasure = (setup: CompositeActionCenterSetup): void => {
+    CreateMeasurePage.CreateMeasureAPI(
+        setup.targetMeasureName,
+        setup.targetCqlLibraryName,
+        SupportedModels.qiCore6,
+        undefined,
+        1
+    )
+}
+
+const createCompositeMeasureWithSeedData = (setup: CompositeActionCenterSetup): void => {
+    CreateMeasurePage.CreateCompositeMeasureAPI(
+        setup.measureName,
+        setup.cqlLibraryName,
+        SupportedCompositeModels.qiCore6
+    )
+
+    TestData.requestMeasureGroup('PUT', {
+        scoring: 'Composite',
+        populations: [],
+        measureGroupTypes: ['Process'],
+        populationBasis: 'Boolean',
+        compositeScoring: 'Opportunity'
+    }).then((response) => {
+        expect(response.status).to.eql(200)
+        expect(response.body.scoring).to.eql('Composite')
+        expect(response.body.compositeScoring).to.eql('Opportunity')
+    })
+
+    TestCasesPage.CreateTestCaseAPI(
+        compositePrimaryTestCase.title,
+        compositePrimaryTestCase.group,
+        compositePrimaryTestCase.description,
+        TestCaseJson.TestCaseJson_Valid
+    )
+
+    TestCasesPage.CreateTestCaseAPI(
+        compositeSecondaryTestCase.title,
+        compositeSecondaryTestCase.group,
+        compositeSecondaryTestCase.description,
+        TestCaseJson.TestCaseJson_Valid,
+        false,
+        true
+    )
+}
+
+const openCompositeMeasureTestCases = (): void => {
+    cy.reload()
+    MeasuresPage.actionCenter('edit', 0, { expectCqlEditorTab: false })
+    cy.get(EditMeasurePage.testCasesTab).should('be.visible').click()
+    cy.get(EditMeasurePage.testCasesTab).should('have.attr', 'aria-selected', 'true')
+    cy.url().should('include', '/edit/test-cases')
+}
+
+const versionCompositeMeasure = (): void => {
+    step('Version composite measure through the Measures action center')
+    cy.get(Header.mainMadiePageButton).click()
+    MeasuresPage.actionCenter('version')
+    cy.get(MeasuresPage.measureVersionTypeDropdown).should('be.visible').click()
+    cy.get(MeasuresPage.measureVersionMajor).should('be.visible').click()
+    cy.get(MeasuresPage.confirmMeasureVersionNumber).should('be.visible').type('1.0.000')
+    cy.get(MeasuresPage.measureVersionContinueBtn).should('be.enabled').click()
+    cy.get(MeasuresPage.versionToastSuccessMsg)
+        .should('be.visible')
+        .and('contain.text', 'New version of measure is Successfully created')
+    MeasuresPage.actionCenter('edit', 0, { expectCqlEditorTab: false })
+    cy.get(EditMeasurePage.testCasesTab).should('be.visible').click()
+}
+
+const openFirstTestCaseJsonAndAssertNames = (expectedFamily: string, expectedGiven: string): void => {
+    TestCasesPage.clickEditforCreatedTestCase()
+    cy.get(TestCasesPage.jsonTab).should('be.visible').click()
+    cy.get(TestCasesPage.tcSearchIcone).click()
+    cy.get('.ace_search_form > .ace_search_field').type('family').type('{enter}')
+    cy.get(TestCasesPage.testCaseJson).should('contain.text', `"family": "${expectedFamily}"`)
+    cy.get(TestCasesPage.testCaseJson)
+        .invoke('text')
+        .then((text: string) => {
+            const jsonText = text.replace(/\s+/g, ' ').trim()
+            expect(jsonText).to.contain(`"given": [ "${expectedGiven}" ]`)
+        })
+}
+
+// Enable these specs once MAT-10118 is available by default.
+describe.skip('[MAT-10118] Composite test case action center', () => {
+    let setup: CompositeActionCenterSetup
+
+    beforeEach('Create composite setup', () => {
+        setup = buildCompositeActionCenterSetup()
+        OktaLogin.SessionLogin()
+        createCompositeMeasureWithSeedData(setup)
+        createCopyTargetMeasure(setup)
+        openCompositeMeasureTestCases()
+    })
+
+    afterEach('Clean up composite setup', () => {
+        Utilities.releaseAllLocksForCleanup(MadieObject.Measure)
+        Utilities.deleteMeasure(setup.measureName, setup.cqlLibraryName)
+        Utilities.deleteMeasure(setup.targetMeasureName, setup.targetCqlLibraryName, false, false, 1)
+    })
+
+    it('shows the composite draft action center controls', () => {
+        cy.get(TestCasesPage.importTestCasesBtn).should('be.visible')
+        cy.get(TestCasesPage.actionCenterDelete).should('be.disabled')
+        cy.get(TestCasesPage.actionCenterClone).should('be.disabled')
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.disabled')
+        cy.get(TestCasesPage.actionCenterMakeJsonMatchUi).should('be.disabled')
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.disabled')
+
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterDelete).should('be.enabled')
+        cy.get(TestCasesPage.actionCenterClone).should('be.enabled')
+        cy.get(TestCasesPage.actionCenterShiftDates).should('be.enabled')
+        cy.get(TestCasesPage.actionCenterMakeJsonMatchUi).should('be.enabled')
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled')
+    })
+
+    it('deletes a single composite test case', () => {
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterDelete).should('be.enabled').click()
+
+        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
+            'contain.text',
+            `You are choosing to delete the following Test Case(s)!${compositeSecondaryTestCase.group} - ${compositeSecondaryTestCase.title}`
+        )
+        cy.get(CQLEditorPage.deleteContinueButton).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('not.contain', compositeSecondaryTestCase.title)
+    })
+
+    it('deletes multiple composite test cases', () => {
+        TestCasesPage.checkTestCase(1)
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterDelete).should('be.enabled').click()
+
+        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
+            'contain.text',
+            `${compositePrimaryTestCase.group} - ${compositePrimaryTestCase.title}`
+        )
+        cy.get(CQLEditorPage.confirmationMsgRemoveDelete).should(
+            'contain.text',
+            `${compositeSecondaryTestCase.group} - ${compositeSecondaryTestCase.title}`
+        )
+        cy.get(CQLEditorPage.deleteContinueButton).click()
+
+        cy.get(TestCasesPage.testCaseListTable).should('not.contain', compositePrimaryTestCase.title)
+        cy.get(TestCasesPage.testCaseListTable).should('not.contain', compositeSecondaryTestCase.title)
+    })
+
+    it('makes composite test case JSON match the UI values', () => {
+        openFirstTestCaseJsonAndAssertNames('Health', 'Lizzy')
+
+        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.get('[data-testid="test-case-title-0_select"]').click()
+        cy.get(TestCasesPage.actionCenterMakeJsonMatchUi).click()
+        cy.get('.MuiDialog-paper > .MuiBox-root').should('contain.text', 'Are you sure?')
+        cy.get('.MuiDialogContent-root').should(
+            'have.text',
+            'For each of the selected 1 test cases, you are about to:Set all "family" fields in the JSON to the group value that was entered in the UISet all "given" fields in the JSON to the title value that was entered in the UIAre you sure you want to proceed?'
+        )
+        cy.get(TestCasesPage.makeJsonMatchUiContinueButton).click()
+        cy.get('.toast').should('contain.text', 'All family and given fields have been set for the selected test cases')
+        Utilities.waitForElementToNotExist('.toast', 60000)
+
+        openFirstTestCaseJsonAndAssertNames(compositePrimaryTestCase.group, compositePrimaryTestCase.title)
+    })
+
+    it('shows matching QI-Core 6 measures in the composite copy-to modal', () => {
+        TestCasesPage.checkTestCase(2)
+        cy.get(TestCasesPage.actionCenterCopyToMeasure).should('be.enabled').click()
+
+        cy.contains(setup.targetMeasureName).should('be.visible')
+        cy.get(TestCasesPage.copyToSave).should('be.disabled')
+    })
+
+    it('disables delete for inherited composite test cases after versioning', () => {
+        versionCompositeMeasure()
+        TestCasesPage.checkTestCase(1)
+        cy.get(TestCasesPage.actionCenterDelete).should('be.disabled')
+    })
+})

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -9,7 +9,6 @@ import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
 import { MeasureCQL } from '../../../../../Shared/MeasureCQL'
 import { QDMElements } from '../../../../../Shared/QDMElements'
 import { umlsLoginForm } from '../../../../../Shared/umlsLoginForm'
-import { Header } from '../../../../../Shared/Header'
 
 let measureName = 'CVListQDMPositiveEncounterPerformedWithMO' + Date.now()
 let CqlLibraryName = 'CVListQDMPositiveEncounterPerformedWithMO' + Date.now()
@@ -33,22 +32,17 @@ describe('Measure Creation: Patient Based: CV measure with multiple groups with 
 
         //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
+        TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
-        TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-
-        OktaLogin.Login()
-
         //adding supplemental data
-        MeasuresPage.actionCenter('edit')
         // add SDE to test case coverage
         cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         MeasureGroupPage.includeSdeData()
-        cy.get(Header.mainMadiePageButton).click()
     })
 
     after('Logout and Clean up', () => {
@@ -56,11 +50,6 @@ describe('Measure Creation: Patient Based: CV measure with multiple groups with 
     })
 
     it('Test Case execution with patient based groups with MOs', () => {
-        //Click on Edit Button
-        MeasuresPage.actionCenter('edit')
-
-        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
-
         //Group Creation
         //Click on Measure Group tab
         Utilities.waitForElementVisible(EditMeasurePage.measureGroupsTab, 30000)
@@ -206,22 +195,17 @@ describe('Measure Creation: Non-patient based: CV measure with multiple groups w
 
         //Create New Measure
         CreateMeasurePage.CreateQDMMeasureWithBaseConfigurationFieldsAPI(measureData)
+        TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
         OktaLogin.Login()
         MeasuresPage.actionCenter('edit')
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
-        TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
-
-        OktaLogin.Login()
-
         //adding supplemental data
-        MeasuresPage.actionCenter('edit')
         // add SDE to test case coverage
         cy.get(EditMeasurePage.measureGroupsTab).should('be.visible')
         cy.get(EditMeasurePage.measureGroupsTab).click()
 
         MeasureGroupPage.includeSdeData()
-        cy.get(Header.mainMadiePageButton).click()
     })
 
     after('Logout and Clean up', () => {
@@ -229,11 +213,6 @@ describe('Measure Creation: Non-patient based: CV measure with multiple groups w
     })
 
     it('Test Case execution with non-patient based groups with MOs', () => {
-        //Click on Edit Button
-        MeasuresPage.actionCenter('edit')
-
-        CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
-
         //Group Creation
         //Click on Measure Group tab
         Utilities.waitForElementVisible(EditMeasurePage.measureGroupsTab, 30000)

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -46,11 +46,13 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(MeasureGroupPage.supplementalDataDefinitionDescriptionTextBox).type('This is a description.')
 
         //Save Supplemental data
-        cy.get('[data-testid="measure-Supplemental Data-save"]').click({ force: true })
+        cy.get(MeasureGroupPage.saveSupplementalDataElements).should('be.visible').and('be.enabled').click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
             'Measure Supplemental Data have been Saved Successfully'
         )
+        Utilities.waitForElementToNotExist(EditMeasurePage.successMessage, 50000)
+        Utilities.waitForElementDisabled(MeasureGroupPage.saveSupplementalDataElements, 60000)
     })
 
     afterEach('Logout and Clean up Measures', () => {
@@ -93,8 +95,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 60000)
 
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.executeTestCaseButton)
         cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
         cy.get(TestCasesPage.executeTestCaseButton).click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Pass')
@@ -228,15 +229,9 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
 
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 30000)
 
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
         //Click on Execute Test Case button on Edit Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
-        cy.get(TestCasesPage.executeTestCaseButton).should('exist')
-        cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
-        cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
-        cy.get(TestCasesPage.executeTestCaseButton).focus()
-        cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
-        cy.get(TestCasesPage.executeTestCaseButton).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.executeTestCaseButton)
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.visible').and('be.enabled').click()
         cy.get(TestCasesPage.testCaseStatus).eq(0).should('contain.text', 'Pass')
         cy.get(TestCasesPage.testCaseStatus).eq(1).should('contain.text', 'Fail')
 
@@ -306,15 +301,8 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 30000)
 
         //Click on Execute Test Case button on Edit Test Case page
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
-        cy.get(TestCasesPage.executeTestCaseButton).should('exist')
-        cy.get(TestCasesPage.executeTestCaseButton).should('be.enabled')
-        cy.get(TestCasesPage.executeTestCaseButton).should('be.visible')
-        cy.get(TestCasesPage.executeTestCaseButton).focus()
-        cy.get(TestCasesPage.executeTestCaseButton).invoke('click')
-        cy.get(TestCasesPage.executeTestCaseButton).click()
-        cy.get(TestCasesPage.executeTestCaseButton).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.executeTestCaseButton)
+        cy.get(TestCasesPage.executeTestCaseButton).should('be.visible').and('be.enabled').click()
         cy.get(TestCasesPage.testCaseStatus).should('contain.text', 'Fail')
     })
 })
@@ -354,8 +342,9 @@ describe('Run / Execute QDM Test Case button validations', () => {
         Utilities.waitForElementDisabled(EditMeasurePage.cqlEditorSaveButton, 60000)
         cy.get(EditMeasurePage.cqlEditorExpandCollapseBtn).click()
 
-        cy.get(EditMeasurePage.testCasesTab).should('be.visible')
-        cy.get(EditMeasurePage.testCasesTab).click()
+        cy.intercept('GET', /\/api\/measures\/[^/]+\/test-cases(?:\?.*)?$/).as('testCaseList')
+        TestCasesPage.openTestCasesTab()
+        cy.wait('@testCaseList').its('response.statusCode').should('eq', 200)
         TestCasesPage.clickEditforCreatedTestCase()
 
         Utilities.waitForElementVisible(TestCasesPage.testCaseSyntaxError, 105000)

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Builder/HierarchicalValueSet.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Builder/HierarchicalValueSet.cy.ts
@@ -1,0 +1,157 @@
+import { CreateMeasurePage, SupportedModels } from '../../../../../Shared/CreateMeasurePage'
+import {
+    MeasureGroupPage,
+    MeasureGroups,
+    MeasureScoring,
+    MeasureType,
+    PopulationBasis
+} from '../../../../../Shared/MeasureGroupPage'
+import { MeasuresPage } from '../../../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../../../Shared/OktaLogin'
+import { TestCaseBuilder } from '../../../../../Shared/TestCaseBuilder'
+import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
+import { Utilities } from '../../../../../Shared/Utilities'
+
+const timestamp = Date.now()
+const measureName = `HierarchicalValueSet${timestamp}`
+const cqlLibraryName = `HierarchicalValueSetLib${timestamp}`
+const occupationObservationId = 'occupation-observation'
+
+const measureCql = `library ${cqlLibraryName} version '0.0.000'
+
+using QICore version '6.0.0'
+
+include FHIRHelpers version '4.4.000' called FHIRHelpers
+
+parameter "Measurement Period" Interval<DateTime>
+
+context Patient
+
+define "Initial Population":
+  true
+
+define "Denominator":
+  "Initial Population"
+
+define "Denominator Exclusions":
+  not "Initial Population"
+
+define "Numerator":
+  "Initial Population"
+`
+
+const populations: MeasureGroups = {
+    initialPopulation: 'Initial Population',
+    denominator: 'Denominator',
+    denomExclusion: 'Denominator Exclusions',
+    numerator: 'Numerator'
+}
+
+const testCaseJson = JSON.stringify({
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+        {
+            fullUrl: 'https://madie.cms.gov/Patient/occupation-patient',
+            resource: {
+                resourceType: 'Patient',
+                id: 'occupation-patient',
+                meta: {
+                    profile: ['http://hl7.org/fhir/us/qicore/StructureDefinition/qicore-patient']
+                },
+                gender: 'female'
+            }
+        },
+        {
+            fullUrl: `https://madie.cms.gov/Observation/${occupationObservationId}`,
+            resource: {
+                resourceType: 'Observation',
+                id: occupationObservationId,
+                meta: {
+                    profile: [
+                        'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-occupation'
+                    ]
+                },
+                code: {
+                    coding: [
+                        {
+                            system: 'http://loinc.org',
+                            code: '11341-5',
+                            display: 'History of Occupation'
+                        }
+                    ]
+                },
+                status: 'corrected',
+                subject: {
+                    reference: 'Patient/occupation-patient'
+                },
+                valueCodeableConcept: {
+                    coding: [
+                        {
+                            system: 'http://www.cms.gov/Medicare/Coding/HCPCSReleaseCodeSets',
+                            code: 'G0438',
+                            display: 'Annual wellness visit'
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+})
+
+const expectedStatusOptions = [
+    'Amended',
+    'Cancelled',
+    'Corrected',
+    'Entered in Error',
+    'Final',
+    'Preliminary',
+    'Registered',
+    'Unknown'
+]
+
+describe('Test Case Builder hierarchical value sets', () => {
+    beforeEach('Create measure and occupation test case', () => {
+        CreateMeasurePage.CreateMeasureAPI(measureName, cqlLibraryName, SupportedModels.qiCore6, {
+            measureCql
+        })
+        MeasureGroupPage.CreateMeasureGroupAPI(
+            MeasureType.process,
+            PopulationBasis.boolean,
+            MeasureScoring.Proportion,
+            populations
+        )
+        TestCasesPage.CreateTestCaseAPI(
+            'Observation occupation status',
+            'Hierarchical value set',
+            'Displays nested observation status concepts',
+            testCaseJson
+        )
+
+        OktaLogin.Login()
+        MeasuresPage.actionCenter('edit')
+    })
+
+    afterEach('Clean up measure', () => {
+        Utilities.deleteMeasure()
+    })
+
+    it('displays every hierarchical Observation Status option', () => {
+        TestCasesPage.clickEditforCreatedTestCase()
+
+        TestCaseBuilder.editAddedResource(occupationObservationId)
+
+        TestCaseBuilder.selectLeftMenu(' *Status')
+
+        cy.get(TestCaseBuilder.observationStatus).should('be.visible').click()
+
+        cy.get(TestCaseBuilder.dropdownListbox)
+            .should('be.visible')
+            .within(() => {
+                expectedStatusOptions.forEach((status) => {
+                    cy.contains(TestCaseBuilder.dropdownOption, status).should('be.visible')
+                })
+                cy.get(TestCaseBuilder.dropdownOption).should('have.length', expectedStatusOptions.length)
+            })
+    })
+})

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/TestCaseImportValidations.cy.ts
@@ -91,13 +91,8 @@ describe('Test Case Import: functionality tests', () => {
         TestCasesPage.clickEditforCreatedTestCase(true)
 
         //edit second test case so that it will fail
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')
@@ -215,8 +210,9 @@ describe('Test Case Import validations for versioned Measures', () => {
         Utilities.waitForElementVisible(CQLEditorPage.successfulCQLSaveNoErrors, 40700)
         cy.get(CQLEditorPage.successfulCQLSaveNoErrors).should('be.visible')
 
-        //navigate to the main MADiE / measure list page
-        cy.get(Header.mainMadiePageButton).click()
+        // Reset the SPA at the measure-list boundary before versioning.
+        cy.visit('/measures')
+        cy.get(MeasuresPage.measureListTitles, { timeout: 60000 }).should('be.visible')
 
         //Click on Version Measure
         MeasuresPage.actionCenter('version')
@@ -238,10 +234,10 @@ describe('Test Case Import validations for versioned Measures', () => {
     it('Measure is in VERSIONED status: user is owner: import button is available', () => {
 
         //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
+        MeasuresPage.actionCenter('edit', undefined, { expectCqlEditorTab: false })
 
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.paginationLimitSelect)
 
         Utilities.waitForElementVisible(TestCasesPage.paginationLimitSelect, 16500)
 
@@ -263,10 +259,10 @@ describe('Test Case Import validations for versioned Measures', () => {
         cy.get(MeasuresPage.allMeasuresTab).click()
 
         //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
+        MeasuresPage.actionCenter('edit', undefined, { expectCqlEditorTab: false })
 
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.paginationLimitSelect)
 
         Utilities.waitForElementVisible(TestCasesPage.paginationLimitSelect, 16500)
 
@@ -304,14 +300,8 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
 
     it('Importing: not a .zip file', () => {
 
-        //navigate to the main MADiE / measure list page
-        cy.get(Header.mainMadiePageButton).click()
-
-        //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
-
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.importTestCasesBtn)
 
         //click on the Import Test Cases button
         cy.get(TestCasesPage.importTestCasesBtn).click()
@@ -329,14 +319,8 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
 
     it('Importing: .zip\'s test case folder does not contain a json file', () => {
 
-        //navigate to the main MADiE / measure list page
-        cy.get(Header.mainMadiePageButton).click()
-
-        //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
-
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.importTestCasesBtn)
 
         //click on the Import Test Cases button
         cy.get(TestCasesPage.importTestCasesBtn).click()
@@ -357,14 +341,8 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
 
     it('Importing: .zip\'s test case folder contains multiple json files', () => {
 
-        //navigate to the main MADiE / measure list page
-        cy.get(Header.mainMadiePageButton).click()
-
-        //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
-
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.importTestCasesBtn)
 
         //click on the Import Test Cases button
         cy.get(TestCasesPage.importTestCasesBtn).click()
@@ -385,14 +363,8 @@ describe('Test Case Import: File structure Not Accurate validation tests', () =>
 
     it('Importing: .zip\'s test case folder contains malformed json file', () => {
 
-        //navigate to the main MADiE / measure list page
-        cy.get(Header.mainMadiePageButton).click()
-
-        //Click on Edit Measure
-        MeasuresPage.actionCenter('edit')
-
         //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        TestCasesPage.openTestCasesTab(TestCasesPage.importTestCasesBtn)
 
         //click on the Import Test Cases button
         cy.get(TestCasesPage.importTestCasesBtn).click()
@@ -464,9 +436,14 @@ describe('Test Case Import: New Test cases on measure validations: uniqueness te
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 35000)
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Population details for this group updated successfully.')
+        Utilities.waitForElementToNotExist(EditMeasurePage.successMessage, 60000)
+        Utilities.waitForElementDisabled(MeasureGroupPage.saveMeasureGroupDetails, 60000)
 
-        //Navigate to Test Case page
-        cy.get(EditMeasurePage.testCasesTab).click()
+        // Reset the edit shell before navigating away from Population Criteria.
+        cy.visit('/measures')
+        cy.get(MeasuresPage.measureListTitles, { timeout: 60000 }).should('be.visible')
+        MeasuresPage.actionCenter('edit', 2)
+        TestCasesPage.openTestCasesTab('input[type="checkbox"]')
 
         // export test cases - select all
         cy.get('input[type="checkbox"]').first().check() 

--- a/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/TestCaseListPageSorting.cy.ts
@@ -65,13 +65,8 @@ describe('Sort by each of the test case list page\'s columns', () => {
         //edit test case to cause it to fail
         TestCasesPage.clickEditforCreatedTestCase()
 
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-        cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-        TestCasesPage.openExpectedActualTab()
-
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')

--- a/docs/ai/debugging.md
+++ b/docs/ai/debugging.md
@@ -26,6 +26,11 @@ Find the cause before changing code.
 
 ## Timeout Debugging
 
+Parallel Cypress workers are terminated when they produce no output for 20 minutes. Use
+`CYPRESS_WORKER_INACTIVITY_TIMEOUT_SECONDS` to tune this threshold for a run, or set it to `0` to
+disable inactivity detection. The worker wrapper captures `scripts/ci-diagnostics.sh` output before
+terminating the process group so the console log retains the stuck process and latest-result state.
+
 For timeouts, check:
 
 1. Is the selector correct?
@@ -70,6 +75,22 @@ Prefer this order:
 3. stable text
 4. stable container + child selector
 5. class selectors only as a last resort
+
+## Repeated Login And SPA State Failures
+
+When a test works during slow manual execution but fails after repeated login, edit, or navigation commands:
+
+1. Check whether API setup can complete before the first UI login.
+2. Compare the flow with a nearby passing spec that uses one login and one continuous edit session.
+3. Inspect both the URL and the visibly selected tab. A route such as `/edit/cql-editor` does not prove the CQL editor rendered if stale SPA state still displays another tab.
+4. Treat repeated login, return-to-list, and edit cycles as a likely state-transition race before changing selectors or adding waits.
+5. Synchronize on durable UI state, such as the destination list or a save button returning to disabled, rather than adding a fixed delay.
+
+This pattern was confirmed in `QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts`: the stable test-environment flow created the measure and test case through APIs, logged in once, added supplemental data, and continued in the same edit session.
+
+If native tab activation updates the URL but the previously selected tab remains rendered, the edit shell is already desynchronized. First verify the preceding save has settled. If the mismatch persists, reset at the measure-list boundary, wait for the list to render, reopen the correct fixture index, and then activate the destination tab. A same-route reload may rehydrate the stale tab state and is not sufficient evidence of recovery.
+
+For versioned measures, distinguish View mode from Edit mode when using measure action helpers. Do not wait for an edit-only CQL tab when the action opens a versioned measure for viewing; open the Test Cases tab and synchronize on its destination content instead.
 
 ## API/Data Debugging
 

--- a/docs/quality/cypress-automation-guidelines.md
+++ b/docs/quality/cypress-automation-guidelines.md
@@ -56,6 +56,10 @@ These helper paths are already established and should be reused before adding ne
 - When a reusable test-case editor control needs a `data-testid` selector, add it to `TestCasesPage` instead of leaving the literal selector in a spec. Inline `data-testid` strings are acceptable for one-off assertions, but reusable Expected/Actual, stratification, action-center, and editor controls should stay behind the page object so selector churn is localized.
 - When a reusable measure, library, or test-case UI control needs a `data-testid` selector, add it to the relevant page object instead of leaving the literal selector in a spec. Inline `data-testid` strings are acceptable for one-off assertions, but reusable list-row action buttons, locked-state controls, and shared navigation targets should stay behind the page object so selector churn is localized.
 - During temporary UI debug instrumentation or high-value flow narration, prefer the shared `step(...)` helper over ad hoc `cy.log(...)` calls so runner output stays consistent across specs and shared helpers.
+- When a UI scenario needs API-created measure data or test cases, complete that API setup before the UI login when the existing helpers support it. Prefer one login and one continuous edit session over repeated login, edit, return-to-list, and edit cycles; repeated session and SPA navigation transitions can leave the route and rendered tab content out of sync.
+- After saving controlled UI state through a shared helper, wait for a meaningful settled condition before continuing. A success toast alone may not prove that React state is ready for navigation; when available, also verify the save control returns to its disabled state or wait for the save request and resulting UI readiness.
+- Use the shared native tab-activation helper for Expected/Actual and Test Cases transitions that can shift the split view. Pass a destination readiness selector when the next command depends on rendered tab content.
+- When opening a versioned measure in View mode, configure action helpers not to expect edit-only CQL content. Synchronize on the intended destination tab instead.
 
 ## Refactor Rules
 

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -69,6 +69,8 @@ Work boundary for the next slice:
 
 Recently proven service/helper slices:
 
+- CI worker reliability: `scripts/run-with-timeout.js` now bounds silent Cypress worker hangs with a configurable 20-minute inactivity timeout, captures the existing CI diagnostics before termination, and terminates the full worker process group so `cypress-parallel` can return control to Jenkins.
+
 - Measure service: `Measure.cy.ts`, `MeasureBundle.cy.ts`, `MeasureExport.cy.ts`, `DraftMeasure.cy.ts`, `MeasureVersion.cy.ts`, `QI Core Test-Cases.cy.ts`.
 - QDM service: `QDM Test-Cases.cy.ts`, `QDM Measure.cy.ts`, `QDMMeasureVersion.cy.ts`.
 - CQL library service: `CreateCQL-Library.cy.ts`, `EditCQL-Library.cy.ts`, `VersionAndDraftCQL-Library.cy.ts`, `CQLLibraryDelete.cy.ts`.

--- a/scripts/run-with-timeout.js
+++ b/scripts/run-with-timeout.js
@@ -1,33 +1,32 @@
 #!/usr/bin/env node
 
-const { spawn } = require('child_process')
+const { spawn, spawnSync } = require('child_process')
 
 const timeoutSeconds = Number(process.argv[2])
 const command = process.argv[3]
 const args = process.argv.slice(4)
 const heartbeatSeconds = Number(process.env.CYPRESS_WORKER_HEARTBEAT_SECONDS || 300)
+const inactivityTimeoutSeconds = Number(process.env.CYPRESS_WORKER_INACTIVITY_TIMEOUT_SECONDS || 1200)
 
 if (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0 || !command) {
-  console.error('Usage: node scripts/run-with-timeout.js <seconds> <command> [args...]')
-  process.exit(1)
+    console.error('Usage: node scripts/run-with-timeout.js <seconds> <command> [args...]')
+    process.exit(1)
 }
 
 function quoteArg(arg) {
-  if (process.platform === 'win32') {
-    return `"${String(arg).replace(/"/g, '\\"')}"`
-  }
+    if (process.platform === 'win32') {
+        return `"${String(arg).replace(/"/g, '\\"')}"`
+    }
 
-  return `'${String(arg).replace(/'/g, `'\\''`)}'`
+    return `'${String(arg).replace(/'/g, `'\\''`)}'`
 }
 
 function formatElapsed(seconds) {
-  const hrs = Math.floor(seconds / 3600)
-  const mins = Math.floor((seconds % 3600) / 60)
-  const secs = seconds % 60
+    const hrs = Math.floor(seconds / 3600)
+    const mins = Math.floor((seconds % 3600) / 60)
+    const secs = seconds % 60
 
-  return [hrs, mins, secs]
-    .map((value) => String(value).padStart(2, '0'))
-    .join(':')
+    return [hrs, mins, secs].map((value) => String(value).padStart(2, '0')).join(':')
 }
 
 const shellCommand = [command, ...args].map(quoteArg).join(' ')
@@ -35,81 +34,128 @@ const shellCommand = [command, ...args].map(quoteArg).join(' ')
 console.error(`Starting command with timeout ${timeoutSeconds}s: ${shellCommand}`)
 
 const child = spawn(shellCommand, {
-  stdio: ['ignore', 'pipe', 'pipe'],
-  env: process.env,
-  detached: process.platform !== 'win32',
-  shell: true
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+    detached: process.platform !== 'win32',
+    shell: true
 })
 
 const startedAt = Date.now()
 let lastOutputAt = startedAt
+let inactivityTimer = null
 
 child.stdout.on('data', (chunk) => {
-  lastOutputAt = Date.now()
-  process.stdout.write(chunk)
+    lastOutputAt = Date.now()
+    scheduleInactivityTimeout()
+    process.stdout.write(chunk)
 })
 
 child.stderr.on('data', (chunk) => {
-  lastOutputAt = Date.now()
-  process.stderr.write(chunk)
+    lastOutputAt = Date.now()
+    scheduleInactivityTimeout()
+    process.stderr.write(chunk)
 })
 
 child.on('error', (err) => {
-  console.error(`Failed to start command: ${err.message}`)
+    console.error(`Failed to start command: ${err.message}`)
 })
 
 let timedOut = false
-const heartbeatTimer = Number.isFinite(heartbeatSeconds) && heartbeatSeconds > 0
-  ? setInterval(() => {
-      const elapsedSeconds = Math.floor((Date.now() - startedAt) / 1000)
-      const silentSeconds = Math.floor((Date.now() - lastOutputAt) / 1000)
-      console.error(
-        `Command heartbeat after ${formatElapsed(elapsedSeconds)}; last output ${formatElapsed(silentSeconds)} ago`
-      )
-    }, heartbeatSeconds * 1000)
-  : null
+let timeoutReason = ''
+
+function runDiagnostics() {
+    console.error('Capturing CI diagnostics before terminating the command')
+
+    const diagnostics = spawnSync('sh', ['scripts/ci-diagnostics.sh'], {
+        stdio: 'inherit',
+        timeout: 30000
+    })
+
+    if (diagnostics.error) {
+        console.error(`Failed to capture CI diagnostics: ${diagnostics.error.message}`)
+    }
+}
+
+function terminateCommand(reason) {
+    if (timedOut) {
+        return
+    }
+
+    timedOut = true
+    timeoutReason = reason
+    console.error(`${reason}: ${shellCommand}`)
+    runDiagnostics()
+
+    try {
+        if (process.platform === 'win32') {
+            child.kill('SIGTERM')
+        } else {
+            process.kill(-child.pid, 'SIGTERM')
+        }
+    } catch (err) {
+        console.error(`Failed to terminate timed-out process: ${err.message}`)
+    }
+
+    setTimeout(() => {
+        try {
+            if (process.platform === 'win32') {
+                child.kill('SIGKILL')
+            } else {
+                process.kill(-child.pid, 'SIGKILL')
+            }
+        } catch (_err) {
+            // Process already exited.
+        }
+    }, 10000).unref()
+}
+
+function scheduleInactivityTimeout() {
+    if (inactivityTimer) {
+        clearTimeout(inactivityTimer)
+    }
+
+    if (!Number.isFinite(inactivityTimeoutSeconds) || inactivityTimeoutSeconds <= 0) {
+        return
+    }
+
+    inactivityTimer = setTimeout(() => {
+        terminateCommand(`Command produced no output for ${inactivityTimeoutSeconds}s`)
+    }, inactivityTimeoutSeconds * 1000)
+}
+
+scheduleInactivityTimeout()
+
+const heartbeatTimer =
+    Number.isFinite(heartbeatSeconds) && heartbeatSeconds > 0
+        ? setInterval(() => {
+              const elapsedSeconds = Math.floor((Date.now() - startedAt) / 1000)
+              const silentSeconds = Math.floor((Date.now() - lastOutputAt) / 1000)
+              console.error(
+                  `Command heartbeat after ${formatElapsed(elapsedSeconds)}; last output ${formatElapsed(silentSeconds)} ago`
+              )
+          }, heartbeatSeconds * 1000)
+        : null
 
 heartbeatTimer?.unref()
 
 const timer = setTimeout(() => {
-  timedOut = true
-  console.error(`Command exceeded ${timeoutSeconds}s timeout: ${shellCommand}`)
-
-  try {
-    if (process.platform === 'win32') {
-      child.kill('SIGTERM')
-    } else {
-      process.kill(-child.pid, 'SIGTERM')
-    }
-  } catch (err) {
-    console.error(`Failed to terminate timed-out process: ${err.message}`)
-  }
-
-  setTimeout(() => {
-    try {
-      if (process.platform === 'win32') {
-        child.kill('SIGKILL')
-      } else {
-        process.kill(-child.pid, 'SIGKILL')
-      }
-    } catch (_err) {
-      // Process already exited.
-    }
-  }, 10000).unref()
+    terminateCommand(`Command exceeded ${timeoutSeconds}s timeout`)
 }, timeoutSeconds * 1000)
 
 child.on('exit', (code, signal) => {
-  clearTimeout(timer)
-  heartbeatTimer && clearInterval(heartbeatTimer)
+    clearTimeout(timer)
+    inactivityTimer && clearTimeout(inactivityTimer)
+    heartbeatTimer && clearInterval(heartbeatTimer)
 
-  if (timedOut) {
-    process.exit(124)
-  }
+    if (timedOut) {
+        console.error(`Command terminated: ${timeoutReason}`)
+        process.exit(124)
+    }
 
-  if (signal) {
-    console.error(`Command exited from signal ${signal}: ${shellCommand}`)
-    process.exit(128)
-  }
+    if (signal) {
+        console.error(`Command exited from signal ${signal}: ${shellCommand}`)
+        process.exit(128)
+    }
 
-  process.exit(code ?? 0)
+    process.exit(code ?? 0)
 })


### PR DESCRIPTION
## Summary

Improves Cypress regression reliability across test-case workflows, shared helpers, and CI timeout handling. Adds coverage for composite test-case action-center behavior and hierarchical value sets.

## Changes

- Stabilized Expected/Actual and Test Cases tab navigation using shared native tab activation.
- Fixed `TestCaseListPageSorting.cy.ts` to use the shared boolean Expected/Actual checkbox helper.
- Reduced repeated login and SPA navigation transitions in QDM execution flows.
- Replaced forced supplemental-data saves with visible, enabled, and settled-state assertions.
- Improved test-case import interactions and shared builder resource editing.
- Added API support for creating composite measures.
- Added hierarchical Observation Status value-set coverage.
- Added composite test-case action-center coverage behind the MAT-10118 feature gate.
- Added CI worker inactivity detection, diagnostics capture, and process-group termination.
- Updated Cypress reliability, debugging, and refactor backlog documentation.

## Technical Notes

- Reuses `TestCasesPage` Expected/Actual helpers for split-panel normalization.
- Uses native activation for tabs that can become clipped or shift the split-view layout.
- Completes API-created test data before UI login where supported.
- Waits for meaningful settled conditions after saves instead of relying only on success messages.
- Composite test coverage remains skipped until MAT-10118 is enabled by default.

## Testing

- `npm run compile` — passed
- `npm run quality:no-focused-tests` — passed
- `git diff --check` — passed
- `node --check scripts/run-with-timeout.js` — passed
- `TestCaseListPageSorting.cy.ts` against `test` — 1 passing
- `CreateUpdateTestCaseQICORE411.cy.ts` against `test` — 1 passing

## Risk

- Shared tab-navigation and builder helpers affect multiple test-case flows.
- Composite action-center coverage cannot run until its feature flag is enabled.
- CI timeout behavior now terminates the full worker process group after capturing diagnostics.

## Documentation

Updated:

- `docs/quality/cypress-automation-guidelines.md`
- `docs/quality/test-refactor-backlog.md`
- `docs/ai/debugging.md`