### PR TITLE
MAT-9813 add admin user profile measure action tests

### DIFF
--- a/cypress/Shared/AdminUserProfilePage.ts
+++ b/cypress/Shared/AdminUserProfilePage.ts
@@ -1,0 +1,118 @@
+import { OktaLogin } from './OktaLogin'
+import { MeasuresPage } from './MeasuresPage'
+
+export class AdminUserProfilePage {
+    public static readonly userSearchInput = '[data-testid="user-search-input"]'
+    public static readonly userSearchButton = '[data-testid="user-trigger-search"]'
+    public static readonly userHarpIdCell = '[data-testid$="_harpId"]'
+    public static readonly userNameLink = '[data-testid^="user-name-link-"]'
+    public static readonly measuresTable = '[data-testid="user-profile-measures-tbl"]'
+
+    public static readonly exportButton = '[data-testid="export-action-btn"]'
+    public static readonly humanReadableButton = '[data-testid="view-hr-action-btn"]'
+    public static readonly historyButton = '[data-testid="history-action-btn"]'
+    public static readonly compareVersionsButton = MeasuresPage.compareVersionsBtn
+
+    public static readonly exportTooltip = '[data-testid="export-action-tooltip"]'
+    public static readonly humanReadableTooltip = '[data-testid="view-hr-action-tooltip"]'
+    public static readonly historyTooltip = '[data-testid="history-action-tooltip"]'
+    public static readonly compareVersionsTooltip = '[data-testid="compare-versions-action-tooltip"]'
+
+    public static openAdminWorkspace(): void {
+        cy.visit('/admin')
+        cy.location('pathname').should('eq', '/admin')
+        cy.get(this.userSearchInput).should('be.visible').and('be.enabled')
+    }
+
+    public static openUserProfile(harpId = OktaLogin.getUser(false)): void {
+        this.openAdminWorkspace()
+
+        cy.get(this.userSearchInput).clear().type(harpId)
+        cy.get(this.userSearchButton).should('be.visible').click()
+        cy.intercept('PUT', '**/api/admin/userProfile/*/measures/searches*').as('profileMeasures')
+        cy.contains(this.userHarpIdCell, harpId)
+            .closest('tr')
+            .find(this.userNameLink)
+            .click()
+
+        cy.wait('@profileMeasures').its('response.statusCode').should('eq', 200)
+        cy.wait('@profileMeasures').its('response.statusCode').should('eq', 200)
+        cy.location('pathname').should('eq', `/admin/userProfile/${harpId}`)
+        cy.get(MeasuresPage.ownedMeasures).should('be.visible')
+        cy.get(MeasuresPage.sharedMeasures).should('be.visible')
+        cy.get(this.measuresTable).should('be.visible')
+    }
+
+    public static assertDisabledAction(
+        buttonSelector: string,
+        tooltipSelector: string,
+        expectedTooltip: string
+    ): void {
+        cy.get(buttonSelector).should('be.disabled')
+        cy.get(tooltipSelector).trigger('mouseover')
+        cy.get('.MuiTooltip-tooltip:visible').last().should('have.text', expectedTooltip)
+        cy.get(tooltipSelector).trigger('mouseout')
+    }
+
+    public static assertEnabledAction(
+        buttonSelector: string,
+        tooltipSelector: string,
+        expectedTooltip: string
+    ): void {
+        cy.get(buttonSelector).should('be.enabled')
+        cy.get(buttonSelector).realHover({ scrollBehavior: false })
+        cy.get('.MuiTooltip-tooltip:visible').last().should('have.text', expectedTooltip)
+        cy.get(tooltipSelector).trigger('mouseout')
+    }
+
+    public static selectMeasureRow(rowIndex: number): void {
+        cy.get(this.measuresTable)
+            .find('tbody tr')
+            .eq(rowIndex)
+            .find('input[type="checkbox"]')
+            .check()
+    }
+
+    public static selectMeasureByVersion(version: string): void {
+        cy.contains(`${this.measuresTable} tbody td`, version)
+            .closest('tr')
+            .find('input[type="checkbox"]')
+            .check()
+    }
+
+    public static openMeasuresTab(tabSelector: string): void {
+        cy.get(tabSelector).should('be.visible').click()
+        cy.get(tabSelector).should('have.attr', 'aria-selected', 'true')
+        cy.get(this.measuresTable).should('be.visible')
+    }
+
+    public static selectMeasureByName(measureName: string): Cypress.Chainable<JQuery<HTMLElement>> {
+        return cy.contains(`${this.measuresTable} tbody td`, measureName)
+            .should('be.visible')
+            .closest('tr')
+            .find('input[type="checkbox"]')
+            .should('be.visible')
+            .check()
+    }
+
+    public static expandMeasureSet(
+        measureId: string,
+        expectedExpandedRows = 1
+    ): Cypress.Chainable<JQuery<HTMLElement>> {
+        const measureRow = `[data-testid="measure-name-${measureId}_select"]`
+        const expandIcon = `[data-testid="measure-name-${measureId}_expandArrow"]`
+
+        cy.get(measureRow).should('be.visible')
+        cy.get(expandIcon)
+            .should('be.visible')
+            .find('svg')
+            .should('be.visible')
+            .click()
+
+        return cy
+            .get(this.measuresTable)
+            .find('tr.expanded-row:visible')
+            .should('have.length', expectedExpandedRows)
+    }
+
+}

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileCompareMeasureVersions.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileCompareMeasureVersions.cy.ts
@@ -1,0 +1,171 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../Shared/MeasureGroupPage'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { MeasureDraftBody, TestData } from '../../../Shared/TestData'
+import { Utilities } from '../../../Shared/Utilities'
+
+// MAT-9813: Enable when the AdminUserProfile feature is available in TEST.
+describe.skip('Admin user profile Compare Measure Versions', () => {
+    let measureName = ''
+    let draftMeasureName = ''
+    let cqlLibraryName = ''
+    let profileOwner = ''
+    const measureCql = MeasureCQL.CQL_For_Cohort
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        measureName = `AdminProfileCompare${uniqueSuffix}`
+        draftMeasureName = `${measureName}Draft`
+        cqlLibraryName = `AdminProfileCompareLib${uniqueSuffix}`
+        profileOwner = OktaLogin.getUser(false)
+
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCql)
+        TestData.saveMeasureCql(`${measureCql}\n`).then((response) => {
+            TestData.expectSavedMeasureCql(response)
+        })
+        MeasureGroupPage.CreateCohortMeasureGroupAPI()
+        TestData.readMeasure().then((measureResponse) => {
+            const measure = measureResponse.body
+
+            TestData.versionMeasure().then((response) => {
+                expect(response.status).to.eq(200)
+
+                const draftBody: MeasureDraftBody = {
+                    measureName: draftMeasureName,
+                    cqlLibraryName,
+                    model: measure.model,
+                    createdBy: profileOwner,
+                    cql: measure.cql,
+                    elmJson: measure.elmJson,
+                    ecqmTitle: measure.ecqmTitle,
+                    measurementPeriodStart: measure.measurementPeriodStart,
+                    measurementPeriodEnd: measure.measurementPeriodEnd
+                }
+
+                TestData.requestMeasureDraft(draftBody).then((draftResponse) => {
+                    expect(draftResponse.status).to.eq(201)
+                    TestData.writeFixture('measureId1', draftResponse.body.id)
+                    TestData.readMeasure().then((versionResponse) => {
+                        TestData.requestMeasureById('GET', draftResponse.body.id).then((createdDraftResponse) => {
+                            expect(createdDraftResponse.body.measureSetId).to.eq(versionResponse.body.measureSetId)
+                        })
+                    })
+                })
+            })
+        })
+
+    })
+
+    afterEach(() => {
+        Utilities.deleteVersionedMeasure(measureName, cqlLibraryName)
+        Utilities.deleteMeasure(undefined, undefined, false, false, 1)
+    })
+
+    const compareSelectedInstances = () => {
+        TestData.readMeasureId(1).then((draftMeasureId) => {
+            const draftRow = `[data-testid="measure-name-${draftMeasureId}_select"]`
+            cy.get(draftRow).find('input[type="checkbox"]').should('be.visible').check()
+            AdminUserProfilePage.expandMeasureSet(draftMeasureId)
+                .find('input[type="checkbox"]')
+                .should('be.visible')
+                .check()
+        })
+
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.compareVersionsButton,
+            AdminUserProfilePage.compareVersionsTooltip,
+            'Compare Measure Versions'
+        )
+        cy.get(AdminUserProfilePage.compareVersionsButton).click()
+        cy.contains('h2', 'Compare Measure Versions').should('be.visible')
+        cy.get(MeasuresPage.compareVersionsCqlTab).should('be.visible')
+        cy.get(MeasuresPage.compareVersionsHRTab).should('be.visible')
+    }
+
+    it('compares two API-created instances from the same Owned Measure set', () => {
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileOwner)
+        cy.contains(profileOwner).should('be.visible')
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, draftMeasureName).should('be.visible')
+
+        compareSelectedInstances()
+    })
+
+    it('compares two API-created instances from the same Shared Measure set', () => {
+        const sharedProfileUser = OktaLogin.getUser(true)
+
+        TestData.readMeasureId().then((versionMeasureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', versionMeasureId, sharedProfileUser).then(
+                (response) => {
+                    expect(response.status).to.eq(200)
+                }
+            )
+        })
+        TestData.readMeasureId(1).then((draftMeasureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', draftMeasureId, sharedProfileUser).then(
+                (response) => {
+                    expect(response.status).to.eq(200)
+                }
+            )
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(sharedProfileUser)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, draftMeasureName).should('be.visible')
+
+        compareSelectedInstances()
+    })
+
+    it('disables Compare when three instances from the same Owned Measure set are selected', () => {
+        const secondDraftName = `${measureName}SecondDraft`
+
+        TestData.versionMeasure('major', 1).then((response) => {
+            expect(response.status).to.eq(200)
+            expect(response.body.version).to.eq('2.0.000')
+        })
+        TestData.readMeasureId(1).then((secondVersionId) => {
+            TestData.requestMeasureById('GET', secondVersionId).then((secondVersionResponse) => {
+                const secondVersion = secondVersionResponse.body
+                const secondDraftBody: MeasureDraftBody = {
+                    measureName: secondDraftName,
+                    cqlLibraryName,
+                    model: secondVersion.model,
+                    createdBy: profileOwner,
+                    cql: secondVersion.cql,
+                    elmJson: secondVersion.elmJson,
+                    ecqmTitle: secondVersion.ecqmTitle,
+                    measurementPeriodStart: secondVersion.measurementPeriodStart,
+                    measurementPeriodEnd: secondVersion.measurementPeriodEnd
+                }
+
+                TestData.requestMeasureDraft(secondDraftBody, 1).then((draftResponse) => {
+                    expect(draftResponse.status).to.eq(201)
+                    TestData.writeFixture('measureId2', draftResponse.body.id)
+                })
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileOwner)
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, secondDraftName).should('be.visible')
+
+        TestData.readMeasureId(2).then((secondDraftId) => {
+            const secondDraftRow = `[data-testid="measure-name-${secondDraftId}_select"]`
+            cy.get(secondDraftRow).find('input[type="checkbox"]').should('be.visible').check()
+            AdminUserProfilePage.expandMeasureSet(secondDraftId, 2)
+                .find('input[type="checkbox"]')
+                .should('have.length', 2)
+                .check()
+        })
+
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.compareVersionsButton,
+            AdminUserProfilePage.compareVersionsTooltip,
+            'Select 2 instances within the same measure set to compare measure versions'
+        )
+    })
+})

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileMeasureActions.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileMeasureActions.cy.ts
@@ -1,0 +1,189 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { Environment } from '../../../Shared/Environment'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { TestCasesPage } from '../../../Shared/TestCasesPage'
+import { Utilities } from '../../../Shared/Utilities'
+
+let profileUser = ''
+
+// MAT-9813: Enable when the AdminUserProfile feature is available in TEST.
+describe.skip('Admin user profile measure actions', () => {
+    beforeEach(() => {
+        profileUser = Environment.credentials().adminUser?.toLowerCase() ?? ''
+        expect(profileUser, 'configured Admin profile user').not.to.be.empty
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileUser)
+    })
+
+    ;[
+        { name: 'Owned Measures', selector: MeasuresPage.ownedMeasures },
+        { name: 'Shared Measures', selector: MeasuresPage.sharedMeasures }
+    ].forEach(({ name, selector }) => {
+        it(`disables measure actions when no ${name} are selected`, () => {
+            cy.get(selector).click()
+            cy.get(selector).should('have.attr', 'aria-selected', 'true')
+            cy.get(AdminUserProfilePage.measuresTable).should('be.visible')
+
+            AdminUserProfilePage.assertDisabledAction(
+                AdminUserProfilePage.exportButton,
+                AdminUserProfilePage.exportTooltip,
+                'Select measure to export'
+            )
+            AdminUserProfilePage.assertDisabledAction(
+                AdminUserProfilePage.humanReadableButton,
+                AdminUserProfilePage.humanReadableTooltip,
+                'Select measure to view human readable'
+            )
+            AdminUserProfilePage.assertDisabledAction(
+                AdminUserProfilePage.compareVersionsButton,
+                AdminUserProfilePage.compareVersionsTooltip,
+                'Select 2 instances within the same measure set to compare measure versions'
+            )
+            AdminUserProfilePage.assertDisabledAction(
+                AdminUserProfilePage.historyButton,
+                AdminUserProfilePage.historyTooltip,
+                'Select a measure to view history'
+            )
+        })
+    })
+
+    it('opens Human Readable for one selected Owned Measure', () => {
+        cy.get(MeasuresPage.ownedMeasures).click()
+        AdminUserProfilePage.selectMeasureRow(0)
+
+        cy.get(AdminUserProfilePage.humanReadableButton).should('be.enabled').click()
+        cy.get(EditMeasurePage.humanReadablePopup).should('be.visible').and('contain.text', 'Human Readable')
+    })
+
+    it('opens Measure History for one selected Owned Measure', () => {
+        cy.get(MeasuresPage.ownedMeasures).click()
+        AdminUserProfilePage.selectMeasureRow(0)
+
+        cy.get(AdminUserProfilePage.historyButton).should('be.enabled').click()
+        cy.get('[data-testid="measure-history-header"]').should('be.visible')
+    })
+
+    it('shows both export options for one selected Owned Measure', () => {
+        cy.get(MeasuresPage.ownedMeasures).click()
+        AdminUserProfilePage.selectMeasureRow(0)
+
+        cy.get(AdminUserProfilePage.exportButton).should('be.enabled').click()
+        cy.get(MeasuresPage.exportNonPublishingOption).should('be.visible').and('have.text', 'Export')
+        cy.get(MeasuresPage.exportPublishingOption)
+            .should('be.visible')
+            .and('have.text', 'Export for Publishing')
+    })
+
+    it('exports one selected Owned Measure and records the Admin attribution', () => {
+        cy.get(MeasuresPage.ownedMeasures).click()
+        AdminUserProfilePage.selectMeasureByVersion('1.0.000')
+
+        cy.get(AdminUserProfilePage.exportButton).should('be.enabled').click()
+        cy.get(MeasuresPage.exportNonPublishingOption).should('be.visible').click()
+        cy.get(MeasuresPage.exportingDialog).should('be.visible')
+        cy.get(MeasuresPage.exportFinishedCheck, { timeout: 60000 }).should('be.visible')
+        cy.get(TestCasesPage.successMsg).should('contain.text', 'Measure exported successfully')
+        cy.get(TestCasesPage.QDMTcDiscardChangesButton).click()
+
+        cy.get(AdminUserProfilePage.historyButton).should('be.enabled').click()
+        cy.get(MeasuresPage.userActionRow).should('contain.text', 'EXPORTED_MEASURE')
+        cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'by MADiE Admin')
+    })
+
+    it('exports one selected Owned Measure for publishing', () => {
+        cy.get(MeasuresPage.ownedMeasures).click()
+        AdminUserProfilePage.selectMeasureByVersion('1.0.000')
+
+        cy.get(AdminUserProfilePage.exportButton).should('be.enabled').click()
+        cy.get(MeasuresPage.exportPublishingOption).should('be.visible').click()
+        cy.get(MeasuresPage.exportingDialog).should('be.visible')
+        cy.get(MeasuresPage.exportFinishedCheck, { timeout: 60000 }).should('be.visible')
+        cy.get(TestCasesPage.successMsg).should('contain.text', 'Measure exported successfully')
+    })
+
+})
+
+describe.skip('Admin user profile unrelated Owned Measure selections', () => {
+    let firstMeasureName = ''
+    let secondMeasureName = ''
+    let firstLibraryName = ''
+    let secondLibraryName = ''
+    let profileOwner = ''
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        firstMeasureName = `AdminProfileUnrelatedOne${uniqueSuffix}`
+        secondMeasureName = `AdminProfileUnrelatedTwo${uniqueSuffix}`
+        firstLibraryName = `AdminProfileUnrelatedLibOne${uniqueSuffix}`
+        secondLibraryName = `AdminProfileUnrelatedLibTwo${uniqueSuffix}`
+        profileOwner = OktaLogin.getUser(false)
+
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            firstMeasureName,
+            firstLibraryName,
+            MeasureCQL.CQL_For_Cohort,
+            0
+        )
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            secondMeasureName,
+            secondLibraryName,
+            MeasureCQL.CQL_For_Cohort,
+            1
+        )
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileOwner)
+    })
+
+    afterEach(() => {
+        Utilities.deleteMeasure(undefined, undefined, false, false, 0)
+        Utilities.deleteMeasure(undefined, undefined, false, false, 1)
+    })
+
+    it('updates actions when one and then two unrelated measures are selected', () => {
+        AdminUserProfilePage.selectMeasureByName(firstMeasureName)
+
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.exportButton,
+            AdminUserProfilePage.exportTooltip,
+            'Export measure'
+        )
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.humanReadableButton,
+            AdminUserProfilePage.humanReadableTooltip,
+            'View human readable'
+        )
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.historyButton,
+            AdminUserProfilePage.historyTooltip,
+            'View History'
+        )
+
+        AdminUserProfilePage.selectMeasureByName(secondMeasureName)
+
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.exportButton,
+            AdminUserProfilePage.exportTooltip,
+            'Select measure to export'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.humanReadableButton,
+            AdminUserProfilePage.humanReadableTooltip,
+            'Select measure to view human readable'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.historyButton,
+            AdminUserProfilePage.historyTooltip,
+            'Select a measure to view history'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.compareVersionsButton,
+            AdminUserProfilePage.compareVersionsTooltip,
+            'Select 2 instances within the same measure set to compare measure versions'
+        )
+    })
+})

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileQdmMeasureActions.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileQdmMeasureActions.cy.ts
@@ -1,0 +1,73 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { Utilities } from '../../../Shared/Utilities'
+
+// MAT-9813: Enable when the AdminUserProfile feature is available in TEST.
+describe.skip('Admin user profile QDM Measure actions', () => {
+    let measureName = ''
+    let cqlLibraryName = ''
+    let profileOwner = ''
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        measureName = `AdminProfileQdm${uniqueSuffix}`
+        cqlLibraryName = `AdminProfileQdmLib${uniqueSuffix}`
+        profileOwner = OktaLogin.getUser(false)
+
+        CreateMeasurePage.CreateQDMMeasureAPI(
+            measureName,
+            cqlLibraryName,
+            MeasureCQL.returnBooleanPatientBasedQDM_CQL
+        )
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileOwner)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.ownedMeasures)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody tr`, measureName)
+            .should('be.visible')
+            .and('contain.text', 'QDM')
+    })
+
+    afterEach(() => {
+        Utilities.deleteMeasure()
+    })
+
+    it('enables QDM single-measure actions and shows both export options', () => {
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.exportButton,
+            AdminUserProfilePage.exportTooltip,
+            'Export measure'
+        )
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.humanReadableButton,
+            AdminUserProfilePage.humanReadableTooltip,
+            'View human readable'
+        )
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.historyButton,
+            AdminUserProfilePage.historyTooltip,
+            'View History'
+        )
+
+        cy.get(AdminUserProfilePage.exportButton).click()
+        cy.get(MeasuresPage.exportNonPublishingOption).should('be.visible').and('have.text', 'Export')
+        cy.get(MeasuresPage.exportPublishingOption)
+            .should('be.visible')
+            .and('have.text', 'Export for Publishing')
+    })
+
+    it('opens Human Readable for a QDM Measure', () => {
+        cy.get(AdminUserProfilePage.humanReadableButton).should('be.enabled').click()
+        cy.get(EditMeasurePage.humanReadablePopup).should('be.visible').and('contain.text', 'Human Readable')
+    })
+
+    it('opens Measure History for a QDM Measure', () => {
+        cy.get(AdminUserProfilePage.historyButton).should('be.enabled').click()
+        cy.get('[data-testid="measure-history-header"]').should('be.visible')
+    })
+})

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileSharedMeasureActions.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileSharedMeasureActions.cy.ts
@@ -1,0 +1,180 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../Shared/MeasureGroupPage'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { TestCasesPage } from '../../../Shared/TestCasesPage'
+import { TestData } from '../../../Shared/TestData'
+import { Utilities } from '../../../Shared/Utilities'
+
+// MAT-9813: Enable when the AdminUserProfile feature is available in TEST.
+describe.skip('Admin user profile Shared Measure actions', () => {
+    let measureName = ''
+    let cqlLibraryName = ''
+    let profileUser = ''
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        measureName = `AdminProfileShared${uniqueSuffix}`
+        cqlLibraryName = `AdminProfileSharedLib${uniqueSuffix}`
+        profileUser = OktaLogin.getUser(true)
+
+        const measureCql = MeasureCQL.CQL_For_Cohort
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, measureCql)
+        TestData.saveMeasureCql(`${measureCql}\n`).then((response) => {
+            TestData.expectSavedMeasureCql(response)
+        })
+        MeasureGroupPage.CreateCohortMeasureGroupAPI()
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', measureId, profileUser).then((response) => {
+                expect(response.status).to.eq(200)
+                expect(response.body[measureId][0].userId).to.eq(profileUser)
+                expect(response.body[measureId][0].roles).to.include('SHARED_WITH')
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileUser)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+    })
+
+    afterEach(() => {
+        Utilities.deleteMeasure()
+    })
+
+    it('enables the single-measure actions and shows both export options', () => {
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.exportButton,
+            AdminUserProfilePage.exportTooltip,
+            'Export measure'
+        )
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.humanReadableButton,
+            AdminUserProfilePage.humanReadableTooltip,
+            'View human readable'
+        )
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.historyButton,
+            AdminUserProfilePage.historyTooltip,
+            'View History'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.compareVersionsButton,
+            AdminUserProfilePage.compareVersionsTooltip,
+            'Select 2 instances within the same measure set to compare measure versions'
+        )
+
+        cy.get(AdminUserProfilePage.exportButton).click()
+        cy.get(MeasuresPage.exportNonPublishingOption).should('be.visible').and('have.text', 'Export')
+        cy.get(MeasuresPage.exportPublishingOption)
+            .should('be.visible')
+            .and('have.text', 'Export for Publishing')
+    })
+
+    it('opens Human Readable for a Shared Measure', () => {
+        cy.get(AdminUserProfilePage.humanReadableButton).should('be.enabled').click()
+        cy.get(EditMeasurePage.humanReadablePopup).should('be.visible').and('contain.text', 'Human Readable')
+    })
+
+    it('opens Measure History for a Shared Measure', () => {
+        cy.get(AdminUserProfilePage.historyButton).should('be.enabled').click()
+        cy.get('[data-testid="measure-history-header"]').should('be.visible')
+    })
+
+    ;[
+        { name: 'Export', selector: MeasuresPage.exportNonPublishingOption },
+        { name: 'Export for Publishing', selector: MeasuresPage.exportPublishingOption }
+    ].forEach(({ name, selector }) => {
+        it(`exports a Shared Measure using ${name}`, () => {
+            cy.intercept('GET', '**/api/measures/*/exports?*').as('measureExport')
+            cy.get(AdminUserProfilePage.exportButton).should('be.enabled').click()
+            cy.get(selector).should('be.visible').click()
+            cy.get(MeasuresPage.exportingDialog).should('be.visible')
+            cy.wait('@measureExport', { timeout: 60000 }).its('response.statusCode').should('eq', 201)
+            cy.get(MeasuresPage.exportFinishedCheck, { timeout: 60000 }).should('be.visible')
+            cy.get(TestCasesPage.successMsg).should('contain.text', 'Measure exported successfully')
+
+            if (name === 'Export') {
+                cy.get(TestCasesPage.QDMTcDiscardChangesButton).should('be.visible').click()
+                cy.get(AdminUserProfilePage.historyButton).should('be.enabled').click()
+                cy.get(MeasuresPage.userActionRow).should('contain.text', 'EXPORTED_MEASURE')
+                cy.get(MeasuresPage.additionalActionRow).should('contain.text', 'by MADiE Admin')
+            }
+        })
+    })
+})
+
+describe.skip('Admin user profile unrelated Shared Measure selections', () => {
+    let firstMeasureName = ''
+    let secondMeasureName = ''
+    let firstLibraryName = ''
+    let secondLibraryName = ''
+    let profileUser = ''
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        firstMeasureName = `AdminProfileSharedOne${uniqueSuffix}`
+        secondMeasureName = `AdminProfileSharedTwo${uniqueSuffix}`
+        firstLibraryName = `AdminProfileSharedLibOne${uniqueSuffix}`
+        secondLibraryName = `AdminProfileSharedLibTwo${uniqueSuffix}`
+        profileUser = OktaLogin.getUser(true)
+
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            firstMeasureName,
+            firstLibraryName,
+            MeasureCQL.CQL_For_Cohort,
+            0
+        )
+        CreateMeasurePage.CreateQICoreMeasureAPI(
+            secondMeasureName,
+            secondLibraryName,
+            MeasureCQL.CQL_For_Cohort,
+            1
+        )
+        ;[0, 1].forEach((measureNumber) => {
+            TestData.readMeasureId(measureNumber).then((measureId) => {
+                TestData.requestSharePermissions('measure', 'GRANT', measureId, profileUser).then((response) => {
+                    expect(response.status).to.eq(200)
+                })
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileUser)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+    })
+
+    afterEach(() => {
+        Utilities.deleteMeasure(undefined, undefined, false, false, 0)
+        Utilities.deleteMeasure(undefined, undefined, false, false, 1)
+    })
+
+    it('disables actions when two unrelated Shared Measures are selected', () => {
+        AdminUserProfilePage.selectMeasureByName(firstMeasureName)
+        AdminUserProfilePage.selectMeasureByName(secondMeasureName)
+
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.exportButton,
+            AdminUserProfilePage.exportTooltip,
+            'Select measure to export'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.humanReadableButton,
+            AdminUserProfilePage.humanReadableTooltip,
+            'Select measure to view human readable'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.historyButton,
+            AdminUserProfilePage.historyTooltip,
+            'Select a measure to view history'
+        )
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.compareVersionsButton,
+            AdminUserProfilePage.compareVersionsTooltip,
+            'Select 2 instances within the same measure set to compare measure versions'
+        )
+    })
+})


### PR DESCRIPTION
## Summary

Adds Cypress automation coverage for MAT-9813 Admin User Profile measure actions on the Owned Measures and Shared Measures tabs.

The tests cover QI-Core and QDM measures, including export, Human Readable, measure history, and version comparison behavior.

## Changes

- Added a reusable `AdminUserProfilePage` page object.
- Added reliable direct navigation to `/admin`.
- Added exact Admin user-profile route and table-readiness assertions.
- Added Owned Measures action coverage.
- Added Shared Measures action coverage.
- Added QDM-specific action coverage.
- Added Owned and Shared Compare Measure Versions coverage.
- Added API-isolated measure creation, sharing, versioning, drafting, and cleanup.
- Added selection boundary coverage for:
  - No selected measures
  - One selected measure
  - Two unrelated measures
  - Two instances from the same measure set
  - Three instances from the same measure set
- Added tooltip assertions without viewport movement.
- Verified Admin export history attribution.

## Acceptance Criteria Covered

- Export, View Human Readable, and View History enabled for one selection.
- Single-measure actions disabled for zero or multiple selections.
- Compare enabled for exactly two instances from the same measure set.
- Compare disabled for unrelated measures or more than two same-set instances.
- Export menu contains:
  - Export
  - Export for Publishing
- Export and Export for Publishing complete successfully.
- Export history contains `EXPORTED_MEASURE` and `by MADiE Admin`.
- Human Readable dialog opens.
- Measure History dialog opens.
- Compare Measure Versions dialog opens.
- Owned and Shared Measures are covered.
- QI-Core and QDM measures are represented.

## Technical Notes

- UI interactions remain in the Admin profile page object.
- Measure lifecycle and sharing setup reuse existing API helpers.
- Generated measures are selected by name or ID instead of table position.
- No fixed waits, forced interactions, or broad exception suppression were added.
- The suites currently use `describe.skip` because `AdminUserProfile` is not available in TEST.
- Each skip includes a MAT-9813 note describing when it should be removed.

## Testing

Complete MAT-9813 suite against DEV:

- `AdminUserProfileMeasureActions.cy.ts`: 8 passing
- `AdminUserProfileSharedMeasureActions.cy.ts`: 6 passing
- `AdminUserProfileCompareMeasureVersions.cy.ts`: 3 passing
- `AdminUserProfileQdmMeasureActions.cy.ts`: 3 passing

Overall result: **20 passing tests across four specs**

Additional validation:

- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`

## Risk

Low. Changes are isolated to new Cypress automation and a new Admin User Profile page object.

The tests remain skipped outside DEV until the `AdminUserProfile` feature is available in TEST.

## Documentation

Documentation Updates: None