### PR TITLE
test: add admin profile measure and library View/Edit coverage

### DIFF
--- a/cypress/Shared/AdminUserProfilePage.ts
+++ b/cypress/Shared/AdminUserProfilePage.ts
@@ -139,9 +139,17 @@ export class AdminUserProfilePage {
     }
 
     public static findLibraryRow(libraryName: string): Cypress.Chainable<JQuery<HTMLElement>> {
-        return cy.contains(`${this.librariesTable} tbody td`, libraryName)
+        return cy.contains(`${this.librariesTable} td`, libraryName)
             .should('be.visible')
             .closest('tr')
+    }
+
+    public static findLibraryRowById(libraryId: string): Cypress.Chainable<JQuery<HTMLElement>> {
+        return cy.get(`[data-testid="checkbox-${libraryId}"]`).should('be.visible').closest('tr')
+    }
+
+    public static findLibraryAction(libraryId: string): Cypress.Chainable<JQuery<HTMLElement>> {
+        return cy.get(`[data-testid="library-action-${libraryId}"]`).should('be.visible')
     }
 
     public static selectLibraryByName(libraryName: string): Cypress.Chainable<JQuery<HTMLElement>> {
@@ -162,12 +170,19 @@ export class AdminUserProfilePage {
     }
 
     public static selectMeasureByName(measureName: string): Cypress.Chainable<JQuery<HTMLElement>> {
-        return cy.contains(`${this.measuresTable} tbody td`, measureName)
+        return this.findMeasureRow(measureName)
             .should('be.visible')
-            .closest('tr')
             .find('input[type="checkbox"]')
             .should('be.visible')
             .check()
+    }
+
+    public static findMeasureRow(measureName: string): Cypress.Chainable<JQuery<HTMLElement>> {
+        return cy.contains(`${this.measuresTable} tbody td`, measureName).should('be.visible').closest('tr')
+    }
+
+    public static findMeasureAction(measureId: string): Cypress.Chainable<JQuery<HTMLElement>> {
+        return cy.get(`[data-testid="measure-action-${measureId}"]`).should('be.visible')
     }
 
     public static expandMeasureSet(

--- a/cypress/Shared/LibraryCQL.ts
+++ b/cypress/Shared/LibraryCQL.ts
@@ -15,7 +15,10 @@ export class LibraryCQL {
     public static readonly validCQL4QICORELib = "library SupplementalDataElementsQICore4 version '2.0.0'\n\n" +
         "using QICore version '4.1.1'\n\n" +
         "include FHIRHelpers version '4.1.000' called FHIRHelpers\n\n" +
-        "valueset \"ONC Administrative Sex\": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1'"
+        "valueset \"ONC Administrative Sex\": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1'\n\n" +
+        'context Patient\n\n' +
+        'define "Valid Library":\n' +
+        '  true'
 
     public static readonly invalidFhir4Lib = "library TESTMEASURE0000000003 version '0.0.000'\nusing FHIR version '4.0.1'\n" +
         "include FHIRHelpers version '4.1.000' called FHIRHelpers\ninclude SupplementalDataElementsFHIR4 version '2.0.000' called SDE\n" +

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileLibraryViewEdit.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileLibraryViewEdit.cy.ts
@@ -1,0 +1,162 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CQLLibraryPage } from '../../../Shared/CQLLibraryPage'
+import { SupportedModels } from '../../../Shared/CreateMeasurePage'
+import { Environment } from '../../../Shared/Environment'
+import { LibraryCQL } from '../../../Shared/LibraryCQL'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { TestData } from '../../../Shared/TestData'
+import { MadieObject, Utilities } from '../../../Shared/Utilities'
+
+// MAT-9821: AdminUserProfile is not yet available in TEST; prove this coverage in DEV first.
+const describeAdminUserProfile = describe.skip
+
+describeAdminUserProfile('Admin user profile library View and Edit navigation', () => {
+    let libraryName = ''
+    let libraryOwner = ''
+    let sharedProfileUser = ''
+    let adminUser = ''
+    let createdLibraryId = ''
+    let libraryCreated = false
+    let libraryLocked = false
+
+    const createDraftLibrary = (): void => {
+        CQLLibraryPage.createLibraryAPI(libraryName, SupportedModels.qiCore4, {
+            cql: LibraryCQL.validCQL4QICORELib
+        })
+        libraryCreated = true
+    }
+
+    const shareLibraryWith = (user: string): void => {
+        TestData.readCqlLibraryId().then((libraryId) => {
+            TestData.requestSharePermissions('library', 'GRANT', libraryId, user).then((response) => {
+                expect(response.status).to.eq(200)
+            })
+        })
+    }
+
+    const openProfileLibrary = (
+        profileUser: string,
+        tab = AdminUserProfilePage.ownedLibrariesTab
+    ): void => {
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileUser)
+        AdminUserProfilePage.openLibrariesTab(tab)
+        AdminUserProfilePage.submitLibrarySearch(libraryName)
+        AdminUserProfilePage.findLibraryRow(libraryName).should('be.visible')
+    }
+
+    const findCreatedLibraryAction = (): Cypress.Chainable<JQuery<HTMLElement>> => {
+        return cy.then(() => {
+            expect(createdLibraryId, 'created library ID').not.to.be.empty
+            return AdminUserProfilePage.findLibraryAction(createdLibraryId)
+        })
+    }
+
+    const assertLibraryDetailMode = (expectedMode: 'view' | 'edit'): void => {
+        cy.then(() => {
+            expect(createdLibraryId, 'created library ID').not.to.be.empty
+            cy.location('pathname').should('contain', `/cql-libraries/${createdLibraryId}/edit/details`)
+        })
+        cy.get('[data-testid="CQL Library Details"]').should('be.visible').click()
+
+        if (expectedMode === 'view') {
+            cy.get(CQLLibraryPage.readOnlyCqlLibraryName).should('be.visible')
+        } else {
+            cy.get(CQLLibraryPage.cqlLibraryNameTextbox).should('be.visible').and('be.enabled')
+        }
+    }
+
+    beforeEach(() => {
+        const suffix = Date.now()
+        libraryName = `AdminProfileLibraryViewEdit${suffix}`
+        libraryOwner = OktaLogin.getUser(false)
+        sharedProfileUser = OktaLogin.getUser(true)
+        adminUser = Environment.credentials().adminUser?.toLowerCase() ?? ''
+        expect(adminUser, 'configured admin user').not.to.be.empty
+        libraryCreated = false
+        libraryLocked = false
+        createdLibraryId = ''
+    })
+
+    afterEach(() => {
+        if (libraryLocked) {
+            Utilities.releaseAllLocksForCleanup(MadieObject.Library, true)
+        }
+        if (libraryCreated) {
+            Utilities.deleteLibrary()
+        }
+    })
+
+    it('opens an unshared draft from Owned Libraries in read-only View mode', () => {
+        createDraftLibrary()
+        TestData.readCqlLibraryId().then((libraryId) => {
+            createdLibraryId = libraryId
+        })
+        openProfileLibrary(libraryOwner)
+
+        findCreatedLibraryAction().should('have.text', 'View').click()
+        assertLibraryDetailMode('view')
+    })
+
+    it('opens an admin-shared draft from Owned Libraries in Edit mode', () => {
+        createDraftLibrary()
+        TestData.readCqlLibraryId().then((libraryId) => {
+            createdLibraryId = libraryId
+        })
+        shareLibraryWith(adminUser)
+        openProfileLibrary(libraryOwner)
+
+        findCreatedLibraryAction().should('have.text', 'Edit').click()
+        assertLibraryDetailMode('edit')
+    })
+
+    it('opens an admin-shared draft from Shared Libraries in Edit mode', () => {
+        createDraftLibrary()
+        TestData.readCqlLibraryId().then((libraryId) => {
+            createdLibraryId = libraryId
+        })
+        shareLibraryWith(adminUser)
+        shareLibraryWith(sharedProfileUser)
+        openProfileLibrary(sharedProfileUser, AdminUserProfilePage.sharedLibrariesTab)
+
+        findCreatedLibraryAction().should('have.text', 'Edit').click()
+        assertLibraryDetailMode('edit')
+    })
+
+    it('opens a library locked by another user from Owned Libraries in read-only View mode', () => {
+        createDraftLibrary()
+        TestData.readCqlLibraryId().then((libraryId) => {
+            createdLibraryId = libraryId
+        })
+        shareLibraryWith(adminUser)
+        shareLibraryWith(sharedProfileUser)
+        Utilities.lockSharedLibrary(true)
+        libraryLocked = true
+
+        openProfileLibrary(libraryOwner)
+
+        findCreatedLibraryAction().should('have.text', 'View')
+        cy.then(() => {
+            cy.get(`[data-testid="library-lock-icon-${createdLibraryId}"]`).should('be.visible')
+        })
+        findCreatedLibraryAction().click()
+        cy.then(() => {
+            cy.location('pathname').should('contain', `/cql-libraries/${createdLibraryId}/edit/details`)
+        })
+        cy.get(CQLLibraryPage.libraryLockedModalMessage).should('be.visible')
+    })
+
+    it('opens a versioned library from Owned Libraries in read-only View mode', () => {
+        createDraftLibrary()
+        TestData.readCqlLibraryId().then((libraryId) => {
+            createdLibraryId = libraryId
+        })
+        TestData.versionCqlLibrary('1.0.000').then((response) => {
+            expect(response.status).to.eq(200)
+        })
+        openProfileLibrary(libraryOwner)
+
+        findCreatedLibraryAction().should('have.text', 'View').click()
+        assertLibraryDetailMode('view')
+    })
+})

--- a/cypress/e2e/WebInterface/Admin/AdminUserProfileMeasureViewEdit.cy.ts
+++ b/cypress/e2e/WebInterface/Admin/AdminUserProfileMeasureViewEdit.cy.ts
@@ -1,0 +1,170 @@
+import { AdminUserProfilePage } from '../../../Shared/AdminUserProfilePage'
+import { CreateMeasurePage } from '../../../Shared/CreateMeasurePage'
+import { EditMeasurePage } from '../../../Shared/EditMeasurePage'
+import { Environment } from '../../../Shared/Environment'
+import { MeasureCQL } from '../../../Shared/MeasureCQL'
+import { MeasureGroupPage } from '../../../Shared/MeasureGroupPage'
+import { MadieObject, Utilities } from '../../../Shared/Utilities'
+import { MeasuresPage } from '../../../Shared/MeasuresPage'
+import { OktaLogin } from '../../../Shared/OktaLogin'
+import { TestData } from '../../../Shared/TestData'
+
+// MAT-9820: AdminUserProfile is not yet available in TEST; prove this coverage in DEV first.
+const describeAdminUserProfile = describe.skip
+
+describeAdminUserProfile('Admin user profile measure View and Edit navigation', () => {
+    let measureName = ''
+    let libraryName = ''
+    let measureOwner = ''
+    let sharedProfileUser = ''
+    let adminUser = ''
+    let measureCreated = false
+    let measureLocked = false
+    let measureVersioned = false
+    let createdMeasureId = ''
+
+    const createDraftMeasure = (): void => {
+        CreateMeasurePage.CreateQICoreMeasureAPI(measureName, libraryName, MeasureCQL.CQL_For_Cohort)
+        measureCreated = true
+    }
+
+    const captureCreatedMeasureId = (): void => {
+        TestData.readMeasureId().then((measureId) => {
+            createdMeasureId = measureId
+        })
+    }
+
+    const shareMeasureWith = (user: string): void => {
+        TestData.readMeasureId().then((measureId) => {
+            TestData.requestSharePermissions('measure', 'GRANT', measureId, user).then((response) => {
+                expect(response.status).to.eq(200)
+            })
+        })
+    }
+
+    const openProfileMeasure = (profileUser: string, tab = MeasuresPage.ownedMeasures): void => {
+        OktaLogin.AdminLogin()
+        AdminUserProfilePage.openUserProfile(profileUser)
+        if (tab === MeasuresPage.sharedMeasures) {
+            AdminUserProfilePage.openMeasuresTab(tab)
+        }
+        AdminUserProfilePage.findMeasureRow(measureName).should('be.visible')
+    }
+
+    const findCreatedMeasureAction = (): Cypress.Chainable<JQuery<HTMLElement>> => {
+        return cy.then(() => {
+            expect(createdMeasureId, 'created measure ID').not.to.be.empty
+            return AdminUserProfilePage.findMeasureAction(createdMeasureId)
+        })
+    }
+
+    const assertMeasureDetailMode = (expectedMode: 'view' | 'edit'): void => {
+        cy.then(() => {
+            expect(createdMeasureId, 'created measure ID').not.to.be.empty
+            cy.location('pathname').should('contain', `/measures/${createdMeasureId}/edit/details`)
+        })
+
+        if (expectedMode === 'view') {
+            cy.get(EditMeasurePage.readOnlyMeasureName).should('be.visible')
+        } else {
+            cy.get(EditMeasurePage.measureNameTextBox).should('be.visible').and('be.enabled')
+        }
+    }
+
+    beforeEach(() => {
+        const suffix = Date.now()
+        measureName = `AdminProfileViewEdit${suffix}`
+        libraryName = `AdminProfileViewEditLib${suffix}`
+        measureOwner = OktaLogin.getUser(false)
+        sharedProfileUser = OktaLogin.getUser(true)
+        adminUser = Environment.credentials().adminUser?.toLowerCase() ?? ''
+        expect(adminUser, 'configured admin user').not.to.be.empty
+        measureCreated = false
+        measureLocked = false
+        measureVersioned = false
+        createdMeasureId = ''
+    })
+
+    afterEach(() => {
+        if (measureLocked) {
+            Utilities.releaseAllLocksForCleanup(MadieObject.Measure, true)
+        }
+        if (measureVersioned) {
+            Utilities.deleteVersionedMeasure(measureName, libraryName)
+        } else if (measureCreated) {
+            Utilities.deleteMeasure()
+        }
+    })
+
+    it('opens an unshared draft from Owned Measures in read-only View mode', () => {
+        createDraftMeasure()
+        captureCreatedMeasureId()
+        openProfileMeasure(measureOwner)
+
+        findCreatedMeasureAction().should('have.text', 'View').click()
+        assertMeasureDetailMode('view')
+    })
+
+    it('opens an admin-shared draft from Owned Measures in Edit mode', () => {
+        createDraftMeasure()
+        captureCreatedMeasureId()
+        shareMeasureWith(adminUser)
+        openProfileMeasure(measureOwner)
+
+        findCreatedMeasureAction().should('have.text', 'Edit').click()
+        assertMeasureDetailMode('edit')
+    })
+
+    it('opens an admin-shared draft from Shared Measures in Edit mode', () => {
+        createDraftMeasure()
+        captureCreatedMeasureId()
+        shareMeasureWith(adminUser)
+        shareMeasureWith(sharedProfileUser)
+        openProfileMeasure(sharedProfileUser, MeasuresPage.sharedMeasures)
+
+        findCreatedMeasureAction().should('have.text', 'Edit').click()
+        assertMeasureDetailMode('edit')
+    })
+
+    it('opens a measure locked by another user from Owned Measures in read-only View mode', () => {
+        createDraftMeasure()
+        captureCreatedMeasureId()
+        shareMeasureWith(adminUser)
+        shareMeasureWith(sharedProfileUser)
+        Utilities.lockSharedMeasure(true)
+        measureLocked = true
+
+        openProfileMeasure(measureOwner)
+
+        findCreatedMeasureAction().should('have.text', 'View')
+        cy.then(() => {
+            expect(createdMeasureId, 'created measure ID').not.to.be.empty
+            cy.get(`[data-testid="measure-lock-icon-${createdMeasureId}"]`).should('be.visible')
+        })
+        findCreatedMeasureAction().click()
+        cy.then(() => {
+            cy.location('pathname').should('contain', `/measures/${createdMeasureId}/edit`)
+        })
+        cy.get(EditMeasurePage.measureLockedModalMessage)
+            .should('be.visible')
+            .and('contain.text', 'You will be unable to make changes at this time.')
+    })
+
+    it('opens a versioned measure from Owned Measures in read-only View mode', () => {
+        createDraftMeasure()
+        captureCreatedMeasureId()
+        TestData.saveMeasureCql(`${MeasureCQL.CQL_For_Cohort}\n`).then((response) => {
+            TestData.expectSavedMeasureCql(response)
+        })
+        MeasureGroupPage.CreateCohortMeasureGroupAPI()
+        TestData.versionMeasure().then((response) => {
+            expect(response.status).to.eq(200)
+            measureVersioned = true
+        })
+
+        openProfileMeasure(measureOwner)
+
+        findCreatedMeasureAction().should('have.text', 'View').click()
+        assertMeasureDetailMode('view')
+    })
+})


### PR DESCRIPTION
## Summary

Adds DEV-proven Cypress coverage for MAT-9820 and MAT-9821 admin-user-profile navigation to measures and libraries, respectively.

## Changes

- Adds measure View/Edit/read-only/locked/versioned navigation scenarios.
- Adds equivalent library View/Edit/read-only/locked/versioned navigation scenarios.
- Uses exact ID-based action and lock selectors to avoid ambiguous row actions.
- Verifies read-only versus edit mode through permission-specific form controls.
- Corrects the reusable valid QI-Core library CQL fixture with `context Patient` and a valid definition.
- Leaves both new DEV-proven suites skipped pending controlled re-enablement.

## Technical Notes

- Test setup uses existing `TestData`, `Utilities`, and page-object helpers.
- Created resource IDs are captured before user-scope changes, preventing fixture-context mismatches.
- No fixed waits or forced interactions were added.

## Testing

- Local DEV execution: both new specs passed.
- `npm run compile`
- `npm run quality:no-focused-tests`
- `git diff --check`

## Risk

- Suites are intentionally skipped after DEV proof because `AdminUserProfile` is not yet available in TEST. Re-enable when the feature is promoted.

## Documentation

Documentation Updates: None