### PR TITLE
Stabilize weekly regression test workflows

### DIFF
--- a/cypress/Shared/EditMeasurePage.ts
+++ b/cypress/Shared/EditMeasurePage.ts
@@ -322,7 +322,13 @@ export class EditMeasurePage {
     }
 
     public static actionCenter(action: EditMeasureActions, options?: MeasureActionOptions): void {
-        cy.get(this.editMeasureButtonActionBtn).click()
+        cy.get(this.editMeasureButtonActionBtn)
+            .should('be.visible')
+            .closest('button')
+            .should('be.enabled')
+            .then(($button) => {
+                $button[0].click()
+            })
 
         switch (action) {
             case EditMeasureActions.export: {

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -1004,23 +1004,31 @@ export class TestCasesPage {
     const { clearFirst = false, index } = options
 
     this.normalizeExpectedActualPopulationPanel()
-    const typeValue = (input: Cypress.Chainable<JQuery<HTMLElement>>) => {
-      const readyInput = input.should('exist').should('be.enabled')
+    const getInput = () => {
+      const input = cy.get(inputSelector)
+
+      return typeof index === 'number' ? input.eq(index) : input
+    }
+    const typeValue = () => {
+      getInput()
+        .should('exist')
+        .should('be.enabled')
+        .then(($input) => {
+          $input[0].scrollIntoView({ block: 'center', inline: 'nearest' })
+        })
+
+      this.normalizeExpectedActualPopulationPanel()
 
       if (clearFirst) {
-        readyInput.clear({ scrollBehavior: false }).type(value, { scrollBehavior: false })
-        return
+        getInput().clear({ scrollBehavior: false }).type(value, { scrollBehavior: false })
+      } else {
+        getInput().type(value, { scrollBehavior: false })
       }
 
-      readyInput.type(value, { scrollBehavior: false })
+      getInput().should('have.value', value)
     }
 
-    if (typeof index === 'number') {
-      typeValue(cy.get(inputSelector).eq(index))
-      return
-    }
-
-    typeValue(cy.get(inputSelector))
+    typeValue()
   }
 
   public static toggleHighlightingResults(highlightingSectionSelector: string): void {
@@ -1028,7 +1036,11 @@ export class TestCasesPage {
       .should('be.visible')
       .contains('Results')
       .first()
-      .click({ scrollBehavior: false })
+      .should('exist')
+      .should('not.have.attr', 'aria-disabled', 'true')
+      .then(($control) => {
+        $control[0].click()
+      })
   }
 
   private static normalizeExpectedActualPopulationPanel(options: {

--- a/cypress/e2e/WebInterface/508/508Example.cy.ts
+++ b/cypress/e2e/WebInterface/508/508Example.cy.ts
@@ -1,64 +1,54 @@
 import { OktaLogin } from '../../../Shared/OktaLogin'
 
-// describe('508', () => {
-//     beforeEach('Login', () => {
-//         OktaLogin.Login()
-//
-//         cy.injectAxe()
-//     })
-//     afterEach('Log Out', () => {
-//         //login.matLogout()
-//     })
-//     it('508 test check for all', () => {
-//
-//         cy.checkA11y()
-//
-//     })
-//     it('specify values in options', () => {
-//
-//         //Have to use @ts-ignore for now when extending runOptions
-//         // @ts-ignore
-//         cy.checkA11y( null,{ runOnly: { type: 'tag', values: ['wcag21aa', 'wcag2aa']} })
-//         //['wcag21aa', 'wcag2aa', 'best-practice', 'section508']
-//     })
-//     it('Has no detectable a11y violations on load (filtering to only include critical impact violations)', () => {
-//         // Test on initial load, only report and assert for critical impact items
-//         cy.checkA11y(null, {
-//             includedImpacts: ['critical', 'serious'],
-//
-//         })
-//     })
-//     it('Only logs a11y violations while allowing the test to pass', () => {
-//         // Do not fail the test when there are accessibility failures
-//         cy.checkA11y(null, null, null, true)
-//
-//     })
-//     it('508 test check for one element or section', () => {
-//         cy.checkA11y(OktaLogin.signInButton)
-//         cy.checkA11y('.auth-footer')
-//     })
-//     it('Logs violations to the terminal', () => {
-//         cy.checkA11y(null, null, terminalLog)
-//     })
-//
-// })
+describe.skip('508', () => {
+    // beforeEach('Login', () => {
+    //     OktaLogin.Login()
+    //     cy.injectAxe()
+    // })
+    // afterEach('Log Out', () => {
+    //     //login.matLogout()
+    // })
+    // it('508 test check for all', () =>
+    //     cy.checkA11y()
+    // })
+    // it('specify values in options', () => {
+    //     //Have to use @ts-ignore for now when extending runOptions
+    //     // @ts-ignore
+    //     cy.checkA11y(null, { runOnly: { type: 'tag', values: ['wcag21aa', 'wcag2aa'] } })
+    //     //['wcag21aa', 'wcag2aa', 'best-practice', 'section508']
+    // })
+    // it('Has no detectable a11y violations on load (filtering to only include critical impact violations)', () => {
+    //     // Test on initial load, only report and assert for critical impact items
+    //     cy.checkA11y(null, {
+    //         includedImpacts: ['critical', 'serious']
+    //     })
+    // })
+    // it('Only logs a11y violations while allowing the test to pass', () => {
+    //     // Do not fail the test when there are accessibility failures
+    //     cy.checkA11y(null, null, null, true)
+    // })
+    // it('508 test check for one element or section', () => {
+    //     cy.checkA11y(OktaLogin.signInButton)
+    //     cy.checkA11y('.auth-footer')
+    // })
+    // it('Logs violations to the terminal', () => {
+    //     cy.checkA11y(null, null, terminalLog)
+})
 
-function terminalLog(violations) {
-    cy.task(
-        'log',
-        `${violations.length} accessibility violation${
-            violations.length === 1 ? '' : 's'
-        } ${violations.length === 1 ? 'was' : 'were'} detected`
-    )
-    // pluck specific keys to keep the table readable
-    const violationData = violations.map(
-        ({ id, impact, description, nodes }) => ({
-            id,
-            impact,
-            description,
-            nodes: nodes.length
-        })
-    )
+// function terminalLog(violations) {
+//     cy.task(
+//         'log',
+//         `${violations.length} accessibility violation${
+//             violations.length === 1 ? '' : 's'
+//         } ${violations.length === 1 ? 'was' : 'were'} detected`
+//     )
+//     // pluck specific keys to keep the table readable
+//     const violationData = violations.map(({ id, impact, description, nodes }) => ({
+//         id,
+//         impact,
+//         description,
+//         nodes: nodes.length
+//     }))
 
-    cy.task('table', violationData)
-}
+//     cy.task('table', violationData)
+// }

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportFilesvalidation.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureExport/QDMMeasureExportFilesvalidation.cy.ts
@@ -122,12 +122,13 @@ describe('Successful QDM Measure Export with versioned measure', () => {
         CQLEditorPage.saveCql({ collapseEditor: true, waitForDisabled: true })
 
         EditMeasurePage.actionCenter(EditMeasureActions.version)
-        cy.contains('Version ' + versionNumber).should('be.visible')
-        Utilities.waitForElementVisible(EditMeasurePage.editMeasureButtonActionBtn, 30000)
-        Utilities.waitForElementEnabled(EditMeasurePage.editMeasureButtonActionBtn, 30000)
+        cy.get(Header.mainMadiePageButton).click()
+        Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
+
+        MeasuresPage.validateVersionNumber(versionNumber)
         cy.log('Major Version Created Successfully')
 
-        EditMeasurePage.actionCenter(EditMeasureActions.export)
+        MeasuresPage.actionCenter('export')
 
         //verify zip file exists
         cy.readFile(path.join(downloadsFolder, 'eCQMTitle4QDM-v1.0.000-QDM.zip'), { timeout: 60000 }).should('exist')

--- a/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QI Core Measure Export/MeasureExportNotTheOwner.cy.ts
@@ -36,7 +36,7 @@ describe('FHIR Measure Export, Not the Owner', () => {
         Utilities.waitForElementVisible(MeasuresPage.measureListTitles, 60000)
     })
 
-    it('Validate the zip file Export is downloaded for FHIR Measure', () => {
+    it('Export, unzip, and verify file types for FHIR Measure', () => {
 
         //Navigate to All Measures tab
         cy.get(MeasuresPage.allMeasuresTab).should('be.visible')
@@ -47,9 +47,6 @@ describe('FHIR Measure Export, Not the Owner', () => {
 
         cy.readFile(path.join(downloadsFolder, expectedFileName), { timeout: 60000 }).should('exist')
         cy.log('Successfully verified zip file export')
-    })
-
-    it('Unzip the downloaded file and verify file types for FHIR Measure', () => {
 
         cy.verifyDownload(expectedFileName)
 
@@ -65,4 +62,3 @@ describe('FHIR Measure Export, Not the Owner', () => {
         cy.verifyDownload('eCQMTitle4QICore-v0.0.000-FHIR.json')
     })
 })
-

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/CV_ListQDMPositiveEncounterPerformed_WithMOAndStratification.cy.ts
@@ -146,7 +146,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
             false,
             false,
             '2025-01-01',
-            '2025-12-31',
+            '2025-12-31'
         )
         TestCasesPage.CreateQDMTestCaseAPI(firstTestCaseTitle, testCaseSeries, testCaseDescription)
         TestCasesPage.CreateQDMTestCaseAPI(secondTestCaseTitle, testCaseSeries, testCaseDescription, undefined, true)
@@ -192,7 +192,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         Utilities.waitForElementVisible(MeasureGroupPage.qdmBCSaveButtonSuccessMsg, 30000)
         cy.get(MeasureGroupPage.qdmBCSaveButtonSuccessMsg).should(
             'contain.text',
-            'Measure Base Configuration ' + 'Updated Successfully',
+            'Measure Base Configuration ' + 'Updated Successfully'
         )
 
         //add pop criteria
@@ -218,7 +218,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Population details for ' + 'this group saved successfully.',
+            'Population details for ' + 'this group saved successfully.'
         )
 
         //Add Supplemental Data Elements
@@ -233,7 +233,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get('[data-testid="measure-Supplemental Data-save"]').click({ force: true })
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Measure Supplemental Data have been Saved Successfully',
+            'Measure Supplemental Data have been Saved Successfully'
         )
 
         //Add Elements to first Test case
@@ -247,7 +247,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
             'Living',
             'White',
             'Male',
-            'Not Hispanic or Latino',
+            'Not Hispanic or Latino'
         )
 
         //Element - Encounter:Performed:Emergency Department Visit
@@ -310,18 +310,28 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get('[data-testid="add-code-concept-button"]').click()
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
-
+        Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 30000)
         //Add Expected value for Test case
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', {
+            clearFirst: true
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', {
+            clearFirst: true
+        })
         TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '60', { clearFirst: true })
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStrata1ExpectedValue, '1')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, '1', { index: 0 })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStrata1ExpectedValue, '1', {
+            clearFirst: true
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, '1', {
+            clearFirst: true,
+            index: 0
+        })
         TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasurePopulationExpectedValue, '1', {
+            clearFirst: true,
             index: 0
         })
         //Commented until MAT-6608 is fixed
@@ -329,7 +339,6 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
             clearFirst: true,
             index: 0
         })
-
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test Case Updated Successfully')
@@ -345,7 +354,7 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
             'Living',
             'White',
             'Male',
-            'Not Hispanic or Latino',
+            'Not Hispanic or Latino'
         )
 
         //Element - Encounter:Performed:Emergency Department Visit
@@ -458,27 +467,37 @@ describe('Measure Creation: CV ListQDMPositiveEncounterPerformed With MO And Str
         cy.get(TestCasesPage.addAttribute).click()
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
+        Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 30000)
 
         //Add Expected value for Test case
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2', {
+            clearFirst: true
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '2', {
+            clearFirst: true
+        })
         TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '45', {
             clearFirst: true,
             index: 1
         })
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStrata1ExpectedValue, '2')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, '2', { index: 0 })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStrata1ExpectedValue, '2', {
+            clearFirst: true
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedInitialPopulationExpectedValue, '2', {
+            clearFirst: true,
+            index: 0
+        })
         TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasurePopulationExpectedValue, '2', {
+            clearFirst: true,
             index: 0
         })
         TestCasesPage.typeExpectedActualValue(TestCasesPage.qdmStratifiedMeasureObservationExpectedValue(4), '45', {
             clearFirst: true
         })
-
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(EditMeasurePage.successMessage).should('contain.text', 'Test Case Updated Successfully')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
@@ -117,19 +117,19 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
         //Validate measure observation expected values
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '@#')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '@#', { clearFirst: true })
         cy.get(TestCasesPage.denominatorObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, 'ab12')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, 'ab12', { clearFirst: true })
         cy.get(TestCasesPage.numeratorObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',
         )
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '-15')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '-15', { clearFirst: true })
         cy.get(TestCasesPage.numeratorObservationExpectedValueError).should(
             'contain.text',
             'Only positive numeric values can be entered in the expected values',

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -1,6 +1,6 @@
 # MADiE Cypress Quality Backlog
 
-Last updated: 2026-07-31
+Last updated: 2026-08-03
 
 Stable automation rules live in `docs/quality/cypress-automation-guidelines.md`. This file tracks only current priorities, blockers, audit signal, and concise completion evidence.
 
@@ -37,7 +37,7 @@ Work boundaries:
 
 | Area | Status | Next action |
 | --- | --- | --- |
-| `RatioPatientTwoIPsWithMOs.cy.ts` | DEV product bug: measure observations are missing in Expected/Actual after the original Population Criteria readiness issue was fixed. | Retest after the DEV fix; preserve the observation assertions. |
+| `RatioPatientTwoIPsWithMOs.cy.ts`, `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts` | TEST product bug: denominator measure observations are missing in Expected/Actual after the original Population Criteria readiness issue was fixed. | Retest after the product fix; preserve the observation assertions. |
 | `ExecuteInvalidTestCases.cy.ts` | Product remains `Invalid` instead of `Pass` after execution. | Product follow-up; do not accept `Invalid`. |
 | `ElementTable.cy.ts` | Deferred by team; React action transition can detach or close without opening the editor. | Resume only when explicitly prioritized; diagnose destination transition. |
 | `CQLLibraryDelete.cy.ts` | Environment/account drift: inactive-user `400` and admin `403 insufficient_scope`. | Repair account/scope state before refactoring. |


### PR DESCRIPTION
## Summary

Improve weekly regression reliability for Expected/Actual inputs, highlighting interactions, and measure export flows while preserving test intent and product-failure assertions.

## Changes

- Reposition and re-query Expected/Actual inputs before typing, keep clear/type contiguous, and assert retained values.
- Activate covered Highlighting Results controls through the shared native interaction path.
- Replace default observation values explicitly in Ratio validation coverage.
- Correct CV stratification observation row targeting and wait for test-case saves to settle.
- Target the actual edit-measure action-center button and restore the stable measure-list boundary for versioned QDM export.
- Combine FHIR export, unzip, and file verification into one artifact-owning test.
- Explicitly skip the 508 example suite so it is excluded from CI execution.
- Extend the backlog product blocker to `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts`.

## Technical Notes

The changes reuse `TestCasesPage` and `EditMeasurePage` instead of adding spec-local workarounds. Controlled inputs are re-queried after React rerenders, and no fixed waits or forced Expected/Actual interactions were added.

The missing denominator-observation fields in the two Ratio patient specs remain a product blocker; their assertions are intentionally preserved.

## Testing

- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`
- MeasureHighlighting selected case: passed locally
- MeasureObservationExpectedValues Ratio validation: passed on TEST
- CV ListQDMPositiveEncounterPerformed with MO and Stratification: passed locally
- MeasureExportNotTheOwner combined export test: passed locally
- QDMMeasureExportFilesvalidation versioned export: passed on TEST
- Shared QDM Expected/Actual consumers exercised through targeted batch runs

## Risk

Low to moderate. Shared interaction helpers changed, but focused consumers passed and final-value assertions prevent silent input failures.

The 508 example suite is intentionally skipped and appears in the quality audit as skipped coverage.

## Documentation

Updated `docs/quality/test-refactor-backlog.md` with the confirmed Ratio same-function product blocker.