### PR TITLE
MAT-9815 add admin profile measure transfer tests

### DIFF
--- a/cypress/Shared/AdminUserProfilePage.ts
+++ b/cypress/Shared/AdminUserProfilePage.ts
@@ -20,11 +20,13 @@ export class AdminUserProfilePage {
     public static readonly humanReadableButton = '[data-testid="view-hr-action-btn"]'
     public static readonly historyButton = '[data-testid="history-action-btn"]'
     public static readonly compareVersionsButton = MeasuresPage.compareVersionsBtn
+    public static readonly transferButton = '[data-testid="transfer-action-btn"]'
 
     public static readonly exportTooltip = '[data-testid="export-action-tooltip"]'
     public static readonly humanReadableTooltip = '[data-testid="view-hr-action-tooltip"]'
     public static readonly historyTooltip = '[data-testid="history-action-tooltip"]'
     public static readonly compareVersionsTooltip = '[data-testid="compare-versions-action-tooltip"]'
+    public static readonly transferTooltip = '[data-testid="transfer-action-tooltip"]'
 
     public static openAdminWorkspace(): void {
         cy.visit('/admin')

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileMeasureTransfer.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileMeasureTransfer.cy.ts
@@ -1,0 +1,234 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { Environment } from '../../../Shared/Environment'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { TestData } from '../../../Shared/TestData'
+import { Utilities } from '../../../Shared/Utilities'
+
+const assertTransferDialog = (
+    measureName: string,
+    model: string,
+    currentOwner: string,
+    selectedMeasureCount = 1
+): void => {
+    cy.get('[role="dialog"]')
+        .should('be.visible')
+        .within(() => {
+            cy.contains('h2', 'Transfer Measure Ownership').should('be.visible')
+            cy.get('.transfer-dialog-info-text').should(
+                'contain.text',
+                `You are about to Transfer ownership of the ${selectedMeasureCount} selected measure(s) below. All versions and drafts will be transferred, but only the most recent measure name appears in the list below.`
+            )
+            ;['Measure', 'Model', 'CMS ID', 'Current Measure Owner'].forEach((columnName) => {
+                cy.contains(columnName).should('be.visible')
+            })
+
+            cy.contains(measureName).should('be.visible')
+            cy.contains(model).should('be.visible')
+            cy.contains(currentOwner).should('be.visible')
+            cy.contains('label', 'New Measure Owner').should('contain.text', '*')
+            cy.get(MeasuresPage.newOwnerTextbox).should('be.visible').and('have.value', '')
+            cy.get('[data-testid="retainShareAccess"] input[type="checkbox"]').should('not.be.checked')
+            cy.contains('Retain Share Access after Transfer').should('be.visible')
+            cy.contains('button', 'Cancel').should('be.enabled')
+            cy.get(MeasuresPage.transferContinueButton).should('be.disabled')
+
+            cy.get(MeasuresPage.paginationLimitSelect).should('contain.text', '5').click()
+        })
+    ;['5', '10', '25', '50'].forEach((pageSize) => {
+        cy.get(`[role="option"][data-value="${pageSize}"]`).should('be.visible')
+    })
+    cy.get('body').type('{esc}')
+}
+
+// MAT-9815: Enable when the AdminUserProfile feature is available in TEST.
+describe.skip('Admin user profile Measure Transfer', () => {
+    let measureName = ''
+    let cqlLibraryName = ''
+    let measureOwner = ''
+    let newOwner = ''
+    let hasSecondMeasure = false
+
+    beforeEach(() => {
+        const uniqueSuffix = Date.now()
+        measureName = `AdminProfileTransfer${uniqueSuffix}`
+        cqlLibraryName = `AdminProfileTransferLib${uniqueSuffix}`
+        measureOwner = OktaLogin.getUser(false)
+        newOwner = OktaLogin.getUser(true)
+        hasSecondMeasure = false
+    })
+
+    afterEach(() => {
+        // Transfer changes the fixture owner, so use the admin deletion path for reliable cleanup.
+        Utilities.deleteVersionedMeasure()
+        if (hasSecondMeasure) {
+            Utilities.deleteVersionedMeasure(undefined, undefined, false, false, 1)
+        }
+    })
+
+    it('disables Transfer on Owned and Shared Measures when no measure is selected', () => {
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, MeasureCQL.CQL_For_Cohort)
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', measureId, newOwner).then((response) => {
+                expect(response.status).to.eq(200)
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(measureOwner)
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.transferButton,
+            AdminUserProfilePage.transferTooltip,
+            'Select a measure to transfer'
+        )
+
+        AdminUserProfilePage.openUserProfile(newOwner)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+        AdminUserProfilePage.assertDisabledAction(
+            AdminUserProfilePage.transferButton,
+            AdminUserProfilePage.transferTooltip,
+            'Select a measure to transfer'
+        )
+    })
+
+    it('opens the Transfer dialog for an Owned QI-Core Measure and allows cancellation', () => {
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, MeasureCQL.CQL_For_Cohort)
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(measureOwner)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.transferButton,
+            AdminUserProfilePage.transferTooltip,
+            'Transfer'
+        )
+        cy.get(AdminUserProfilePage.transferButton).click()
+
+        assertTransferDialog(measureName, 'QI-Core', measureOwner)
+        cy.get('[role="dialog"]').contains('button', 'Cancel').click()
+        cy.get('[role="dialog"]').should('not.exist')
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, measureName).should('be.visible')
+    })
+
+    it('opens the Transfer dialog for a Shared QDM Measure with the actual owner', () => {
+        CreateMeasurePage.CreateQDMMeasureAPI(measureName, cqlLibraryName, MeasureCQL.returnBooleanPatientBasedQDM_CQL)
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', measureId, newOwner).then((response) => {
+                expect(response.status).to.eq(200)
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(newOwner)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+        AdminUserProfilePage.assertEnabledAction(
+            AdminUserProfilePage.transferButton,
+            AdminUserProfilePage.transferTooltip,
+            'Transfer'
+        )
+        cy.get(AdminUserProfilePage.transferButton).click()
+
+        assertTransferDialog(measureName, 'QDM', measureOwner)
+    })
+
+    it('lists multiple selected measures and their CMS ID in the Transfer dialog', () => {
+        const secondMeasureName = measureName.replace('AdminProfileTransfer', 'AlternateProfileMeasure')
+        const secondLibraryName = cqlLibraryName.replace('AdminProfileTransferLib', 'AlternateProfileLibrary')
+        hasSecondMeasure = true
+
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, MeasureCQL.CQL_For_Cohort)
+        CreateMeasurePage.CreateQICoreMeasureAPI(secondMeasureName, secondLibraryName, MeasureCQL.CQL_For_Cohort, 1)
+        TestData.readMeasureSetId().then((measureSetId) => {
+            TestData.requestWithAccessToken<{ cmsId: string }>({
+                method: 'PUT',
+                url: `/api/measures/${measureSetId}/create-cms-id`
+            }).then((response) => {
+                expect(response.status).to.eq(201)
+                expect(response.body.cmsId).to.exist
+                cy.wrap(String(response.body.cmsId)).as('cmsId')
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(measureOwner)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+        cy.get(AdminUserProfilePage.transferButton).should('be.enabled')
+        AdminUserProfilePage.selectMeasureByName(secondMeasureName)
+        cy.get(AdminUserProfilePage.transferButton).should('be.enabled').click()
+
+        assertTransferDialog(measureName, 'QI-Core', measureOwner, 2)
+        cy.get('[role="dialog"]').within(() => {
+            cy.contains(secondMeasureName).should('be.visible')
+            cy.contains('QI-Core').should('be.visible')
+            cy.get<string>('@cmsId').then((cmsId) => {
+                cy.contains(cmsId).should('be.visible')
+            })
+        })
+    })
+
+    it('transfers an Owned Measure to the selected user', () => {
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, MeasureCQL.CQL_For_Cohort)
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(measureOwner)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+        cy.get(AdminUserProfilePage.transferButton).should('be.enabled').click()
+
+        cy.get(MeasuresPage.newOwnerTextbox).type(newOwner)
+        cy.get(MeasuresPage.transferContinueButton).should('be.enabled')
+        cy.intercept('PUT', '**/api/measures/transfer?retainShareAccess=false').as('transferMeasure')
+        cy.get(MeasuresPage.transferContinueButton).click()
+        cy.wait('@transferMeasure').then(({ request, response }) => {
+            expect(response?.statusCode).to.eq(200)
+            expect(request.headers.harpid).to.eq(newOwner)
+            TestData.readMeasureId().then((measureId) => {
+                expect(request.body).to.deep.eq([measureId])
+            })
+        })
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, measureName).should('not.exist')
+
+        AdminUserProfilePage.openUserProfile(newOwner)
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, measureName).should('be.visible')
+    })
+
+    it('transfers a Shared Measure and retains access for the former owner', () => {
+        const sharedProfileUser = Environment.credentials().adminUser?.toLowerCase() ?? ''
+        expect(sharedProfileUser, 'configured Admin profile user').not.to.be.empty
+
+        CreateMeasurePage.CreateQDMMeasureAPI(measureName, cqlLibraryName, MeasureCQL.returnBooleanPatientBasedQDM_CQL)
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', measureId, sharedProfileUser).then((response) => {
+                expect(response.status).to.eq(200)
+            })
+        })
+
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(sharedProfileUser)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+        AdminUserProfilePage.selectMeasureByName(measureName)
+        cy.get(AdminUserProfilePage.transferButton).should('be.enabled').click()
+
+        cy.get(MeasuresPage.newOwnerTextbox).type(newOwner)
+        cy.get('[data-testid="retainShareAccess"] input[type="checkbox"]').check()
+        cy.get(MeasuresPage.transferContinueButton).should('be.enabled')
+        cy.intercept('PUT', '**/api/measures/transfer?retainShareAccess=true').as('transferSharedMeasure')
+        cy.get(MeasuresPage.transferContinueButton).click()
+        cy.wait('@transferSharedMeasure').then(({ request, response }) => {
+            expect(response?.statusCode).to.eq(200)
+            expect(request.headers.harpid).to.eq(newOwner)
+            TestData.readMeasureId().then((measureId) => {
+                expect(request.body).to.deep.eq([measureId])
+            })
+        })
+
+        AdminUserProfilePage.openUserProfile(newOwner)
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, measureName).should('be.visible')
+
+        AdminUserProfilePage.openUserProfile(measureOwner)
+        AdminUserProfilePage.openMeasuresTab(MeasuresPage.sharedMeasures)
+        cy.contains(`${AdminUserProfilePage.measuresTable} tbody td`, measureName).should('be.visible')
+    })
+})


### PR DESCRIPTION
## Summary

Adds Cypress coverage for MAT-9815, allowing Admin users to transfer measures from the Owned Measures and Shared Measures tabs of the Admin User Profile screen.

## Changes

- Added reusable Admin User Profile selectors for the Transfer action and tooltip.
- Added coverage for disabled and enabled Transfer states on Owned and Shared Measures.
- Verified the Transfer dialog:
  - Title and informational text
  - Selected-measure count
  - Measure, Model, CMS ID, and Current Measure Owner data
  - Pagination default and available page sizes
  - Required New Measure Owner field
  - Retain Share Access default state
  - Cancel and Transfer button states
- Added QI-Core and QDM coverage.
- Added multi-measure selection and populated CMS ID coverage.
- Verified successful transfers from both Owned and Shared Measures.
- Verified Retain Share Access behavior after transfer.
- Added admin-based cleanup because transferred measures are no longer owned by the original fixture user.
- Ticket-gated the suite until the `AdminUserProfile` feature is enabled in TEST.

## Technical Notes

- Reuses the existing `AdminUserProfilePage`, `MeasuresPage`, `TestData`, and measure-creation helpers.
- Uses API setup before Admin UI validation.
- Verifies transfer requests by status, target HARP ID, selected measure IDs, and resulting profile ownership.
- Uses distinct generated measure names to ensure name-based row selection targets separate measures.

## Testing

Full focused DEV run:

```text
Tests:    6
Passing:  6
Failing:  0
Duration: 3m 14s