### PR TITLE
fix: stabilize Expected/Actual measure observation entry

### DIFF
--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts
@@ -277,20 +277,40 @@ describe('Measure Creation: Ratio EncounterPerformed, Multiple Criterias With MO
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).type('4')
-        cy.get(TestCasesPage.testCaseDENOMExpected).eq(0).type('1')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('4')
-        cy.get(TestCasesPage.testCaseNUMERExpected).eq(0).type('1')
-        cy.get(TestCasesPage.numeratorObservationRow).eq(0).clear().type('2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '4', { index: 0 })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1', {
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '4', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1', {
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '2', {
+            clearFirst: true,
+            index: 0,
+        })
 
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.visible')
         cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).type('4')
-        cy.get(TestCasesPage.testCaseDENOMExpected).eq(1).type('1')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).clear().type('24')
-        cy.get(TestCasesPage.testCaseNUMERExpected).eq(1).type('1')
-        cy.get(TestCasesPage.numeratorObservationRow).eq(1).clear().type('8')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '4', { index: 1 })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '1', {
+            index: 1,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '24', {
+            clearFirst: true,
+            index: 1,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1', {
+            index: 1,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '8', {
+            clearFirst: true,
+            index: 1,
+        })
 
         //run test case on edit test case page
         cy.get(TestCasesPage.runQDMTestCaseBtn).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QDM  End To End Measure/Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts
@@ -200,13 +200,19 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('3')
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('3')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('2')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).clear().type('6')
-        cy.get(TestCasesPage.testCaseDENEXExpected).type('1')
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('1')
-        cy.get(TestCasesPage.numeratorObservationRow).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '3')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '2', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '6', {
+            clearFirst: true,
+            index: 1,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', { clearFirst: true })
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
@@ -316,12 +322,15 @@ describe('Measure Creation: Ratio ListQDMPositiveEncounterPerformed with MO', ()
         cy.get(TestCasesPage.testCaseIPPExpected).should('exist')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
         cy.get(TestCasesPage.testCaseIPPExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('2')
-        cy.get(TestCasesPage.testCaseDENOMExpected).type('2')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('3')
-        cy.get(TestCasesPage.testCaseDENEXExpected).type('1')
-        cy.get(TestCasesPage.testCaseNUMERExpected).type('1')
-        cy.get(TestCasesPage.numeratorObservationRow).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '3', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENEXExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', { clearFirst: true })
 
         //Save Test case
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
@@ -84,11 +84,9 @@ describe('Measure Creation and Testing: CV Patient With MO', () => {
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
-        cy.get(TestCasesPage.measureObservationRow).type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1')
 
-        cy.get(TestCasesPage.detailsTab).should('exist')
-        cy.get(TestCasesPage.detailsTab).should('be.visible')
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeTwoIPsWithMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioEpisodeTwoIPsWithMOs.cy.ts
@@ -100,41 +100,41 @@ describe('Measure Creation and Testing: Ratio Episode Two IPs w/ MOs', () => {
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
 
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(0).clear().type('2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2', {
+            clearFirst: true,
+            index: 0,
+        })
 
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('exist')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).eq(1).clear().type('2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '2', {
+            clearFirst: true,
+            index: 1,
+        })
 
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('exist')
-        cy.get(TestCasesPage.testCaseDENOMExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseDENOMExpected).clear().type('2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseDENOMExpected, '2', { clearFirst: true })
+        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('have.length', 2)
 
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).should('exist')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '1', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '1', {
+            clearFirst: true,
+            index: 1,
+        })
 
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).should('exist')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).clear().type('1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseNUMERExpected, '2', { clearFirst: true })
+        cy.get(TestCasesPage.numeratorObservationRow).should('have.length', 2)
 
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('exist')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseNUMERExpected).should('be.visible')
-        cy.get(TestCasesPage.testCaseNUMERExpected).clear().type('2')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', {
+            clearFirst: true,
+            index: 1,
+        })
 
-        cy.get(TestCasesPage.numeratorObservationRow).eq(0).should('exist')
-        cy.get(TestCasesPage.numeratorObservationRow).eq(0).should('be.enabled')
-        cy.get(TestCasesPage.numeratorObservationRow).eq(0).scrollIntoView()
-        cy.get(TestCasesPage.numeratorObservationRow).eq(0).clear().type('1')
-
-        cy.get(TestCasesPage.numeratorObservationRow).eq(1).should('exist')
-        cy.get(TestCasesPage.numeratorObservationRow).eq(1).should('be.enabled')
-        cy.get(TestCasesPage.numeratorObservationRow).eq(1).clear().type('1')
-
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(Toasts.otherSuccessToast).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOs.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOs.cy.ts
@@ -157,17 +157,12 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.enabled')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.visible')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).clear().type('44')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '44', {
+            clearFirst: true,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', { clearFirst: true })
 
-        cy.get(TestCasesPage.numeratorObservationRow).should('exist')
-        cy.get(TestCasesPage.numeratorObservationRow).should('be.enabled')
-        cy.get(TestCasesPage.numeratorObservationRow).should('be.visible')
-        cy.get(TestCasesPage.numeratorObservationRow).clear().type('1')
-
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',
@@ -229,17 +224,12 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs', () => {
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.enabled')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.visible')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).clear().type('33')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '33', {
+            clearFirst: true,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '1', { clearFirst: true })
 
-        cy.get(TestCasesPage.numeratorObservationRow).should('exist')
-        cy.get(TestCasesPage.numeratorObservationRow).should('be.enabled')
-        cy.get(TestCasesPage.numeratorObservationRow).should('be.visible')
-        cy.get(TestCasesPage.numeratorObservationRow).clear().type('1')
-
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts
@@ -152,17 +152,12 @@ describe('Measure Creation and Testing: Ratio Patient Two IPs w/ MOs, using same
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
         cy.get(TestCasesPage.testCaseNUMERExpected).should('be.checked')
 
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('exist')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.enabled')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).should('be.visible')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).clear().type('44')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '44', {
+            clearFirst: true,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.numeratorObservationRow, '44', { clearFirst: true })
 
-        cy.get(TestCasesPage.numeratorObservationRow).should('exist')
-        cy.get(TestCasesPage.numeratorObservationRow).should('be.enabled')
-        cy.get(TestCasesPage.numeratorObservationRow).should('be.visible')
-        cy.get(TestCasesPage.numeratorObservationRow).clear().type('44')
-
-        cy.get(TestCasesPage.detailsTab).click()
+        TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(TestCasesPage.successMsg).should(
             'contain.text',

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 6.0.0 End To End Measure and Test Cases/CVEncounterWithMOandStrat600.cy.ts
@@ -105,15 +105,14 @@ describe('Measure Creation and Testing: CV Patient Measure With Stratification',
 
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
-        cy.get(TestCasesPage.testCaseIPPExpected).should('be.enabled')
-        cy.get(TestCasesPage.testCaseIPPExpected).type('1')
-        cy.get(TestCasesPage.testCaseMSRPOPLExpected).type('1')
-        cy.get(TestCasesPage.measureObservationRow).clear().type('125')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseIPPExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.testCaseMSRPOPLExpected, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '125', { clearFirst: true })
 
-        cy.get(TestCasesPage.initialPopulationStratificationExpectedValue).type('1')
-        cy.get(TestCasesPage.measurePopulationStratificationExpectedValue).type('1')
-        cy.get(TestCasesPage.initialPopulationStrata2ExpectedValue).type('0')
-        cy.get(TestCasesPage.measurePopulationStrata2ExpectedValue).type('0')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.initialPopulationStratificationExpectedValue, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measurePopulationStratificationExpectedValue, '1')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.initialPopulationStrata2ExpectedValue, '0')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measurePopulationStrata2ExpectedValue, '0')
 
         cy.get(TestCasesPage.editTestCaseSaveButton).click()
         cy.get(Toasts.otherSuccessToast, { timeout: 7500 }).should(

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMCVMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -164,8 +164,14 @@ describe('Measure Creation: Patient Based: CV measure with multiple groups with 
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
-        cy.get(TestCasesPage.measureObservationRow).eq(0).clear().type('8')
-        cy.get(TestCasesPage.measureObservationRow).eq(1).clear().type('8')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '8', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '8', {
+            clearFirst: true,
+            index: 1,
+        })
 
         //save changes
         cy.get(TestCasesPage.editTestCaseSaveButton).should('be.visible')

--- a/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts
+++ b/cypress/e2e/WebInterface/Test Cases/QDM Test Case/Execution/QDMRatioMeasure_with_multiple_Groups_with_MO.cy.ts
@@ -157,8 +157,14 @@ describe('Measure Creation: Patient Based: Ratio measure with multiple groups wi
         TestCasesPage.openExpectedActualTab({ checkboxSelector: TestCasesPage.testCaseIPPExpected })
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseDENOMExpected)
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(0).clear().type('8')
-        cy.get(TestCasesPage.denominatorObservationExpectedRow).eq(1).clear().type('8')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '8', {
+            clearFirst: true,
+            index: 0,
+        })
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.denominatorObservationExpectedRow, '8', {
+            clearFirst: true,
+            index: 1,
+        })
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseNUMERExpected)
 
         //save changes

--- a/docs/quality/cypress-automation-guidelines.md
+++ b/docs/quality/cypress-automation-guidelines.md
@@ -67,7 +67,8 @@ Reuse these established paths before adding request code:
 - Toggle Highlighting Results through the shared Results-header helper; the split-view sash can cover the right-edge icon.
 - Treat Ace's transparent keyboard textarea as intentionally hidden. Prove readiness on the visible editor and use the shared JSON editor helper.
 - Keep clear and type contiguous for controlled React inputs that restore prior values between events; assert the final value after re-querying.
-- For Expected/Actual numeric inputs with an existing value, use `typeExpectedActualValue(..., { clearFirst: true })`; it replaces the value in one action so React rerenders do not detach the input between clear and type.
+- Use `typeExpectedActualValue(...)` for every Expected/Actual text or numeric field. Pass `{ clearFirst: true }` only when replacing an existing value; initially empty controlled inputs must use the helper's default type-only mode to avoid a clearing rerender.
+- Use `checkExpectedActualCheckbox(...)` and `uncheckExpectedActualCheckbox(...)` for every Expected/Actual checkbox; do not use raw checkbox commands in the split panel.
 
 ## CQL and Population Criteria
 

--- a/docs/quality/test-refactor-backlog.md
+++ b/docs/quality/test-refactor-backlog.md
@@ -37,7 +37,6 @@ Work boundaries:
 
 | Area | Status | Next action |
 | --- | --- | --- |
-| `RatioPatientTwoIPsWithMOs.cy.ts`, `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts` | TEST product bug: denominator measure observations are missing in Expected/Actual after the original Population Criteria readiness issue was fixed. | Retest after the product fix; preserve the observation assertions. |
 | `ExecuteInvalidTestCases.cy.ts` | Product remains `Invalid` instead of `Pass` after execution. | Product follow-up; do not accept `Invalid`. |
 | `ElementTable.cy.ts` | Deferred by team; React action transition can detach or close without opening the editor. | Resume only when explicitly prioritized; diagnose destination transition. |
 | `CQLLibraryDelete.cy.ts` | Environment/account drift: inactive-user `400` and admin `403 insufficient_scope`. | Repair account/scope state before refactoring. |
@@ -76,6 +75,7 @@ Work boundaries:
 ### Test-case reliability
 
 - Proven native, destination-aware navigation for Test Cases, Details, JSON, Expected/Actual, and Highlighting Results.
+- Retested the Ratio Patient measure-observation Expected/Actual assertions after MAT-10284; the product defect is resolved, and both specs now use the shared numeric-entry and Details-tab helpers.
 - Proven shared checkbox and numeric-entry helpers across Qi-Core and QDM split-panel and non-panel layouts.
 - Stabilized QDM demographics, row checkbox selection, search, SDE navigation, clone/copy, execution, highlighting, validation, and action-center flows.
 - Stabilized Qi-Core population values, search, invalid-case navigation, non-owner execution, list coverage, and versioned clone/import flows.


### PR DESCRIPTION
## Summary

Stabilizes Expected/Actual measure-observation entry by using the shared numeric-entry, checkbox, and Details-tab navigation helpers.

## Changes

- Migrated nine Qi-Core and QDM Measure Observation consumers from raw split-panel interactions to shared helpers.
- Preserved clear-and-replace behavior only for inputs with existing values; initially empty controlled inputs use helper type-only mode.
- Added explicit dynamic Measure Observation row readiness for `RatioEpisodeTwoIPsWithMOs`.
- Recorded MAT-10284 resolution and durable helper guidance.

## Testing

Passed:
- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`

**Local validation:** 
- `CVPatientwithMO.cy.ts`, 
- `RatioPatientTwoIPsWithMOs.cy.ts` 
- `RatioPatientTwoIPsWithMOsUsingSameFunction.cy.ts`
- `Ratio_EncounterPerformed_multipleCriterias_WithMO.cy.ts`
- `Ratio_ListQDMPositiveEncounterPerformed_WithMO.cy.ts`

Pending / failing locally:
- N/A

## Risk

The two pending QDM ratio specs require follow-up before merge; this PR preserves their assertions and does not weaken failures.

## Documentation

Updated `docs/quality/cypress-automation-guidelines.md` and `docs/quality/test-refactor-backlog.md`.