### PR TITLE
MAT-9810 add admin library search tests

### DIFF
--- a/cypress/Shared/AdminUserProfilePage.ts
+++ b/cypress/Shared/AdminUserProfilePage.ts
@@ -11,6 +11,10 @@ export class AdminUserProfilePage {
     public static readonly ownedLibrariesTab = CQLLibraryPage.ownedLibrariesTab
     public static readonly sharedLibrariesTab = CQLLibraryPage.sharedLibrariesTab
     public static readonly librariesTable = '[data-testid="user-profile-libraries-tbl"]'
+    public static readonly librarySearchInput = '[data-testid="user-profile-measures-list-search-input"]'
+    public static readonly libraryClearSearch = '[data-testid="user-profile-measures-clear-search"]'
+    public static readonly libraryFilterBy = '[data-testid="filter-by-select"]'
+    public static readonly libraryFilterByInput = '[data-testid="filter-by-select-input"]'
 
     public static readonly exportButton = '[data-testid="export-action-btn"]'
     public static readonly humanReadableButton = '[data-testid="view-hr-action-btn"]'
@@ -94,6 +98,38 @@ export class AdminUserProfilePage {
         cy.get(tabSelector).should('be.visible').click()
         cy.get(tabSelector).should('have.attr', 'aria-selected', 'true')
         cy.get(this.librariesTable).should('be.visible')
+    }
+
+    public static assertLibrarySearchControls(): void {
+        cy.get(this.librarySearchInput).should('be.visible').and('be.enabled')
+        cy.get(this.libraryFilterBy).should('be.visible')
+    }
+
+    public static assertLibraryFilterOptions(): void {
+        cy.get(this.libraryFilterBy).click()
+        cy.get('[role="listbox"]').should('be.visible').find('[role="option"]').then(($options) => {
+            const options = [...$options].map((option) => option.textContent?.trim())
+            expect(options).to.deep.eq(['-', 'Library', 'Version', 'Model'])
+        })
+        cy.get('body').type('{esc}')
+    }
+
+    public static selectLibraryFilter(option: 'Library' | 'Version' | 'Model'): void {
+        cy.get(this.libraryFilterBy).should('be.visible').click()
+        cy.get(`li[data-value="${option}"]`).should('be.visible').click()
+        cy.get(this.libraryFilterBy).should('contain.text', option)
+    }
+
+    public static submitLibrarySearch(searchText: string): void {
+        cy.get(this.librarySearchInput).clear().type(`${searchText}{enter}`)
+    }
+
+    public static clearLibrarySearch(): void {
+        cy.get(this.libraryClearSearch)
+            .should('be.visible')
+            .find('button')
+            .should('be.enabled')
+            .click()
     }
 
     public static findLibraryRow(libraryName: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileLibrarySearch.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileLibrarySearch.cy.ts
@@ -1,0 +1,203 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CQLLibraryPage } from '../../../Shared/CQLLibraryPage'
+import { Environment } from '../../../Shared/Environment'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { TestData } from '../../../Shared/TestData'
+import { SupportedModels } from '../../../Shared/CreateMeasurePage'
+
+type LibraryOwnershipType = 'OWNED' | 'SHARED'
+
+// MAT-9810: Enable when the AdminUserProfile feature is available in TEST.
+describe.skip('Admin user profile library search and filtering', () => {
+    let targetLibraryName = ''
+    let controlLibraryName = ''
+    let libraryOwner = ''
+    let sharedProfileUser = ''
+
+    const searchInput = AdminUserProfilePage.librarySearchInput
+    const filterByDropdown = AdminUserProfilePage.libraryFilterBy
+
+    const interceptProfileLibraries = (
+        alias: string,
+        profileUser: string,
+        ownershipType: LibraryOwnershipType
+    ): void => {
+        cy.intercept({
+            pathname: `/api/cql-libraries/admin/userProfile/${profileUser}/searches`,
+            query: { ownershipType }
+        }).as(alias)
+    }
+
+    const shareLibraryWithProfileUser = (libraryNumber: number): void => {
+        TestData.readCqlLibraryId(libraryNumber).then((libraryId) => {
+            TestData.requestSharePermissions('library', 'GRANT', libraryId, sharedProfileUser).then(
+                (response) => {
+                    expect(response.status).to.eq(200)
+                    expect(response.body[libraryId][0].userId).to.eq(sharedProfileUser)
+                    expect(response.body[libraryId][0].roles).to.include('SHARED_WITH')
+                }
+            )
+        })
+    }
+
+    const openLibrariesForProfile = (
+        profileUser: string,
+        ownershipType: LibraryOwnershipType
+    ): void => {
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileUser)
+
+        const tab = ownershipType === 'OWNED'
+            ? AdminUserProfilePage.ownedLibrariesTab
+            : AdminUserProfilePage.sharedLibrariesTab
+
+        interceptProfileLibraries('profileLibraries', profileUser, ownershipType)
+
+        AdminUserProfilePage.openLibrariesTab(tab)
+        cy.wait('@profileLibraries').its('response.statusCode').should('eq', 200)
+        AdminUserProfilePage.assertLibrarySearchControls()
+        AdminUserProfilePage.assertLibraryFilterOptions()
+    }
+
+    const submitSearch = (
+        profileUser: string,
+        ownershipType: LibraryOwnershipType,
+        searchText: string
+    ): void => {
+        interceptProfileLibraries('searchedProfileLibraries', profileUser, ownershipType)
+
+        AdminUserProfilePage.submitLibrarySearch(searchText)
+        cy.wait('@searchedProfileLibraries').its('response.statusCode').should('eq', 200)
+    }
+
+    const selectFilter = (option: 'Library' | 'Version' | 'Model'): void => {
+        AdminUserProfilePage.selectLibraryFilter(option)
+    }
+
+    const clearSearchWithX = (
+        profileUser: string,
+        ownershipType: LibraryOwnershipType
+    ): void => {
+        interceptProfileLibraries('clearedProfileLibraries', profileUser, ownershipType)
+
+        AdminUserProfilePage.clearLibrarySearch()
+        cy.wait('@clearedProfileLibraries').then(({ request, response }) => {
+            expect(response?.statusCode).to.eq(200)
+            expect(request.query).not.to.have.property('searchField')
+            expect(request.query).not.to.have.property('optionalSearchProperties')
+        })
+    }
+
+    const assertOnlyTargetLibraryIsDisplayed = (): void => {
+        AdminUserProfilePage.findLibraryRow(targetLibraryName).should('be.visible')
+        cy.get(AdminUserProfilePage.librariesTable).should('not.contain.text', controlLibraryName)
+    }
+
+    const assertNoResults = (): void => {
+        cy.get(AdminUserProfilePage.librariesTable).should('contain.text', 'No results were found')
+    }
+
+    const assertEveryDisplayedLibraryHasModel = (model: string): void => {
+        cy.get(`${AdminUserProfilePage.librariesTable} tbody tr`)
+            .should('have.length.greaterThan', 0)
+            .should(($rows) => {
+                $rows.each((_, row) => {
+                    expect(Cypress.$(row).find('td').eq(4).text()).to.include(model)
+                })
+            })
+    }
+
+    const assertEveryDisplayedLibraryVersionContains = (searchText: string): void => {
+        cy.get(`${AdminUserProfilePage.librariesTable} tbody tr`)
+            .should('have.length.greaterThan', 0)
+            .should(($rows) => {
+                $rows.each((_, row) => {
+                    expect(Cypress.$(row).find('td').eq(2).text()).to.include(searchText)
+                })
+            })
+    }
+
+    const verifySearchBehavior = (
+        profileUser: string,
+        ownershipType: LibraryOwnershipType
+    ): void => {
+        openLibrariesForProfile(profileUser, ownershipType)
+
+        // Unfiltered searches cover every verifiable CQL Library field named in the AC.
+        submitSearch(profileUser, ownershipType, targetLibraryName.slice(0, -4))
+        assertOnlyTargetLibraryIsDisplayed()
+
+        submitSearch(profileUser, ownershipType, '0.0')
+        assertEveryDisplayedLibraryVersionContains('0.0')
+
+        submitSearch(profileUser, ownershipType, 'QI-Core v4')
+        assertEveryDisplayedLibraryHasModel('QI-Core v4.1.1')
+
+        submitSearch(profileUser, ownershipType, 'MAT9810NoMatchingLibrary')
+        assertNoResults()
+
+        selectFilter('Library')
+        submitSearch(profileUser, ownershipType, targetLibraryName.slice(0, -4))
+        assertOnlyTargetLibraryIsDisplayed()
+
+        selectFilter('Version')
+        submitSearch(profileUser, ownershipType, '0.0')
+        assertEveryDisplayedLibraryVersionContains('0.0')
+
+        selectFilter('Model')
+        submitSearch(profileUser, ownershipType, 'QI-Core v4')
+        assertEveryDisplayedLibraryHasModel('QI-Core v4.1.1')
+
+        submitSearch(profileUser, ownershipType, 'MAT9810NoMatchingModel')
+        assertNoResults()
+
+        // A matching Library value must not match when the search is restricted to Model.
+        submitSearch(profileUser, ownershipType, targetLibraryName)
+        assertNoResults()
+
+        clearSearchWithX(profileUser, ownershipType)
+
+        cy.get(searchInput).should('have.value', '')
+        cy.get(AdminUserProfilePage.libraryFilterByInput).should('have.value', '')
+        cy.get(filterByDropdown).should('contain.text', 'Filter By')
+        cy.get(`${AdminUserProfilePage.librariesTable} tbody tr`)
+            .should('have.length.greaterThan', 0)
+        cy.get(AdminUserProfilePage.librariesTable).should('not.contain.text', 'No results were found')
+    }
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        const credentials = Environment.credentials()
+        targetLibraryName = `MAT9810Target${uniqueSuffix}`
+        controlLibraryName = `MAT9810Control${uniqueSuffix}`
+
+        libraryOwner = CQLLibraryPage.createLibraryAPI(targetLibraryName, SupportedModels.qiCore4)
+        CQLLibraryPage.createLibraryAPI(controlLibraryName, SupportedModels.QDM, { libraryNumber: 1 })
+        sharedProfileUser = [credentials.harpUser2, credentials.harpUser3, credentials.altHarpUser]
+            .map((user) => user?.toLowerCase() ?? '')
+            .find((user) => user && user !== libraryOwner) ?? ''
+
+        expect(libraryOwner, 'selected library owner').not.to.be.empty
+        expect(sharedProfileUser, 'selected shared profile user').not.to.be.empty
+        expect(sharedProfileUser, 'shared profile user differs from library owner').not.to.eq(libraryOwner)
+        shareLibraryWithProfileUser(0)
+        shareLibraryWithProfileUser(1)
+    })
+
+    afterEach(() => {
+        TestData.setupUserScope()
+        ;[1, 0].forEach((libraryNumber) => {
+            TestData.readCqlLibraryId(libraryNumber).then((libraryId) => {
+                TestData.requestCqlLibraryById('DELETE', libraryId, { failOnStatusCode: false })
+            })
+        })
+    })
+
+    it('searches and filters the selected user\'s Owned Libraries', () => {
+        verifySearchBehavior(libraryOwner, 'OWNED')
+    })
+
+    it('searches and filters the selected user\'s Shared Libraries', () => {
+        verifySearchBehavior(sharedProfileUser, 'SHARED')
+    })
+})


### PR DESCRIPTION
## Summary

Adds Cypress coverage for MAT-9810 library search and filtering on the Admin User Profile Owned Libraries and Shared Libraries tabs.

## Changes

- Added search and Filter By coverage for Owned Libraries and Shared Libraries.
- Validated the supported Filter By options:
  - Library
  - Version
  - Model
- Added unfiltered partial-match searches across library name, version, and model.
- Added column-restricted searches for Library, Version, and Model.
- Added explicit filtered and unfiltered no-results coverage.
- Added coverage confirming that searching a library name with the Model filter does not return a result.
- Added coverage confirming that the Search X:
  - clears the Search field
  - clears Filter By
  - submits an unfiltered request
  - restores the library grid
- Added reusable Admin User Profile page-object actions for library search controls.
- Reused existing API library creation, sharing, user allocation, and cleanup helpers.

## Technical Notes

- Libraries do not have CMS IDs. Product confirmed the CMS ID reference in the original acceptance criteria was a copy/paste error.
- The test expects the library Filter By menu to contain only Library, Version, and Model, plus the `-` unfiltered option.
- The spec remains skipped because the `AdminUserProfile` feature is not currently available in TEST.

## Testing

Static validation:

- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`

Focused DEV validation:

```bash
SPEC='cypress/e2e/WebInterface/Admin/AdminUserProfileLibrarySearch.cy.ts' npm run dev:specific:file