### PR TITLE
Weekly regression fixes

### DIFF
--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -1020,7 +1020,7 @@ export class TestCasesPage {
       this.normalizeExpectedActualPopulationPanel()
 
       if (clearFirst) {
-        getInput().clear({ scrollBehavior: false }).type(value, { scrollBehavior: false })
+        getInput().type(`{selectAll}{backspace}${value}`, { scrollBehavior: false })
       } else {
         getInput().type(value, { scrollBehavior: false })
       }
@@ -1143,8 +1143,7 @@ export class TestCasesPage {
     cy.get(selector, { timeout: 20000 })
       .should('be.visible')
       .should('be.enabled')
-      .clear()
-      .type(value)
+      .type(`{selectAll}{backspace}${value}`, { delay: 0 })
     cy.get(selector).should('have.value', value).blur()
   }
 

--- a/cypress/e2e/Services/CQL Library Service/CreateCQL-Library.cy.ts
+++ b/cypress/e2e/Services/CQL Library Service/CreateCQL-Library.cy.ts
@@ -1,9 +1,5 @@
-import { CQLLibraryPage } from "../../../Shared/CQLLibraryPage"
-import {
-    CqlLibraryBody,
-    CqlLibrarySearchResponse,
-    TestData
-} from "../../../Shared/TestData"
+import { CQLLibraryPage } from '../../../Shared/CQLLibraryPage'
+import { CqlLibraryBody, CqlLibrarySearchResponse, TestData } from '../../../Shared/TestData'
 
 const defaultModel = 'QI-Core v4.1.1'
 
@@ -82,11 +78,26 @@ describe('CQL Library Service: Create CQL Library', () => {
     })
 
     it('Get specific CQL Library', () => {
-        TestData.readCqlLibrary().then((response) => {
-            expect(response.status).to.eql(200)
-            expect(response.body).to.not.be.null
-            expect(response.body.id).to.be.exist
+        const cqlLibraryName = `GetSpecificCqlLibrary${Date.now()}`
+        let cqlLibraryId = ''
+
+        requestCreateLibrary({
+            cqlLibraryName,
+            createdBy: harpUser
         })
+            .then((createResponse) => {
+                expect(createResponse.status).to.eql(201)
+                expect(createResponse.body.id).to.be.exist
+                cqlLibraryId = createResponse.body.id!
+
+                return TestData.requestCqlLibraryById<CqlLibraryBody>('GET', cqlLibraryId)
+            })
+            .then((response) => {
+                expect(response.status).to.eql(200)
+                expect(response.body).to.not.be.null
+                expect(response.body.id).to.eql(cqlLibraryId)
+                expect(response.body.cqlLibraryName).to.eql(cqlLibraryName)
+            })
     })
 
     it('Get All CQL Libraries created by logged in User', () => {
@@ -184,7 +195,9 @@ describe('CQL Library Name validations', () => {
             { failOnStatusCode: false }
         ).then((response) => {
             expect(response.status).to.eql(400)
-            expect(response.body.validationErrors.cqlLibraryName).to.eql('Library name cannot be more than 64 characters.')
+            expect(response.body.validationErrors.cqlLibraryName).to.eql(
+                'Library name cannot be more than 64 characters.'
+            )
         })
     })
 

--- a/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/EditMeasure/CQLChanges.cy.ts
@@ -96,11 +96,11 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             TestCasesPage.clickEditforCreatedTestCase()
 
             //click on Expected/Actual tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            TestCasesPage.openExpectedActualTab()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
             //Click on RunTest Button
-            cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
+            TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', {
+                clearFirst: true
+            })
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
             cy.get(TestCasesPage.runTestButton).should('exist')
             cy.get(TestCasesPage.runTestButton).should('be.visible')
@@ -275,12 +275,12 @@ describe('CQL Changes and how that impacts test cases, observations and populati
             TestCasesPage.clickEditforCreatedTestCase()
 
             //click on Expected/Actual tab
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('exist')
-            cy.get(TestCasesPage.tctExpectedActualSubTab).should('be.visible')
-            TestCasesPage.openExpectedActualTab()
+            TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
 
             //Click on RunTest Button
-            cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
+            TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', {
+                clearFirst: true
+            })
             cy.get(TestCasesPage.editTestCaseSaveButton).click()
             Utilities.waitForElementDisabled(TestCasesPage.editTestCaseSaveButton, 21500)
             cy.get(TestCasesPage.runTestButton).should('exist')

--- a/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore411.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/MeasureAssociation/MeasureAssociationMetaDataQiCore411.cy.ts
@@ -84,6 +84,13 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogCancel, 3500)
         Utilities.waitForElementVisible(EditMeasurePage.cmsIDDialogContinue, 3500)
         cy.get(EditMeasurePage.cmsIDDialogContinue).click()
+        cy.get(EditMeasurePage.cmsIdInput)
+            .should('be.visible')
+            .invoke('val')
+            .then((cmsId) => {
+                expect(cmsId).to.be.a('string').and.not.be.empty
+                newQDMMeasureSetID = cmsId as string
+            })
 
         //Save Endorsement Organization
         cy.get(EditMeasurePage.endorsingOrganizationTextBox).click()
@@ -213,10 +220,12 @@ describe('Measure Association: Transferring meta data and CMS ID from QDM to QI 
         cy.get(EditMeasurePage.associateCmsAssociateBtn).click()
         cy.get(EditMeasurePage.sureDialogContinueBtn).click()
 
+        cy.get(Header.mainMadiePageButton).click()
         MeasuresPage.actionCenter('edit', 2)
 
         //confirming the cms id on the QI Core measure
         cy.get(EditMeasurePage.cmsIdInput)
+            .should('be.visible')
             .invoke('val')
             .then((val) => {
                 expect(val).to.contain(newQDMMeasureSetID + 'FHIR')

--- a/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
+++ b/cypress/e2e/WebInterface/Measure/QDMMeasureGroup/QDMPopulationCriteriaPage.cy.ts
@@ -20,7 +20,6 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
     const measureData: CreateMeasureOptions = {}
 
     beforeEach('Create Measure and login', () => {
-
         newMeasureName = measureName + Date.now()
         newCqlLibraryName = CqlLibraryName + Date.now()
 
@@ -38,7 +37,6 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
     })
 
     afterEach('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
@@ -77,7 +75,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         cy.get(MeasureGroupPage.QDMAddPopCriteriaBtn).click()
@@ -110,7 +108,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should('exist')
         cy.get(MeasureGroupPage.successfulSaveMeasureGroupMsg).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         //navigate away from measure group page
@@ -172,7 +170,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.rateAggregation).should('contain.text', 'Aggregation')
         cy.get(MeasureGroupPage.improvementNotationSelect).should(
             'contain.text',
-            'Increased score indicates improvement',
+            'Increased score indicates improvement'
         )
 
         //Add Improvement Notation --'Decreased score indicates improvement'
@@ -200,7 +198,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.rateAggregation).should('contain.text', 'Aggregation')
         cy.get(MeasureGroupPage.improvementNotationSelect).should(
             'contain.text',
-            'Decreased score indicates improvement',
+            'Decreased score indicates improvement'
         )
 
         //Add Improvement Notation --'Other'
@@ -210,7 +208,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         Utilities.waitForElementDisabled(MeasureGroupPage.measureReportingSaveBtn, 30000)
 
         cy.get(MeasureGroupPage.improvementNotationDescText).type(
-            'This is the required text when IN is set to \"Other\"',
+            'This is the required text when IN is set to \"Other\"'
         )
 
         //save population definition with scoring unit
@@ -235,7 +233,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.improvementNotationSelect).should('contain.text', 'Other')
         cy.get(MeasureGroupPage.improvementNotationDescText).should(
             'contain.text',
-            'This is the required text when IN is set to \"Other\"',
+            'This is the required text when IN is set to \"Other\"'
         )
     })
 
@@ -293,7 +291,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.saveRiskAdjustments).click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Measure Risk Adjustments have been Saved Successfully',
+            'Measure Risk Adjustments have been Saved Successfully'
         )
 
         //click on the Supplemental Data button / link on the left page to populate fields on the right
@@ -308,7 +306,7 @@ describe('Validate QDM Population Criteria section -- scoring and populations', 
         cy.get(MeasureGroupPage.QDMSaveSupplementalDataElements).click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Measure Supplemental Data have been Saved Successfully',
+            'Measure Supplemental Data have been Saved Successfully'
         )
     })
 })
@@ -317,7 +315,6 @@ describe('No values in QDM PC fields, when no CQL', () => {
     const measureData: CreateMeasureOptions = {}
 
     beforeEach('Create Measure and login', () => {
-
         newMeasureName = measureName + Date.now()
         newCqlLibraryName = CqlLibraryName + Date.now()
 
@@ -360,7 +357,6 @@ describe('Save Population Criteria on QDM measure', () => {
     const measureData: CreateMeasureOptions = {}
 
     beforeEach('Create Measure and login', () => {
-
         newMeasureName = measureName + Date.now()
         newCqlLibraryName = CqlLibraryName + Date.now()
 
@@ -394,7 +390,7 @@ describe('Save Population Criteria on QDM measure', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).wait(2000).click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         cy.get(MeasureGroupPage.QDMAddPopCriteriaBtn).click()
@@ -408,7 +404,7 @@ describe('Save Population Criteria on QDM measure', () => {
         cy.get(MeasureGroupPage.saveMeasureGroupDetails).click()
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
     })
 })
@@ -417,7 +413,6 @@ describe('Validations: Population Criteria: Return Types -- Boolean', () => {
     const measureData: CreateMeasureOptions = {}
 
     beforeEach('Create Measure and login', () => {
-
         newMeasureName = measureName + Date.now()
         newCqlLibraryName = CqlLibraryName + Date.now()
 
@@ -434,7 +429,6 @@ describe('Validations: Population Criteria: Return Types -- Boolean', () => {
     })
 
     afterEach('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
@@ -459,7 +453,7 @@ describe('Validations: Population Criteria: Return Types -- Boolean', () => {
         Utilities.waitForElementVisible(EditMeasurePage.successMessage, 30000)
         cy.get(EditMeasurePage.successMessage).should(
             'contain.text',
-            'Population details for this group saved successfully.',
+            'Population details for this group saved successfully.'
         )
 
         Utilities.waitForElementVisible(MeasureGroupPage.initialPopulationSelect, 30000)
@@ -469,7 +463,7 @@ describe('Validations: Population Criteria: Return Types -- Boolean', () => {
         cy.get(MeasureGroupPage.QDMIPPCHelperText).should('be.visible')
         cy.get(MeasureGroupPage.QDMIPPCHelperText).should(
             'contain.text',
-            'For Patient-based Measures, selected definitions must return a Boolean.',
+            'For Patient-based Measures, selected definitions must return a Boolean.'
         )
     })
 })
@@ -478,7 +472,6 @@ describe('Validations: Population Criteria: Return Types -- Non-Boolean', () => 
     const measureData: CreateMeasureOptions = {}
 
     beforeEach('Create Measure and login', () => {
-
         newMeasureName = measureName + Date.now()
         newCqlLibraryName = CqlLibraryName + Date.now()
 
@@ -495,7 +488,6 @@ describe('Validations: Population Criteria: Return Types -- Non-Boolean', () => 
     })
 
     afterEach('Clean up and Logout', () => {
-
         Utilities.deleteMeasure()
     })
 
@@ -517,7 +509,7 @@ describe('Validations: Population Criteria: Return Types -- Non-Boolean', () => 
         cy.get(MeasureGroupPage.QDMIPPCHelperText).should('be.visible')
         cy.get(MeasureGroupPage.QDMIPPCHelperText).should(
             'contain.text',
-            'For Episode-based Measures, selected definitions must return a list of the same type (Non-Boolean)',
+            'For Episode-based Measures, selected definitions must return a list of the same type (Non-Boolean)'
         )
 
         //select a value that will return the correct boolean type

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithMO.cy.ts
@@ -106,17 +106,13 @@ describe('Measure Creation and Testing: CV Episode Measure With MO', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
-        cy.get(TestCasesPage.measureObservationRow).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1', { clearFirst: true })
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVEpisodeWithStratification.cy.ts
@@ -132,24 +132,17 @@ describe('Measure Creation and Testing: CV Episode Measure With Stratification',
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).click()
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
-        cy.get(TestCasesPage.measureObservationRow).type('2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '2', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.initialPopulationStratificationExpectedValue, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measurePopulationStratificationExpectedValue, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.initialPopulationStrata2ExpectedValue, '0', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measurePopulationStrata2ExpectedValue, '0', { clearFirst: true })
 
-        cy.get(TestCasesPage.initialPopulationStratificationExpectedValue).type('1')
-        cy.get(TestCasesPage.measurePopulationStratificationExpectedValue).type('1')
-        cy.get(TestCasesPage.initialPopulationStrata2ExpectedValue).type('0')
-        cy.get(TestCasesPage.measurePopulationStrata2ExpectedValue).type('0')
-
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
@@ -80,7 +80,7 @@ describe('Measure Creation and Testing: CV Patient With MO', () => {
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientBoolean.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientBoolean.cy.ts
@@ -53,9 +53,7 @@ describe('Measure Creation and Testing: Cohort Patient Boolean', () => {
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Test case updated successfully with warnings in JSON')
 

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CohortPatientWithStratification.cy.ts
@@ -96,9 +96,7 @@ describe('Measure Creation and Testing: Cohort Patient w/ Stratification', () =>
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.initialPopulationStratificationExpectedValue)
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVPatientWithStratification.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVPatientWithStratification.cy.ts
@@ -117,20 +117,18 @@ describe('Measure Creation and Testing: CV Patient Measure With Stratification',
 
         TestCasesPage.clickEditforCreatedTestCase()
 
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
-        cy.get(TestCasesPage.measureObservationRow).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1', { clearFirst: true })
 
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.initialPopulationStratificationExpectedValue)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.measurePopulationStratificationExpectedValue)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.initialPopulationStrata2ExpectedValue)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.measurePopulationStrata2ExpectedValue)
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(Toasts.otherSuccessToast).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRunExecuteTC.cy.ts
@@ -132,7 +132,7 @@ describe('Run / Execute Test case and verify passing percentage and coverage', (
         TestCasesPage.openTestCasesTab(TestCasesPage.newTestCaseButton)
         TestCasesPage.clickEditforCreatedTestCase()
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
+        TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.enabled')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/MeasureObservationExpectedValues.cy.ts
@@ -164,7 +164,7 @@ describe('Measure Observation Expected values', () => {
         cy.get(TestCasesPage.testCaseMSRPOPLExpected).should('be.checked')
 
         //Enter value in to Measure observation Expected values
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1.3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1.3', { clearFirst: true })
 
         //attempt to navigate away from the test case page
         cy.get(EditMeasurePage.measureGroupsTab).should('exist')
@@ -243,8 +243,8 @@ describe('Measure observation expected result', () => {
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseMSRPOPLExpected })
 
         //Enter values in to Measure population(MP) & Measure population exclusion(MPE) fields and verify MP-MPE = number of observation rows
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '5')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLEXExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '5', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLEXExpected, '1', { clearFirst: true })
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Observation 1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Observation 2')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Measure Observation 3')
@@ -328,15 +328,15 @@ describe('Measure observation expected result', () => {
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseDENOMExpected })
 
         //Enter values in to Denominator & Denominator exclusion(DE) fields and verify Denominator-DE = number of Denominator observation rows
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '4')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '4', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1', { clearFirst: true })
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Observation 1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Observation 2')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Denominator Observation 3')
 
         //Enter values in to Numerator & Numerator exclusion(NE) fields and verify Denominator-NE = number of Numerator observation rows
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '4')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMEXExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '4', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMEXExpected, '1', { clearFirst: true })
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Observation 1')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Observation 2')
         cy.get(TestCasesPage.testCasePopulationValuesTable).should('contain.text', 'Numerator Observation 3')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExecutionWithCode.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Execution/TestCaseExecutionWithCode.cy.ts
@@ -74,9 +74,7 @@ describe('Test Case Execution with codes', () => {
         TestCasesPage.clickExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.checked')
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.executionContextWarning).should(
             'have.text',

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/FluentFunction.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/FluentFunction.cy.ts
@@ -74,9 +74,7 @@ describe('Fluent Function Capability', () => {
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should('contain.text', 'Test case updated successfully ' +
             'with warnings in JSON')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ExpectedValuesForObservations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseExportImport/ExpectedValuesForObservations.cy.ts
@@ -87,12 +87,12 @@ describe('Ratio based measure with measure observations', () => {
         TestCasesPage.ValidateValueAddedToTestCaseJson('http://local/Encounter')
 
         // set expected values
-        TestCasesPage.openExpectedActualTab()
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '3')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '1')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '3', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '1', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', { clearFirst: true })
 
         // save - return to list
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -135,7 +135,7 @@ describe('Ratio based measure with measure observations', () => {
         cy.get(TestCasesPage.testCaseAction0Btn).click()
 
         // check expected values
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('have.value', '3')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('have.value', '1')
@@ -189,10 +189,10 @@ describe('Proportion based measure with no observations', () => {
         TestCasesPage.ValidateValueAddedToTestCaseJson('http://local/Encounter')
 
         // set expected values
-        TestCasesPage.openExpectedActualTab()
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '3')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '2')
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1')
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '3', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '2', { clearFirst: true })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1', { clearFirst: true })
 
         // save - return to list
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -234,7 +234,7 @@ describe('Proportion based measure with no observations', () => {
         cy.get(TestCasesPage.testCaseAction0Btn).click()
 
         // check expected values
-        TestCasesPage.openExpectedActualTab()
+        TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
 
         cy.get(TestCasesPage.testCaseIPPExpected).should('have.value', '3')
         cy.get(TestCasesPage.testCaseDENOMExpected).should('have.value', '2')

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/TestCaseJSON_TerminologyTests.cy.ts
@@ -5,12 +5,7 @@ import { TestCasesPage } from '../../../../Shared/TestCasesPage'
 import { EditMeasurePage } from '../../../../Shared/EditMeasurePage'
 import { TestCaseJson } from '../../../../Shared/TestCaseJson'
 import { Utilities } from '../../../../Shared/Utilities'
-import {
-    MeasureGroupPage,
-    MeasureScoring,
-    MeasureType,
-    PopulationBasis
-} from '../../../../Shared/MeasureGroupPage'
+import { MeasureGroupPage, MeasureScoring, MeasureType, PopulationBasis } from '../../../../Shared/MeasureGroupPage'
 import { MeasureCQL } from '../../../../Shared/MeasureCQL'
 import { Toasts } from '../../../../Shared/Toasts'
 

--- a/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QI-CORE Test Case/Validations/TestCaseValidations.cy.ts
@@ -8,27 +8,68 @@ import { MeasureCQL } from '../../../../../Shared/MeasureCQL'
 import { TestCasesPage } from '../../../../../Shared/TestCasesPage'
 import { TestCaseJson } from '../../../../../Shared/TestCaseJson'
 
-const now = Date.now()
-let measureName = 'TCValidations' + now
-let CqlLibraryName = 'TCValidationsLib' + now
-let testCaseTitle = 'test case title'
-let testCaseDescription = 'DENOMFail' + now
-let validTestCaseJson = TestCaseJson.TestCaseJson_Valid
-let measureCQL = MeasureCQL.ICFCleanTest_CQL
-let testCaseSeries = 'SBTestSeries'
-let twoFiftyTwoCharacters =
+let measureName: string
+let cqlLibraryName: string
+let testCaseDescription: string
+let updatedTestCaseDescription: string
+
+const testCaseTitle = 'test case title'
+const validTestCaseJson = TestCaseJson.TestCaseJson_Valid
+const measureCQL = MeasureCQL.ICFCleanTest_CQL
+const testCaseSeries = 'SBTestSeries'
+const twoFiftyTwoCharacters =
     'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqr'
-let updatedTestCaseDescription = testCaseDescription + ' ' + 'UpdatedTestCaseDescription'
-let updatedTestCaseSeries = 'CMSTestSeries'
+const updatedTestCaseSeries = 'CMSTestSeries'
+
+const initializeTestData = (): void => {
+    const suffix = `${Date.now()}${Cypress._.random(100000, 999999)}`
+    measureName = `TCValidations${suffix}`
+    cqlLibraryName = `TCValidationsLib${suffix}`
+    testCaseDescription = `DENOMFail${suffix}`
+    updatedTestCaseDescription = `${testCaseDescription} UpdatedTestCaseDescription`
+}
+
+const createMeasureViaApi = (cql = measureCQL): void => {
+    initializeTestData()
+    CreateMeasurePage.CreateQICoreMeasureAPI(measureName, cqlLibraryName, cql)
+}
+
+const createRatioMeasureViaApi = (): void => {
+    createMeasureViaApi(measureCQL)
+    MeasureGroupPage.CreateRatioMeasureGroupAPI(
+        false,
+        false,
+        'Surgical Absence of Cervix',
+        'Surgical Absence of Cervix',
+        'Surgical Absence of Cervix',
+        'Procedure'
+    )
+}
+
+const createCohortMeasureViaApi = (): void => {
+    createMeasureViaApi(measureCQL)
+    MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Procedure')
+}
+
+const createTestCaseViaApi = (jsonValue?: string, secondTestCase?: boolean): void => {
+    TestCasesPage.CreateTestCaseAPI(
+        secondTestCase ? 'SecondTestCase' : testCaseTitle,
+        secondTestCase ? 'SecondTestCaseGroup' : testCaseSeries,
+        testCaseDescription,
+        jsonValue,
+        false,
+        secondTestCase
+    )
+}
 
 describe('Create Test Case Validations', () => {
     beforeEach('Login', () => {
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
+        createMeasureViaApi()
         OktaLogin.Login()
     })
 
     afterEach('Logout', () => {
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
 
     it('Create Test Case: Description more than 250 characters', () => {
@@ -90,26 +131,24 @@ describe('Create Test Case Validations', () => {
 
 describe('Edit Test Case Validations', () => {
     beforeEach('Create measure, test case, and login', () => {
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName)
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
+        createMeasureViaApi()
+        createTestCaseViaApi(validTestCaseJson)
         OktaLogin.Login()
     })
 
     afterEach('Logout', () => {
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
 
     it('Edit Test Case: Description more than 250 characters', () => {
         MeasuresPage.actionCenter('edit')
         TestCasesPage.clickEditforCreatedTestCase()
         TestCasesPage.openDetailsTab(TestCasesPage.testCaseDescriptionTextBox)
-        cy.get(TestCasesPage.testCaseDescriptionTextBox).clear()
-        cy.get(TestCasesPage.testCaseDescriptionTextBox).type(twoFiftyTwoCharacters, { delay: 0 })
+        TestCasesPage.replaceTestCaseDetailsInput(TestCasesPage.testCaseDescriptionTextBox, twoFiftyTwoCharacters)
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
-        cy.get(TestCasesPage.editTCSaveTooltip).should(
-            'have.attr',
-            'aria-label',
-            'description: Test Case Description cannot be more than 250 characters.'
+        cy.get(TestCasesPage.editTestCaseDescriptionInlineError).should(
+            'contain.text',
+            'Test Case Description cannot be more than 250 characters.'
         )
     })
 
@@ -117,12 +156,14 @@ describe('Edit Test Case Validations', () => {
         MeasuresPage.actionCenter('edit')
         TestCasesPage.clickEditforCreatedTestCase()
         TestCasesPage.openDetailsTab(TestCasesPage.testCaseTitle)
-        cy.get(TestCasesPage.testCaseTitle).should('be.visible').should('be.enabled').focus().clear()
-        cy.get(TestCasesPage.testCaseTitle).invoke('val', '')
-        cy.get(TestCasesPage.testCaseTitle).type('{selectall}{backspace}{selectall}{backspace}')
-        cy.get(TestCasesPage.testCaseTitle).type(twoFiftyTwoCharacters, { delay: 0 })
+        TestCasesPage.replaceTestCaseDetailsInput(TestCasesPage.testCaseTitle, twoFiftyTwoCharacters)
         cy.get(TestCasesPage.createTestCaseGroupInput).click()
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.disabled')
+        cy.get(TestCasesPage.editTCSaveTooltip).should(
+            'have.attr',
+            'aria-label',
+            'title: Test Case Title cannot be more than 250 characters.'
+        )
         cy.get(TestCasesPage.editTestCaseTitleInlineError).contains(
             'Test Case Title cannot be more ' + 'than 250 characters.'
         )
@@ -140,20 +181,12 @@ describe('Edit Test Case Validations', () => {
 
 describe('Attempting to create a test case without a title', () => {
     beforeEach('Create measure and login', () => {
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateRatioMeasureGroupAPI(
-            false,
-            false,
-            'Surgical Absence of Cervix',
-            'Surgical Absence of Cervix',
-            'Surgical Absence of Cervix',
-            'Procedure'
-        )
+        createRatioMeasureViaApi()
         OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
 
     it('Create Test Case without a title', () => {
@@ -174,21 +207,13 @@ describe('Attempting to create a test case without a title', () => {
 
 describe('Editing a test case without a title', () => {
     beforeEach('Create measure, test case, and login', () => {
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateRatioMeasureGroupAPI(
-            false,
-            false,
-            'Surgical Absence of Cervix',
-            'Surgical Absence of Cervix',
-            'Surgical Absence of Cervix',
-            'Procedure'
-        )
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription, validTestCaseJson)
+        createRatioMeasureViaApi()
+        createTestCaseViaApi(validTestCaseJson)
         OktaLogin.Login()
     })
 
     afterEach('Logout and Clean up Measures', () => {
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
 
     it('Edit and update test case to have no title', () => {
@@ -314,14 +339,13 @@ describe('Editing a test case without a title', () => {
 
 describe('Duplicate Test Case Title and Group validations', () => {
     beforeEach('Create Measure, Test case and Login', () => {
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Procedure')
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
+        createCohortMeasureViaApi()
+        createTestCaseViaApi()
         OktaLogin.Login()
     })
 
     afterEach('Cleanup and Logout', () => {
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
 
     it('Create Test Case: Verify error message when the Test case Title and group names are duplicate', () => {
@@ -353,7 +377,7 @@ describe('Duplicate Test Case Title and Group validations', () => {
         cy.get(TestCasesPage.createTestCaseGroupInput).should('be.visible')
         cy.get(TestCasesPage.createTestCaseGroupInput).type(testCaseSeries).type('{enter}')
 
-        TestCasesPage.clickCreateTestCaseButton()
+        cy.get(TestCasesPage.createTestCaseSaveButton).should('be.visible').should('be.enabled').click()
 
         cy.get(EditMeasurePage.errorMessage).should(
             'contain.text',
@@ -364,22 +388,14 @@ describe('Duplicate Test Case Title and Group validations', () => {
 
 describe('Edit Duplicate Test Case Title and Group validations', () => {
     beforeEach('Create measure, two test cases, and login', () => {
-        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, CqlLibraryName, measureCQL)
-        MeasureGroupPage.CreateCohortMeasureGroupAPI(false, false, 'Surgical Absence of Cervix', 'Procedure')
-        TestCasesPage.CreateTestCaseAPI(testCaseTitle, testCaseSeries, testCaseDescription)
-        TestCasesPage.CreateTestCaseAPI(
-            'SecondTestCase',
-            'SecondTestCaseGroup',
-            testCaseDescription,
-            undefined,
-            false,
-            true
-        )
+        createCohortMeasureViaApi()
+        createTestCaseViaApi()
+        createTestCaseViaApi(undefined, true)
         OktaLogin.Login()
     })
 
     afterEach('Cleanup and Logout', () => {
-        Utilities.deleteMeasure(measureName, CqlLibraryName)
+        Utilities.deleteMeasure(measureName, cqlLibraryName)
     })
 
     it('Edit Test Case: Verify error message when the Test case Title and group names are duplicate', () => {

--- a/docs/quality/cypress-automation-guidelines.md
+++ b/docs/quality/cypress-automation-guidelines.md
@@ -67,6 +67,7 @@ Reuse these established paths before adding request code:
 - Toggle Highlighting Results through the shared Results-header helper; the split-view sash can cover the right-edge icon.
 - Treat Ace's transparent keyboard textarea as intentionally hidden. Prove readiness on the visible editor and use the shared JSON editor helper.
 - Keep clear and type contiguous for controlled React inputs that restore prior values between events; assert the final value after re-querying.
+- For Expected/Actual numeric inputs with an existing value, use `typeExpectedActualValue(..., { clearFirst: true })`; it replaces the value in one action so React rerenders do not detach the input between clear and type.
 
 ## CQL and Population Criteria
 


### PR DESCRIPTION
## Summary

Stabilizes weekly Cypress regressions across CQL Library retrieval, Test Case setup, Test Case split views, CMS ID association, and QDM validation assertions.

## Changes

- Retrieves the exact CQL Library created by the test rather than relying on shared fixture state.
- Uses readiness-aware Details and Expected/Actual tab interactions.
- Replaces Expected/Actual numeric values in one action to prevent `01` and `01.3` controlled-input values.
- Uses API-backed, unique Test Case validation fixtures with valid CQL.
- Waits for CMS ID transfer before validating association metadata.
- Aligns QDM validation assertions with current UI messages.

## Commits

- `fix(cql-library): retrieve created library by id`
- `fix(test-cases): stabilize split view interactions`
- `fix(measure-association): wait for transferred cms id`
- `refactor(test-cases): isolate validation fixtures with apis`
- `fix(regression): align qdm validation assertions`

## Testing

- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`
- Focused TEST validation cases in `TestCaseValidations.cy.ts`
- TEST runs of:
  - `ExpectedValuesForObservations.cy.ts`
  - `TestCaseExecutionWithCode.cy.ts`
  - `MeasureObservationExpectedValues.cy.ts`

## Risk

Low. Changes are limited to Cypress setup, selectors, and assertions; product behavior is unchanged.

## Documentation

Updated `docs/quality/cypress-automation-guidelines.md` with the Expected/Actual controlled-input pattern.