### PR TITLE
fix: stabilize overnight export and CV test flows

### DIFF
--- a/cypress/Shared/MeasuresPage.ts
+++ b/cypress/Shared/MeasuresPage.ts
@@ -7,6 +7,7 @@ import { FixtureOwner, TestData } from './TestData'
 
 export type MeasureActionOptions = {
     exportForPublish?: boolean
+    targetVersion?: string
     versionType?: string
     updateModelVersion?: boolean
     altUser?: boolean
@@ -109,6 +110,30 @@ export class MeasuresPage {
             Utilities.waitForElementVisible(`${rowSelector} > [class="px-1"] > [type="checkbox"]`, 60000)
             Utilities.waitForElementVisible(`${rowSelector} > [class="px-1"] > [class=" cursor-pointer"]`, 60000)
             cy.get(rowSelector).find('[type="checkbox"]').scrollIntoView().check()
+        })
+    }
+
+    private static selectVersionedMeasureRow(targetVersion: string, measureNumber = 0, options?: MeasureActionOptions): void {
+        TestData.readMeasureId(measureNumber, this.fixtureOwner(options)).then((measureId) => {
+            cy.get(this.measureActionSelector(measureId))
+                .closest('tr')
+                .find('td')
+                .eq(1)
+                .invoke('text')
+                .then((measureName) => {
+                    cy.get(this.measureListRows)
+                        .filter((_, row) => {
+                            const cells = Cypress.$(row).find('td')
+                            return (
+                                cells.eq(1).text().trim() === measureName.trim() &&
+                                cells.eq(2).text().trim() === targetVersion
+                            )
+                        })
+                        .should('have.length', 1)
+                        .find('[type="checkbox"]')
+                        .scrollIntoView()
+                        .check()
+                })
         })
     }
 
@@ -221,7 +246,11 @@ export class MeasuresPage {
             return
         }
 
-        this.selectMeasureRow(selectedMeasureNumber, options)
+        if (options?.targetVersion) {
+            this.selectVersionedMeasureRow(options.targetVersion, selectedMeasureNumber, options)
+        } else {
+            this.selectMeasureRow(selectedMeasureNumber, options)
+        }
 
         switch (normalizedAction) {
             case 'view': {

--- a/cypress/Shared/TestCasesPage.ts
+++ b/cypress/Shared/TestCasesPage.ts
@@ -949,10 +949,12 @@ export class TestCasesPage {
 
     if (typeof index === 'number') {
       checkbox.eq(index).should('exist').check({ scrollBehavior: 'center' })
+      cy.get(checkboxSelector).eq(index).should('be.checked')
       return
     }
 
     checkbox.should('exist').check({ scrollBehavior: 'center' })
+    cy.get(checkboxSelector).should('be.checked')
   }
 
   public static clickExpectedActualCheckbox(

--- a/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/Export/ProportionPatientQicoreProfileTypes.cy.ts
@@ -16,6 +16,14 @@ const { deleteDownloadsFolderBeforeAll } = require('cypress-delete-downloads-fol
 const measureCQL = MeasureCQL.CQL_Populations
 const zipFile = 'eCQMTitle4QICore-v1.0.000-FHIR.zip'
 
+const replaceRichText = (value: string) => {
+    cy.get(EditMeasurePage.measureGenericFieldRTETextBox)
+        .should('be.visible')
+        .click()
+        .type('{selectAll}{backspace}')
+        .type(value, { parseSpecialCharSequences: false })
+}
+
 describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profile types', () => {
     deleteDownloadsFolderBeforeAll()
 
@@ -51,29 +59,27 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
 
         //Description
         cy.get(EditMeasurePage.leftPanelDescription).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox)
-            .clear()
-            .type(
-                'Percentage of cataract surgeries for patients aged 18 and older with a diagnosis of uncomplicated cataract and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following the cataract surgery',
-            )
+        replaceRichText(
+            'Percentage of cataract surgeries for patients aged 18 and older with a diagnosis of uncomplicated cataract and no significant ocular conditions impacting the visual outcome of surgery and had best-corrected visual acuity of 20/40 or better (distance or near) achieved in the operative eye within 90 days following the cataract surgery',
+        )
         cy.get(EditMeasurePage.measureDescriptionSaveButton).click()
         cy.get(EditMeasurePage.measureDescriptionSuccessMessage).should('be.visible')
 
         //Copyright
         cy.get(EditMeasurePage.leftPanelCopyright).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        replaceRichText('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureCopyrightSaveButton).click()
         cy.get(EditMeasurePage.measureCopyrightSuccessMessage).should('be.visible')
 
         //Disclaimer
         cy.get(EditMeasurePage.leftPanelDisclaimer).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        replaceRichText('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureDisclaimerSaveButton).click()
         cy.get(EditMeasurePage.measureDisclaimerSuccessMessage).should('be.visible')
 
         //Rationale
         cy.get(EditMeasurePage.leftPanelRationale).click()
-        cy.get(EditMeasurePage.measureGenericFieldRTETextBox).clear().type('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
+        replaceRichText('Test!@#$%^&*()_+-={}|`~[]\:"<>?;\',./~`')
         cy.get(EditMeasurePage.measureRationaleSaveButton).click()
         cy.get(EditMeasurePage.measureRationaleSuccessMessage).should('be.visible')
 
@@ -129,28 +135,19 @@ describe('FHIR Measure Export for Proportion Patient Measure with QI-Core Profil
         MeasuresPage.validateVersionNumber('1.0.000')
         cy.log('Version Created Successfully')
 
-        MeasuresPage.actionCenter('export')
+        MeasuresPage.actionCenter('export', undefined, { targetVersion: '1.0.000' })
 
         cy.verifyDownload(zipFile)
-        cy.log('Successfully verified zip file export')
-        console.log('Successfully verified zip file export')
-
-        OktaLogin.UILogout()
-    })
-
-    it('Unzip the downloaded file and verify file types', () => {
-        cy.verifyDownload(zipFile)
-
-        // unzipping the Measure Export
-        cy.task('unzipFile', { zipFile: zipFile, path: downloadsFolder }).then((results) => {
+        cy.task('unzipFile', { zipFile, path: downloadsFolder }).then(() => {
             cy.log('unzipFile Task finished')
-            console.log('unzipFile Task finished')
         })
 
-        //Verify all files exist in exported zip file
+        // Verify all files exist in the exported zip file.
         cy.readFile(path.join(downloadsFolder, zipFile))
             .should('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.html')
             .and('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.xml')
             .and('contain', 'eCQMTitle4QICore-v1.0.000-FHIR.json')
+
+        OktaLogin.UILogout()
     })
 })

--- a/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
+++ b/cypress/e2e/WebInterface/Smoke Tests/QICORE 4.1.1 End To End Measure and Test Cases/CVPatientwithMO.cy.ts
@@ -84,7 +84,8 @@ describe('Measure Creation and Testing: CV Patient With MO', () => {
         cy.get(TestCasesPage.testCasePopulationList).should('be.visible')
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseIPPExpected)
         TestCasesPage.checkExpectedActualCheckbox(TestCasesPage.testCaseMSRPOPLExpected)
-        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1')
+        cy.get(TestCasesPage.measureObservationRow).should('have.value', '0')
+        TestCasesPage.typeExpectedActualValue(TestCasesPage.measureObservationRow, '1', { clearFirst: true })
 
         TestCasesPage.openDetailsTab(TestCasesPage.editTestCaseSaveButton)
         cy.get(TestCasesPage.editTestCaseSaveButton).click()

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -19,9 +19,15 @@ function getConfigurationByFile(file) {
 
 function unzipFile(zipFile, outputPath) {
     const zipPath = path.join(outputPath, zipFile)
-    const readStream = fs.createReadStream(zipPath)
+    return new Promise((resolve, reject) => {
+        const readStream = fs.createReadStream(zipPath)
+        const extraction = unzipper.Extract({ path: outputPath })
 
-    readStream.pipe(unzipper.Extract({ path: outputPath }))
+        readStream.on('error', reject)
+        extraction.on('error', reject)
+        extraction.on('close', () => resolve(null))
+        readStream.pipe(extraction)
+    })
 }
 
 function readLock(filePath) {
@@ -109,8 +115,7 @@ module.exports = (on, config) => {
             return null
         },
         unzipFile(zipFileAndPath) {
-            unzipFile(zipFileAndPath.zipFile, zipFileAndPath.path)
-            return null
+            return unzipFile(zipFileAndPath.zipFile, zipFileAndPath.path)
         },
         lighthouse: lighthouse((lighthouseReport) => {
             console.log('---- Writing lighthouse report to disk ----')


### PR DESCRIPTION
## Summary

Stabilizes the overnight regression failures in the CV Patient with Measure Observation and Proportion Patient Qi-Core export flows.

## Changes

- Wait for Expected/Actual checkboxes to be checked before interacting with conditionally rendered observation inputs.
- Wait for the Measure Observation field to render with its initial value, then replace it with the expected value.
- Combine export, download, unzip, and archive-content validation into one independent test.
- Make `unzipFile` wait for extraction completion and return a Cypress-compatible `null` result.
- Select the newly created `1.0.000` versioned measure row before export instead of reselecting the source draft.
- Replace unstable rich-text `.clear()` interactions with select-all/backspace replacement.

## Technical Notes

The changes reuse existing `TestCasesPage` and `MeasuresPage` helpers. Versioned-row targeting is opt-in and matches the scenario’s measure name and requested version.

## Testing

- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`
- All affected suites passed.

## Risk

Low. Existing shared-helper behavior is unchanged by default; versioned-row targeting is only used by the affected export test.

## Documentation

Documentation Updates: None